### PR TITLE
docs: add Copilot instructions and AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,120 @@
+# GitHub Copilot Instructions — CubeLite
+
+This file provides project-wide context and conventions for GitHub Copilot across
+all stacks in the CubeLite monorepo.
+
+---
+
+## Project Overview
+
+**CubeLite** is a Kubernetes context aggregator — a developer tool that lets you
+discover, switch, and manage Kubernetes contexts across clusters from a unified
+interface. It consists of a Rust core library, a cross-platform desktop app
+(Tauri + Svelte), and a native macOS menu-bar app (Swift + SwiftUI).
+
+---
+
+## Monorepo Layout
+
+```
+cubelite/
+├── crates/
+│   └── cubelite-core/       ← Rust library: k8s context management
+├── apps/
+│   ├── desktop/             ← Tauri v2 + Svelte 5 + TypeScript desktop app
+│   └── macos/               ← Swift 6 + SwiftUI native macOS app
+├── .github/
+│   ├── copilot-instructions.md
+│   ├── instructions/        ← Path-scoped Copilot instructions
+│   └── workflows/           ← GitHub Actions CI/CD
+├── AGENTS.md                ← Root agent routing table
+└── Makefile                 ← Dev task shortcuts
+```
+
+---
+
+## Language & Framework Matrix
+
+| Area | Language | Key Libraries |
+|---|---|---|
+| `crates/` | Rust 1.82+ | kube-rs 0.97, tokio, thiserror 2, anyhow 1 |
+| `apps/desktop/` | TypeScript + Svelte 5 | Tauri v2, shadcn-svelte, Tailwind v4, Vitest, Playwright |
+| `apps/macos/` | Swift 6 | SwiftUI, macOS 14+, Observation framework |
+| `.github/` | YAML | GitHub Actions |
+
+---
+
+## Naming Conventions
+
+### Rust
+- Types and traits: `PascalCase`
+- Functions and variables: `snake_case`
+- Constants: `SCREAMING_SNAKE_CASE`
+- Modules: `snake_case`
+- Error types: suffix with `Error` (e.g., `ContextError`)
+
+### TypeScript / Svelte
+- Components: `PascalCase.svelte`
+- Stores and composables: `camelCase`
+- Types and interfaces: `PascalCase`
+- Constants: `SCREAMING_SNAKE_CASE`
+
+### Swift
+- Types and protocols: `PascalCase`
+- Properties and methods: `camelCase`
+- Constants: `camelCase` (Swift convention)
+
+---
+
+## Test Patterns
+
+### Rust (`crates/`)
+- Unit tests in `#[cfg(test)]` modules within source files
+- Integration tests in `crates/<name>/tests/`
+- Mock Kubernetes API via `kube::fake` or custom `tower` stacks
+- Run: `cargo test --workspace`
+
+### Desktop (`apps/desktop/`)
+- Unit/component tests: Vitest
+- End-to-end: Playwright
+- Run: `pnpm --filter desktop test`
+
+### macOS (`apps/macos/`)
+- XCTest for unit tests; SwiftUI previews for UI tests
+- Run: `swift test` or Xcode scheme `CubeLiteTests`
+
+---
+
+## Absolute Rules
+
+### Rust
+- **Never use `unwrap()` or `expect()` in production code** (`crates/` top-level, not in `tests/`)
+  - Use `?` operator, `thiserror`, or `anyhow::Context` instead
+- **No `unsafe` blocks** without explicit justification comment and review
+- All public APIs must have `/// doc comments`
+- Run `cargo clippy --deny warnings` before every commit
+
+### Security
+- **No plaintext secrets** anywhere in code or config files
+- Credentials must use the OS keychain (Keychain on macOS, SecretService on Linux)
+- No telemetry collection without explicit user opt-in
+- CI secrets via GitHub Actions `${{ secrets.* }}` only
+
+### General
+- No direct commits to `main` — all changes via feature branch → PR → squash-merge
+- Commit messages follow Conventional Commits: `type(scope): description`
+
+---
+
+## Agent Routing Table
+
+| Agent | Scope | Activate When |
+|---|---|---|
+| `core-agent` | `crates/**` | Rust logic, k8s API, domain models, error types |
+| `desktop-agent` | `apps/desktop/**` | Svelte components, Tauri commands, frontend tests |
+| `macos-agent` | `apps/macos/**` | Swift/SwiftUI, menu-bar, macOS APIs |
+| `design-agent` | `apps/desktop/**` UI only | Design tokens, shadcn-svelte, Tailwind, accessibility |
+| `devops-agent` | `.github/**` | GitHub Actions, CI/CD workflows, secret handling |
+| `ai-agent` | Any | Cross-cutting AI assistance, architecture decisions |
+
+See path-specific instructions in `.github/instructions/` for per-stack conventions.

--- a/.github/instructions/ci-devops.instructions.md
+++ b/.github/instructions/ci-devops.instructions.md
@@ -1,0 +1,44 @@
+---
+applyTo: ".github/**"
+---
+
+# CI / DevOps Instructions
+
+Guidelines for all files under `.github/` — workflows, actions, and tooling config.
+
+## GitHub Actions YAML
+
+- Indent: 2 spaces
+- Always pin action versions to a full SHA commit hash (not a mutable tag like `@v3`)
+  - Preferred: `uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`
+- Use `timeout-minutes` on every job — default: `15`; long build jobs: `60`
+- Set `permissions` at the top level to the minimum required by each workflow
+
+## Secrets
+
+- **Never hardcode secrets, tokens, or credentials** in workflow files
+- Reference secrets only via `${{ secrets.SECRET_NAME }}`
+- Do not `echo` secret values or use them in `run:` commands that write to logs
+- Use OIDC (`id-token: write`) for cloud authentication where supported
+
+## Job Structure
+
+- Separate jobs for: lint, test, build, release — do not combine unrelated steps
+- Use `needs:` to express explicit dependency ordering
+- Cache dependencies:
+  - Rust: `actions/cache` on `~/.cargo/registry` + `target/` keyed on `Cargo.lock` hash
+  - Node: `actions/setup-node` with `cache: 'pnpm'`
+  - Swift: `actions/cache` on `.build/` keyed on `Package.resolved` hash
+
+## Branch / PR Conventions
+
+- CI must pass on: `main`, `feat/**`, `fix/**`, `chore/**`
+- All PRs require at least one approval and all status checks green before merge
+- Squash merge only — no merge commits, no rebase-merge to `main`
+
+## What to Avoid
+
+- No `continue-on-error: true` on security-critical steps (lint, CodeQL)
+- No `pull_request_target` without explicit checkout restrictions (security risk)
+- No matrix explosion — cap `matrix` to needed platform combinations
+- No self-hosted runners for public-facing workflows without isolation guarantees

--- a/.github/instructions/desktop-svelte.instructions.md
+++ b/.github/instructions/desktop-svelte.instructions.md
@@ -1,0 +1,50 @@
+---
+applyTo: "apps/desktop/**"
+---
+
+# Desktop App Instructions (Tauri + Svelte 5 + TypeScript)
+
+Guidelines for all code under `apps/desktop/`.
+
+## Svelte 5
+
+- Use Svelte 5 runes: `$state`, `$derived`, `$effect`, `$props`
+- Prefer `$derived` over `$effect` → state mutation for derived values
+- Components live in `src/lib/components/`; pages/routes in `src/routes/`
+- One component per file; named after the component with `PascalCase.svelte`
+- Avoid `on:event` directives — use prop callbacks: `onclick={() => …}`
+
+## TypeScript
+
+- `strict: true` is enforced in `tsconfig.json` — no `any` types
+- Use `satisfies` operator for config objects
+- Prefer `type` over `interface` for unions and mapped types; `interface` for extensible shapes
+- All Tauri command payloads typed with matching Rust serialization (`#[serde]`)
+
+## shadcn-svelte & Tailwind v4
+
+- Use shadcn-svelte components from `$lib/components/ui/`
+- Do not override component internals — compose or extend via slot props
+- Tailwind utility classes only — no inline styles, no CSS-in-JS
+- Design tokens defined in `src/app.css` as CSS custom properties; reference via Tailwind `theme()`
+
+## Tauri Commands
+
+- Frontend calls backend via `invoke('command_name', { payload })` from `@tauri-apps/api/core`
+- All command names in `snake_case`; define TypeScript overloads in `src/lib/tauri.ts`
+- Never call `invoke` outside of `$effect` or event handlers — no top-level awaits in components
+- Command errors must produce typed `Result`-shaped objects; handle both `ok` and `error` branches
+
+## Tests
+
+- Unit / component tests: Vitest with `@testing-library/svelte`
+- E2E: Playwright targeting the Tauri WebView
+- Test files: `*.test.ts` co-located or in `src/__tests__/`
+- Run: `pnpm --filter desktop test`
+
+## What to Avoid
+
+- No `localStorage` for sensitive data — use Tauri Store plugin or OS keychain via Rust command
+- No `document.write`, `eval`, `innerHTML` with unsanitized data
+- No `any` types — use `unknown` and narrow
+- No `console.log` left in committed code — use `debug` package or remove

--- a/.github/instructions/rust-core.instructions.md
+++ b/.github/instructions/rust-core.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: "crates/**"
+---
+
+# Rust Core Instructions
+
+Guidelines for all code under `crates/`.
+
+## Style
+
+- Follow Rust API Guidelines (https://rust-lang.github.io/api-guidelines/)
+- `rustfmt` formatting — no manual formatting overrides
+- `snake_case` for functions/variables, `PascalCase` for types, `SCREAMING_SNAKE_CASE` for constants
+- Prefer `impl Trait` return types where object safety is not needed
+- Keep `pub` surface minimal; use `pub(crate)` freely
+
+## Error Handling
+
+- Use `thiserror` for library error types; `anyhow` for application/binary error propagation
+- Define errors via `#[derive(thiserror::Error)]` on explicit enums — one variant per distinct failure mode
+- **Never `unwrap()` or `expect()` in production code** paths (`src/`, NOT `tests/`)
+- Propagate errors with `?`; annotate context with `.context("...")` (anyhow) or `map_err`
+
+## Async
+
+- Runtime: `tokio` (multi-thread scheduler unless constrained)
+- Annotate async entry points with `#[tokio::main]` or `#[tokio::test]`
+- Prefer `tokio::spawn` for detached tasks; use structured concurrency where feasible
+- Use `tokio::sync::{Mutex, RwLock}` — not `std::sync` in async contexts
+
+## Kubernetes
+
+- Client: `kube-rs` 0.97 with `kube::Client`, `kube::Api`
+- Represent cluster context as a value type (not string); enforce type safety at boundaries
+- Mock k8s API in tests: use `kube::fake::ObjectList` / custom `tower::Service` stacks
+- Never hardcode cluster addresses or credentials
+
+## Tests
+
+- Unit tests live in `#[cfg(test)] mod tests { … }` at the bottom of the source file
+- Integration tests in `crates/<crate>/tests/`
+- Run: `cargo test --workspace`
+- Lint: `cargo clippy --deny warnings`
+- Format check: `cargo fmt --check`
+
+## What to Avoid
+
+- No `unsafe` without a `// SAFETY:` comment explaining why it is valid
+- No `std::sync::Mutex` in async code — use `tokio::sync::Mutex`
+- No `unwrap()` / `expect()` outside test modules
+- No `println!` in library code — use `tracing` for diagnostics

--- a/.github/instructions/swift-macos.instructions.md
+++ b/.github/instructions/swift-macos.instructions.md
@@ -1,0 +1,47 @@
+---
+applyTo: "apps/macos/**"
+---
+
+# macOS App Instructions (Swift 6 + SwiftUI)
+
+Guidelines for all code under `apps/macos/`.
+
+## Swift 6
+
+- Full strict concurrency checking enabled (`SWIFT_STRICT_CONCURRENCY = complete`)
+- All types crossing concurrency boundaries must be `Sendable`
+- Prefer `actor` for mutable shared state; `@MainActor` for UI-bound types
+- Use Swift 6 `Observation` framework (`@Observable`) — not `ObservableObject`
+
+## SwiftUI
+
+- Minimum deployment target: **macOS 14**
+- Views are structs — extract sub-views aggressively; keep body under ~20 lines
+- Use `@Environment` and `@EnvironmentObject` for dependency injection
+- Avoid `.onAppear` for async work — use `.task { }` modifier
+- Prefer `@Observable` models over `@StateObject` / `@ObservedObject` pairs
+
+## Menu Bar App
+
+- Entry point: `NSStatusItem` with `NSMenu` or `MenuBarExtra` (SwiftUI)
+- Background agent: `LSUIElement = true` in `Info.plist` to suppress Dock icon
+- Use `AppKit` only where SwiftUI has no equivalent API
+
+## Credentials / Keychain
+
+- All credentials and tokens via `Security.framework` Keychain APIs — no UserDefaults for secrets
+- Wrap Keychain operations in a `KeychainService` actor
+
+## Tests
+
+- XCTest for unit and integration tests
+- SwiftUI previews for visual validation (not substitutes for tests)
+- Run: `swift test` (SPM) or Xcode scheme `CubeLiteTests`
+- Target code coverage ≥ 80% on new code
+
+## What to Avoid
+
+- No `force try` (`try!`) or forced unwrap (`!`) outside of test code
+- No `DispatchQueue.main.async` — use `@MainActor` and structured concurrency
+- No third-party package manager (CocoaPods, Carthage) — Swift Package Manager only
+- No `AnyView` except as a last resort; use type-erased `some View` instead

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — CubeLite Root
+
+This file defines the agent routing protocol for the CubeLite monorepo.
+Each specialized agent owns a subtree. When requests touch multiple subtrees,
+use the inter-agent protocol described below.
+
+---
+
+## Agent Roster
+
+| Agent | Scope | Primary Tools |
+|---|---|---|
+| `core-agent` | `crates/**` | `cargo test`, `cargo clippy --deny warnings`, `cargo build` |
+| `desktop-agent` | `apps/desktop/**` | `pnpm --filter desktop test`, Vitest, Playwright |
+| `macos-agent` | `apps/macos/**` | `swift build`, `swift test`, Xcode |
+| `design-agent` | `apps/desktop/**` (UI only) | Figma MCP, shadcn-svelte, Tailwind tokens |
+| `devops-agent` | `.github/**` | GitHub Actions, secret scanning, YAML lint |
+| `ai-agent` | Any | Architecture, cross-cutting concerns, ADRs |
+
+---
+
+## Ownership Map
+
+```
+cubelite/
+├── crates/                    → core-agent
+│   └── cubelite-core/         → core-agent  (see crates/cubelite-core/AGENTS.md)
+├── apps/
+│   ├── desktop/               → desktop-agent, design-agent
+│   │   └── AGENTS.md          → (see apps/desktop/AGENTS.md)
+│   └── macos/                 → macos-agent
+│       └── AGENTS.md          → (see apps/macos/AGENTS.md)
+├── .github/
+│   ├── workflows/             → devops-agent
+│   └── instructions/          → devops-agent
+├── Cargo.toml                 → core-agent (workspace manifest)
+├── package.json               → desktop-agent (workspace scripts)
+├── Makefile                   → devops-agent
+└── AGENTS.md                  → ai-agent (this file)
+```
+
+---
+
+## Inter-Agent Protocol
+
+When a task spans multiple subtrees:
+
+1. **Identify the primary subtree** (where most code changes land)
+2. **Activate the primary agent** for that subtree
+3. **Notify secondary agents** by posting a comment on the issue
+4. **Never have two agents edit the same file simultaneously**
+5. Cross-cutting changes (e.g., a Rust type + its TypeScript binding) should be
+   batched in a single branch with coordinated commits
+
+---
+
+## Prohibited Actions (All Agents)
+
+- Do NOT commit directly to `main`
+- Do NOT push `--force` to any protected branch
+- Do NOT hardcode secrets, tokens, or API keys in any file
+- Do NOT call `unwrap()` or `expect()` in production Rust code (outside `tests/`)
+- Do NOT install telemetry or tracking without explicit user opt-in
+- Do NOT modify another agent's owned files without coordination
+
+---
+
+## Global Workflow
+
+1. Pick up issue → add `status:in-progress` label + tracking comment
+2. Create branch `feat/<N>-<slug>` or `fix/<N>-<slug>` from `main`
+3. Implement → run local checks (lint, test, coverage)
+4. Push branch → open PR with `Closes #N` in body
+5. Add `status:review` label while PR is open
+6. Squash-merge only → post closing comment → add `status:done` label → close issue
+
+---
+
+## Quality Gates (All Agents)
+
+| Gate | Command |
+|---|---|
+| Rust lint | `cargo clippy --deny warnings` |
+| Rust tests | `cargo test --workspace` |
+| Rust format | `cargo fmt --check` |
+| Desktop tests | `pnpm --filter desktop test` |
+| macOS tests | `swift test` |
+| Secret scan | `gh secret-scanning run` |

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md — Desktop App
+
+Owner: **desktop-agent** (logic, tests) / **design-agent** (UI visuals)
+
+This file defines agent boundaries and rules for the Tauri + Svelte 5 desktop app.
+
+---
+
+## Agents
+
+| Agent | Responsibility |
+|---|---|
+| `desktop-agent` | Tauri commands, Svelte logic, TypeScript types, tests |
+| `design-agent` | Tailwind tokens, shadcn-svelte components, accessibility |
+
+---
+
+## Owned Paths
+
+```
+apps/desktop/
+├── src/
+│   ├── routes/              ← SvelteKit pages
+│   ├── lib/
+│   │   ├── components/      ← Svelte components (design-agent)
+│   │   ├── stores/          ← Svelte state (desktop-agent)
+│   │   └── tauri.ts         ← Tauri command wrappers (desktop-agent)
+│   └── app.css              ← Tailwind base / design tokens (design-agent)
+├── src-tauri/               ← Rust Tauri backend (desktop-agent, coordinate with core-agent)
+├── tests/                   ← Playwright e2e (desktop-agent)
+└── package.json
+```
+
+---
+
+## Required Tools Before Commit
+
+```bash
+pnpm --filter desktop lint      # ESLint + Svelte check
+pnpm --filter desktop test      # Vitest unit tests
+pnpm --filter desktop test:e2e  # Playwright e2e
+```
+
+---
+
+## Prohibited Actions
+
+- No `any` type in TypeScript — use `unknown` and narrow
+- No `localStorage` for secrets — use Tauri Store or OS keychain via Rust
+- No `console.log` in committed code — use `debug` or remove
+- No modifications to `crates/` or `apps/macos/` from this agent
+- No overriding shadcn-svelte component internals — compose via slots/props
+
+---
+
+## Tauri Command Conventions
+
+```typescript
+// src/lib/tauri.ts
+import { invoke } from '@tauri-apps/api/core';
+
+export async function listContexts(): Promise<ContextEntry[]> {
+  return invoke<ContextEntry[]>('list_contexts');
+}
+```
+
+- One wrapper function per Tauri command
+- Return type must match Rust `#[tauri::command]` serde output
+- Handle errors: functions return `Promise<T>` — callers use `try/catch`
+
+---
+
+## Handoff Protocol
+
+When a new Tauri command is needed:
+
+1. `desktop-agent` defines the TypeScript interface and expected payload
+2. Post: `@core-agent: new command \`list_contexts\` needed, TypeScript interface defined in PR`
+3. `core-agent` implements the Rust `#[tauri::command]` in `src-tauri/`

--- a/apps/macos/AGENTS.md
+++ b/apps/macos/AGENTS.md
@@ -1,0 +1,90 @@
+# AGENTS.md — macOS App
+
+Owner: **macos-agent**
+
+This file defines agent boundaries and rules for the native Swift 6 + SwiftUI macOS app.
+
+---
+
+## Agent
+
+| Agent | `macos-agent` |
+|---|---|
+| **Owned paths** | `apps/macos/**` |
+| **Language** | Swift 6 |
+| **Frameworks** | SwiftUI, AppKit (minimal), Security.framework |
+| **Minimum target** | macOS 14 |
+
+---
+
+## Owned Paths
+
+```
+apps/macos/
+├── CubeLite/
+│   ├── App.swift               ← Entry point, @main
+│   ├── MenuBarView.swift        ← MenuBarExtra / NSStatusItem
+│   ├── Models/                  ← @Observable models
+│   ├── Views/                   ← SwiftUI views
+│   ├── Services/
+│   │   ├── KubeconfigService.swift   ← Read kubeconfig
+│   │   └── KeychainService.swift     ← Keychain actor
+│   └── Info.plist
+├── CubeLiteTests/
+│   └── ContextTests.swift
+└── Package.swift
+```
+
+---
+
+## Required Tools Before Commit
+
+```bash
+swift build                     # must compile cleanly
+swift test                      # all XCTests must pass
+```
+
+Or via Xcode:
+- Build scheme: `CubeLite`
+- Test scheme: `CubeLiteTests`
+
+---
+
+## Prohibited Actions
+
+- No `try!` or forced unwrap (`!`) outside test code
+- No `DispatchQueue.main.async` — use `@MainActor` and structured concurrency
+- No third-party package managers (CocoaPods, Carthage) — SPM only
+- No plaintext secrets — Keychain only via `KeychainService`
+- No modifications to `crates/` or `apps/desktop/` from this agent
+
+---
+
+## Concurrency Patterns
+
+```swift
+// Correct: @MainActor for UI updates
+@MainActor
+func refreshContextList() async {
+    contexts = try await kubeconfigService.listContexts()
+}
+
+// Correct: actor for shared mutable state
+actor KeychainService {
+    func store(token: String, for key: String) throws { … }
+}
+
+// Wrong: DispatchQueue in Swift 6
+// DispatchQueue.main.async { self.contexts = result }
+```
+
+---
+
+## Handoff Protocol
+
+When a new kubeconfig feature is needed that would benefit from the Rust core:
+
+1. `macos-agent` defines the Swift protocol/interface
+2. Post: `@core-agent: new feature needed — \`parseKubeconfig\`, Swift interface defined`
+3. Consider whether a shared Rust FFI or a pure Swift implementation is appropriate
+4. Document the decision in the issue before implementing

--- a/crates/cubelite-core/AGENTS.md
+++ b/crates/cubelite-core/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md — cubelite-core
+
+Owner: **core-agent**
+
+This file defines agent boundaries and rules for the `crates/cubelite-core` Rust crate.
+
+---
+
+## Agent
+
+| Agent | `core-agent` |
+|---|---|
+| **Owned paths** | `crates/**` |
+| **Language** | Rust 1.82+ |
+| **Key crates** | `kube-rs 0.97`, `tokio`, `thiserror 2`, `anyhow 1` |
+
+---
+
+## Owned Paths
+
+```
+crates/
+└── cubelite-core/
+    ├── src/
+    │   ├── lib.rs
+    │   ├── context.rs       ← k8s context model
+    │   ├── client.rs        ← kube::Client wrapping
+    │   └── error.rs         ← thiserror error types
+    ├── tests/               ← integration tests
+    └── Cargo.toml
+```
+
+---
+
+## Required Tools Before Commit
+
+```bash
+cargo fmt --check               # formatting
+cargo clippy --deny warnings    # lint (zero warnings allowed)
+cargo test --workspace          # all tests must pass
+```
+
+---
+
+## Prohibited Actions
+
+- No `unwrap()` or `expect()` in `src/` (only `tests/` may use them)
+- No `unsafe` without `// SAFETY:` justification comment
+- No `println!` in library code — use `tracing::{debug, info, warn, error}`
+- No direct k8s cluster credentials in code — read from kubeconfig only
+- No modifications to `apps/` or `.github/` from this agent
+
+---
+
+## Test Patterns
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_context_list_returns_vec() {
+        // Arrange: build fake kube client
+        // Act: call domain function
+        // Assert: verify output
+    }
+}
+```
+
+---
+
+## Handoff Protocol
+
+When a Rust type needs a TypeScript binding:
+
+1. Define and stabilize the Rust type first
+2. Post a comment on the issue: `@desktop-agent: new type \`ContextEntry\` in \`cubelite-core\`, binding needed`
+3. Desktop-agent creates the mirrored TypeScript interface


### PR DESCRIPTION
## Summary

Adds all Copilot and agent documentation for the CubeLite monorepo as specified in M0 issues #9, #10, #11.

## Files Added

| File | Purpose |
|---|---|
| `.github/copilot-instructions.md` | Project-wide Copilot context: layout, conventions, rules, agent routing |
| `.github/instructions/rust-core.instructions.md` | Path-scoped rules for `crates/**` |
| `.github/instructions/desktop-svelte.instructions.md` | Path-scoped rules for `apps/desktop/**` |
| `.github/instructions/swift-macos.instructions.md` | Path-scoped rules for `apps/macos/**` |
| `.github/instructions/ci-devops.instructions.md` | Path-scoped rules for `.github/**` |
| `AGENTS.md` | Root agent roster, ownership map, inter-agent protocol, quality gates |
| `crates/cubelite-core/AGENTS.md` | core-agent boundaries, Rust conventions, test patterns |
| `apps/desktop/AGENTS.md` | desktop-agent + design-agent boundaries, Tauri/Svelte conventions |
| `apps/macos/AGENTS.md` | macos-agent boundaries, Swift 6 concurrency patterns |

Closes #9, Closes #10, Closes #11