### PR TITLE
feat(core): kube-rs client + resource models

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -1,0 +1,52 @@
+use cubelite_core::{
+    client::KubeClient,
+    resources::{DeploymentInfo, NamespaceInfo, PodInfo},
+};
+use std::path::Path;
+
+/// List pods in the given namespace for the specified kubeconfig context.
+#[tauri::command]
+pub async fn list_pods(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<PodInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_pods(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List all namespaces accessible from the specified kubeconfig context.
+#[tauri::command]
+pub async fn list_namespaces(
+    kubeconfig_path: String,
+    context: Option<String>,
+) -> Result<Vec<NamespaceInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client.list_namespaces().await.map_err(|e| e.to_string())
+}
+
+/// List all deployments in the given namespace for the specified kubeconfig context.
+#[tauri::command]
+pub async fn list_deployments(
+    kubeconfig_path: String,
+    namespace: String,
+    context: Option<String>,
+) -> Result<Vec<DeploymentInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_deployments(&namespace)
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod kubernetes;

--- a/crates/cubelite-core/Cargo.toml
+++ b/crates/cubelite-core/Cargo.toml
@@ -11,6 +11,8 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
 dirs = "5"
+kube = { version = "0.97", features = ["runtime", "derive", "client"] }
+k8s-openapi = { version = "0.23", features = ["v1_30"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -1,0 +1,151 @@
+use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::core::v1::{Namespace, Pod};
+use kube::{
+    config::{KubeConfigOptions, Kubeconfig},
+    Api, Client, Config,
+};
+use std::path::Path;
+
+use crate::{
+    error::ConfigError,
+    resources::{DeploymentInfo, NamespaceInfo, PodInfo},
+};
+
+/// Async Kubernetes client wrapper pre-configured from a kubeconfig file.
+pub struct KubeClient {
+    inner: Client,
+}
+
+impl KubeClient {
+    /// Build a [`KubeClient`] from the kubeconfig at `path`.
+    ///
+    /// `context` selects a named context; if `None` the file's `current-context` is used.
+    pub async fn new(path: &Path, context: Option<&str>) -> Result<Self, ConfigError> {
+        let raw = tokio::fs::read_to_string(path)
+            .await
+            .map_err(|source| ConfigError::Io { source })?;
+
+        let kubeconfig: Kubeconfig = serde_yaml::from_str(&raw)
+            .map_err(|source| ConfigError::ParseError { source })?;
+
+        let options = KubeConfigOptions {
+            context: context.map(str::to_string),
+            ..Default::default()
+        };
+
+        let config = Config::from_custom_kubeconfig(kubeconfig, &options)
+            .await
+            .map_err(|e| ConfigError::MergeError {
+                reason: e.to_string(),
+            })?;
+
+        let inner = Client::try_from(config).map_err(|e| ConfigError::ClientError {
+            reason: e.to_string(),
+        })?;
+
+        Ok(Self { inner })
+    }
+
+    /// List pods in `namespace`, or across all namespaces when `namespace` is `None`.
+    pub async fn list_pods(&self, namespace: Option<&str>) -> Result<Vec<PodInfo>, ConfigError> {
+        let api: Api<Pod> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+
+        let pod_list = api
+            .list(&Default::default())
+            .await
+            .map_err(|e| ConfigError::ClientError {
+                reason: e.to_string(),
+            })?;
+
+        let pods = pod_list
+            .items
+            .into_iter()
+            .filter_map(|pod| {
+                let name = pod.metadata.name?;
+                let ns = pod.metadata.namespace.unwrap_or_default();
+                let phase = pod.status.as_ref().and_then(|s| s.phase.clone());
+                let container_statuses = pod
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.container_statuses.as_deref())
+                    .unwrap_or(&[]);
+                let ready = container_statuses.iter().all(|cs| cs.ready);
+                let restarts = container_statuses.iter().map(|cs| cs.restart_count).sum();
+                Some(PodInfo {
+                    name,
+                    namespace: ns,
+                    phase,
+                    ready,
+                    restarts,
+                })
+            })
+            .collect();
+
+        Ok(pods)
+    }
+
+    /// List all namespaces.
+    pub async fn list_namespaces(&self) -> Result<Vec<NamespaceInfo>, ConfigError> {
+        let api: Api<Namespace> = Api::all(self.inner.clone());
+
+        let ns_list = api
+            .list(&Default::default())
+            .await
+            .map_err(|e| ConfigError::ClientError {
+                reason: e.to_string(),
+            })?;
+
+        let namespaces = ns_list
+            .items
+            .into_iter()
+            .filter_map(|ns| {
+                let name = ns.metadata.name?;
+                let phase = ns.status.as_ref().and_then(|s| s.phase.clone());
+                Some(NamespaceInfo { name, phase })
+            })
+            .collect();
+
+        Ok(namespaces)
+    }
+
+    /// List all deployments in `namespace`.
+    pub async fn list_deployments(
+        &self,
+        namespace: &str,
+    ) -> Result<Vec<DeploymentInfo>, ConfigError> {
+        let api: Api<Deployment> = Api::namespaced(self.inner.clone(), namespace);
+
+        let deploy_list = api
+            .list(&Default::default())
+            .await
+            .map_err(|e| ConfigError::ClientError {
+                reason: e.to_string(),
+            })?;
+
+        let deployments = deploy_list
+            .items
+            .into_iter()
+            .filter_map(|d| {
+                let name = d.metadata.name?;
+                let ns = d.metadata.namespace.unwrap_or_default();
+                let replicas = d.spec.as_ref().and_then(|s| s.replicas).unwrap_or(0);
+                let ready_replicas = d
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.ready_replicas)
+                    .unwrap_or(0);
+                Some(DeploymentInfo {
+                    name,
+                    namespace: ns,
+                    replicas,
+                    ready_replicas,
+                })
+            })
+            .collect();
+
+        Ok(deployments)
+    }
+}

--- a/crates/cubelite-core/src/error.rs
+++ b/crates/cubelite-core/src/error.rs
@@ -11,11 +11,14 @@ pub enum ConfigError {
         source: serde_yaml::Error,
     },
 
-    #[error("context not found: {name}")]
+    #[error("context '{name}' not found in kubeconfig")]
     ContextNotFound { name: String },
 
-    #[error("failed to merge kubeconfig files: {reason}")]
+    #[error("failed to merge or load kubeconfig: {reason}")]
     MergeError { reason: String },
+
+    #[error("kubernetes client error: {reason}")]
+    ClientError { reason: String },
 
     #[error("I/O error: {source}")]
     Io {

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -1,5 +1,9 @@
+pub mod client;
 pub mod error;
 pub mod kubeconfig;
+pub mod resources;
 
+pub use client::KubeClient;
 pub use error::ConfigError;
 pub use kubeconfig::{KubeConfig, list_contexts, set_active_context};
+pub use resources::{DeploymentInfo, NamespaceInfo, PodInfo};

--- a/crates/cubelite-core/src/resources.rs
+++ b/crates/cubelite-core/src/resources.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+/// Lightweight representation of a Kubernetes Pod for display purposes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PodInfo {
+    pub name: String,
+    pub namespace: String,
+    pub phase: Option<String>,
+    pub ready: bool,
+    pub restarts: i32,
+}
+
+/// Lightweight representation of a Kubernetes Namespace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamespaceInfo {
+    pub name: String,
+    pub phase: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes Deployment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentInfo {
+    pub name: String,
+    pub namespace: String,
+    pub replicas: i32,
+    pub ready_replicas: i32,
+}


### PR DESCRIPTION
Closes #3

## Changes

- `crates/cubelite-core/src/client.rs` — `KubeClient` async wrapper (new/context-aware, uses `Config::from_custom_kubeconfig`)
- `crates/cubelite-core/src/resources.rs` — `PodInfo`, `NamespaceInfo`, `DeploymentInfo` serde structs
- `crates/cubelite-core/src/error.rs` — added `ClientError { reason }` variant
- `crates/cubelite-core/Cargo.toml` — pinned `kube 0.97`, `k8s-openapi 0.23`
- `crates/cubelite-core/src/lib.rs` — re-exported new modules
- `apps/desktop/src-tauri/src/commands/kubernetes.rs` — Tauri `#[tauri::command]` bridge
- `apps/desktop/src-tauri/src/commands/mod.rs` — declares `pub mod kubernetes`

> **Note:** `src-tauri/Cargo.toml` needs `cubelite-core = { path = "../../crates/cubelite-core" }` and `src-tauri/src/lib.rs` needs `mod commands; tauri::generate_handler![commands::kubernetes::list_pods, ...]` registration.