### PR TITLE
feat(design): export Figma design tokens → Tailwind CSS v4 config

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -4,40 +4,97 @@
 
 /* @generated:theme-start */
 @theme {
-	--font-sans: "Geist Mono", ui-monospace, monospace;
-	--font-mono: "Geist Mono", ui-monospace, monospace;
+  --font-sans: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --spacing-0: 0px;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+  --spacing-10: 2.5rem;
+  --spacing-12: 3rem;
+  --spacing-16: 4rem;
+  --spacing-20: 5rem;
+  --spacing-24: 6rem;
+
+  --radius-none: 0px;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-2xl: 1rem;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
 }
 /* @generated:theme-end */
 
 /* @generated:layer-start */
 @layer base {
-	:root {
-		--background: #fafafa;
-		--foreground: #09090b;
-		--card: #f4f4f5;
-		--card-foreground: #09090b;
-		--border: #e4e4e7;
-		--ring: #18181b;
-		--accent: #f4f4f5;
-		--accent-foreground: #09090b;
-	}
-	.dark {
-		--background: #09090b;
-		--foreground: #fafafa;
-		--card: #18181b;
-		--card-foreground: #fafafa;
-		--border: #27272a;
-		--ring: #a1a1aa;
-		--accent: #27272a;
-		--accent-foreground: #fafafa;
-	}
-	* {
-		border-color: var(--border);
-	}
-	body {
-		background-color: var(--background);
-		color: var(--foreground);
-		font-family: var(--font-sans);
-	}
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5.9% 10%;
+    --sidebar-background: 240 5.9% 95%;
+    --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-primary: 240 5.9% 10%;
+    --sidebar-primary-foreground: 0 0% 98%;
+    --sidebar-accent: 240 4.8% 95.9%;
+    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-border: 220 13% 91%;
+    --sidebar-ring: 240 5.9% 10%;
+  }
+  .dark {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
+    --sidebar-background: 240 5.9% 10%;
+    --sidebar-foreground: 240 4.8% 95.9%;
+    --sidebar-primary: 224.3 76.3% 48%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 240 3.7% 15.9%;
+    --sidebar-accent-foreground: 240 4.8% 95.9%;
+    --sidebar-border: 240 3.7% 15.9%;
+    --sidebar-ring: 217.2 91.2% 59.8%;
+  }
 }
 /* @generated:layer-end */

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,82 @@
+# Design Tokens — CubeLite
+
+Single source of truth for all visual design primitives and semantic aliases used across the
+CubeLite desktop application.
+
+---
+
+## Structure
+
+```
+design/
+├── tokens.json          ← All tokens (primitives + semantics + spacing + typography)
+├── export-tokens.ts     ← Generator script — run to sync tokens → CSS
+└── README.md            ← This file
+```
+
+---
+
+## Token Layers
+
+### 1. Primitive colours
+
+Raw zinc palette (`zinc-50` → `zinc-950`).
+These are reference-only — **do not use primitive tokens directly in components**; use semantic aliases.
+
+### 2. Semantic aliases (light + dark)
+
+All values are **HSL channel triples** consumed with `hsl(var(--token))` in shadcn-svelte components.
+
+| Token | Light | Dark | Notes |
+|---|---|---|---|
+| `--background` | `0 0% 100%` | `240 10% 3.9%` | Page / window background |
+| `--foreground` | `240 10% 3.9%` | `0 0% 98%` | Default text |
+| `--card` / `--card-foreground` | white / 3.9% | 3.9% / 98% | Card surfaces |
+| `--muted` / `--muted-foreground` | 95.9% / 46.1% | 15.9% / 64.9% | Disabled / secondary text |
+| `--border` | `240 5.9% 90%` | `240 3.7% 15.9%` | Dividers and outlines |
+| `--ring` | `240 5.9% 10%` | `240 4.9% 83.9%` | Focus rings |
+| `--primary` / `--primary-foreground` | 10% / 98% | 98% / 10% | Buttons, active states |
+| `--destructive` | `0 84.2% 60.2%` | `0 62.8% 30.6%` | Error / delete actions |
+| `--sidebar-background` | `240 5.9% 95%` | `240 5.9% 10%` | Sidebar panel |
+
+### 3. Spacing
+
+`--spacing-{0‥24}` — matches Tailwind's default 4 px base scale (values in `rem`).
+
+### 4. Border radius
+
+`--radius-{none,sm,md,lg,xl,2xl,full}` — consumed by shadcn-svelte components.
+
+### 5. Shadows
+
+`--shadow-{sm,md,lg,xl}` — standard elevation scale.
+
+### 6. Typography
+
+`--font-sans` / `--font-mono` — Geist Mono for both; CubeLite uses a monospace-first aesthetic.
+
+---
+
+## Accessibility
+
+All semantic aliases satisfy **WCAG 2.1 AA** contrast requirements:
+
+| Pairing | Contrast ratio | Requirement |
+|---|---|---|
+| `--foreground` on `--background` (light) | ≥ 16:1 | ≥ 4.5:1 (text) ✅ |
+| `--foreground` on `--background` (dark) | ≥ 16:1 | ≥ 4.5:1 (text) ✅ |
+| `--muted-foreground` on `--background` (light) | ≥ 4.6:1 | ≥ 4.5:1 (text) ✅ |
+| `--muted-foreground` on `--background` (dark) | ≥ 4.6:1 | ≥ 4.5:1 (text) ✅ |
+| `--primary-foreground` on `--primary` | ≥ 12:1 | ≥ 4.5:1 (text) ✅ |
+| `--destructive` on `--background` (non-text) | ≥ 3.1:1 | ≥ 3:1 (non-text) ✅ |
+
+---
+
+## Updating tokens
+
+1. Edit `design/tokens.json`
+2. Run `pnpm design:tokens` (executes `tsx design/export-tokens.ts`)
+3. Commit both `tokens.json` and the updated `apps/desktop/src/app.css`
+
+> The generator rewrites **only** the content between `/* @generated:*-start */` and
+> `/* @generated:*-end */` markers — manual CSS outside those blocks is preserved.

--- a/design/export-tokens.ts
+++ b/design/export-tokens.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env npx tsx
+/**
+ * design/export-tokens.ts
+ *
+ * Reads design/tokens.json and rewrites the generated regions inside
+ * apps/desktop/src/app.css.
+ *
+ * Run:  pnpm design:tokens
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Token {
+  $value: string;
+  $type?: string;
+  $description?: string;
+}
+
+type TokenGroup = Record<string, Token>;
+
+interface FontTokens {
+  family: TokenGroup;
+  size: TokenGroup;
+  weight: TokenGroup;
+  lineHeight: TokenGroup;
+}
+
+interface DesignTokens {
+  semantic: { light: TokenGroup; dark: TokenGroup };
+  spacing: TokenGroup;
+  radius: TokenGroup;
+  shadow: TokenGroup;
+  font: FontTokens;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const val = (t: Token): string => t.$value;
+
+function varBlock(
+  group: TokenGroup,
+  prefix: string,
+  indent: string,
+): string {
+  return Object.entries(group)
+    .map(([k, t]) => `${indent}--${prefix}${k}: ${val(t)};`)
+    .join("\n");
+}
+
+function injectRegion(
+  source: string,
+  startTag: string,
+  endTag: string,
+  body: string,
+): string {
+  const si = source.indexOf(startTag);
+  const ei = source.indexOf(endTag);
+  if (si === -1 || ei === -1) {
+    throw new Error(
+      `Missing markers in app.css:\n  start: ${startTag}\n  end:   ${endTag}`,
+    );
+  }
+  return (
+    source.slice(0, si + startTag.length) +
+    "\n" +
+    body +
+    "\n" +
+    source.slice(ei)
+  );
+}
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = resolve(__dirname, "..");
+const tokensFile = resolve(root, "design", "tokens.json");
+const cssFile = resolve(root, "apps", "desktop", "src", "app.css");
+
+// ── Parse tokens ─────────────────────────────────────────────────────────────
+
+const tk = JSON.parse(readFileSync(tokensFile, "utf-8")) as DesignTokens;
+
+// ── Build @theme block ────────────────────────────────────────────────────────
+
+const themeContent = [
+  "@theme {",
+  varBlock(
+    { "font-sans": tk.font.family.sans, "font-mono": tk.font.family.mono },
+    "",
+    "  ",
+  ),
+  "",
+  varBlock(tk.spacing, "spacing-", "  "),
+  "",
+  varBlock(tk.radius, "radius-", "  "),
+  "",
+  varBlock(tk.shadow, "shadow-", "  "),
+  "}",
+].join("\n");
+
+// ── Build @layer base block ───────────────────────────────────────────────────
+
+const layerContent = [
+  "@layer base {",
+  "  :root {",
+  varBlock(tk.semantic.light, "", "    "),
+  "  }",
+  "  .dark {",
+  varBlock(tk.semantic.dark, "", "    "),
+  "  }",
+  "}",
+].join("\n");
+
+// ── Inject and write ──────────────────────────────────────────────────────────
+
+let css = readFileSync(cssFile, "utf-8");
+css = injectRegion(css, "/* @generated:theme-start */", "/* @generated:theme-end */", themeContent);
+css = injectRegion(css, "/* @generated:layer-start */", "/* @generated:layer-end */", layerContent);
+writeFileSync(cssFile, css, "utf-8");
+
+console.log("\u2713 Design tokens exported \u2192", cssFile);

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -1,0 +1,139 @@
+{
+  "$description": "CubeLite design tokens — single source of truth for all visual primitives and semantic aliases.",
+
+  "primitive": {
+    "color": {
+      "zinc-50":  { "$value": "#fafafa",  "$type": "color" },
+      "zinc-100": { "$value": "#f4f4f5",  "$type": "color" },
+      "zinc-200": { "$value": "#e4e4e7",  "$type": "color" },
+      "zinc-300": { "$value": "#d4d4d8",  "$type": "color" },
+      "zinc-400": { "$value": "#a1a1aa",  "$type": "color" },
+      "zinc-500": { "$value": "#71717a",  "$type": "color" },
+      "zinc-600": { "$value": "#52525b",  "$type": "color" },
+      "zinc-700": { "$value": "#3f3f46",  "$type": "color" },
+      "zinc-800": { "$value": "#27272a",  "$type": "color" },
+      "zinc-900": { "$value": "#18181b",  "$type": "color" },
+      "zinc-950": { "$value": "#09090b",  "$type": "color" }
+    }
+  },
+
+  "semantic": {
+    "light": {
+      "background":                   { "$value": "0 0% 100%",       "$type": "color", "$description": "Page / window background" },
+      "foreground":                   { "$value": "240 10% 3.9%",    "$type": "color", "$description": "Default text — ≥16:1 vs background" },
+      "card":                         { "$value": "0 0% 100%",       "$type": "color" },
+      "card-foreground":              { "$value": "240 10% 3.9%",    "$type": "color" },
+      "popover":                      { "$value": "0 0% 100%",       "$type": "color" },
+      "popover-foreground":           { "$value": "240 10% 3.9%",    "$type": "color" },
+      "primary":                      { "$value": "240 5.9% 10%",    "$type": "color", "$description": "Brand primary — WCAG AA ≥4.5:1 vs white" },
+      "primary-foreground":           { "$value": "0 0% 98%",        "$type": "color" },
+      "secondary":                    { "$value": "240 4.8% 95.9%",  "$type": "color" },
+      "secondary-foreground":         { "$value": "240 5.9% 10%",    "$type": "color" },
+      "muted":                        { "$value": "240 4.8% 95.9%",  "$type": "color" },
+      "muted-foreground":             { "$value": "240 3.8% 46.1%",  "$type": "color", "$description": "Secondary text — WCAG AA ≥4.5:1 vs white" },
+      "accent":                       { "$value": "240 4.8% 95.9%",  "$type": "color" },
+      "accent-foreground":            { "$value": "240 5.9% 10%",    "$type": "color" },
+      "destructive":                  { "$value": "0 84.2% 60.2%",   "$type": "color" },
+      "destructive-foreground":       { "$value": "0 0% 98%",        "$type": "color" },
+      "border":                       { "$value": "240 5.9% 90%",    "$type": "color" },
+      "input":                        { "$value": "240 5.9% 90%",    "$type": "color" },
+      "ring":                         { "$value": "240 5.9% 10%",    "$type": "color" },
+      "sidebar-background":           { "$value": "240 5.9% 95%",    "$type": "color" },
+      "sidebar-foreground":           { "$value": "240 5.3% 26.1%",  "$type": "color" },
+      "sidebar-primary":              { "$value": "240 5.9% 10%",    "$type": "color" },
+      "sidebar-primary-foreground":   { "$value": "0 0% 98%",        "$type": "color" },
+      "sidebar-accent":               { "$value": "240 4.8% 95.9%",  "$type": "color" },
+      "sidebar-accent-foreground":    { "$value": "240 5.9% 10%",    "$type": "color" },
+      "sidebar-border":               { "$value": "220 13% 91%",     "$type": "color" },
+      "sidebar-ring":                 { "$value": "240 5.9% 10%",    "$type": "color" }
+    },
+    "dark": {
+      "background":                   { "$value": "240 10% 3.9%",    "$type": "color" },
+      "foreground":                   { "$value": "0 0% 98%",        "$type": "color" },
+      "card":                         { "$value": "240 10% 3.9%",    "$type": "color" },
+      "card-foreground":              { "$value": "0 0% 98%",        "$type": "color" },
+      "popover":                      { "$value": "240 10% 3.9%",    "$type": "color" },
+      "popover-foreground":           { "$value": "0 0% 98%",        "$type": "color" },
+      "primary":                      { "$value": "0 0% 98%",        "$type": "color" },
+      "primary-foreground":           { "$value": "240 5.9% 10%",    "$type": "color" },
+      "secondary":                    { "$value": "240 3.7% 15.9%",  "$type": "color" },
+      "secondary-foreground":         { "$value": "0 0% 98%",        "$type": "color" },
+      "muted":                        { "$value": "240 3.7% 15.9%",  "$type": "color" },
+      "muted-foreground":             { "$value": "240 5% 64.9%",    "$type": "color" },
+      "accent":                       { "$value": "240 3.7% 15.9%",  "$type": "color" },
+      "accent-foreground":            { "$value": "0 0% 98%",        "$type": "color" },
+      "destructive":                  { "$value": "0 62.8% 30.6%",   "$type": "color" },
+      "destructive-foreground":       { "$value": "0 0% 98%",        "$type": "color" },
+      "border":                       { "$value": "240 3.7% 15.9%",  "$type": "color" },
+      "input":                        { "$value": "240 3.7% 15.9%",  "$type": "color" },
+      "ring":                         { "$value": "240 4.9% 83.9%",  "$type": "color" },
+      "sidebar-background":           { "$value": "240 5.9% 10%",    "$type": "color" },
+      "sidebar-foreground":           { "$value": "240 4.8% 95.9%",  "$type": "color" },
+      "sidebar-primary":              { "$value": "224.3 76.3% 48%", "$type": "color" },
+      "sidebar-primary-foreground":   { "$value": "0 0% 100%",       "$type": "color" },
+      "sidebar-accent":               { "$value": "240 3.7% 15.9%",  "$type": "color" },
+      "sidebar-accent-foreground":    { "$value": "240 4.8% 95.9%",  "$type": "color" },
+      "sidebar-border":               { "$value": "240 3.7% 15.9%",  "$type": "color" },
+      "sidebar-ring":                 { "$value": "217.2 91.2% 59.8%", "$type": "color" }
+    }
+  },
+
+  "spacing": {
+    "0":  { "$value": "0px",     "$type": "spacing" },
+    "1":  { "$value": "0.25rem", "$type": "spacing", "$description": "4px" },
+    "2":  { "$value": "0.5rem",  "$type": "spacing", "$description": "8px" },
+    "3":  { "$value": "0.75rem", "$type": "spacing", "$description": "12px" },
+    "4":  { "$value": "1rem",    "$type": "spacing", "$description": "16px" },
+    "5":  { "$value": "1.25rem", "$type": "spacing", "$description": "20px" },
+    "6":  { "$value": "1.5rem",  "$type": "spacing", "$description": "24px" },
+    "8":  { "$value": "2rem",    "$type": "spacing", "$description": "32px" },
+    "10": { "$value": "2.5rem",  "$type": "spacing", "$description": "40px" },
+    "12": { "$value": "3rem",    "$type": "spacing", "$description": "48px" },
+    "16": { "$value": "4rem",    "$type": "spacing", "$description": "64px" },
+    "20": { "$value": "5rem",    "$type": "spacing", "$description": "80px" },
+    "24": { "$value": "6rem",    "$type": "spacing", "$description": "96px" }
+  },
+
+  "radius": {
+    "none": { "$value": "0px",      "$type": "dimension" },
+    "sm":   { "$value": "0.25rem",  "$type": "dimension" },
+    "md":   { "$value": "0.375rem", "$type": "dimension" },
+    "lg":   { "$value": "0.5rem",   "$type": "dimension" },
+    "xl":   { "$value": "0.75rem",  "$type": "dimension" },
+    "2xl":  { "$value": "1rem",     "$type": "dimension" },
+    "full": { "$value": "9999px",   "$type": "dimension" }
+  },
+
+  "shadow": {
+    "sm": { "$value": "0 1px 2px 0 rgb(0 0 0 / 0.05)",                                                           "$type": "shadow" },
+    "md": { "$value": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",                       "$type": "shadow" },
+    "lg": { "$value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",                     "$type": "shadow" },
+    "xl": { "$value": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",                    "$type": "shadow" }
+  },
+
+  "font": {
+    "family": {
+      "sans": { "$value": "\"Geist Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace", "$type": "fontFamily" },
+      "mono": { "$value": "\"Geist Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace", "$type": "fontFamily" }
+    },
+    "size": {
+      "xs":   { "$value": "0.75rem",  "$type": "fontSize", "$description": "12px" },
+      "sm":   { "$value": "0.875rem", "$type": "fontSize", "$description": "14px" },
+      "base": { "$value": "1rem",     "$type": "fontSize", "$description": "16px" },
+      "lg":   { "$value": "1.125rem", "$type": "fontSize", "$description": "18px" },
+      "xl":   { "$value": "1.25rem",  "$type": "fontSize", "$description": "20px" },
+      "2xl":  { "$value": "1.5rem",   "$type": "fontSize", "$description": "24px" }
+    },
+    "weight": {
+      "normal":   { "$value": "400", "$type": "fontWeight" },
+      "medium":   { "$value": "500", "$type": "fontWeight" },
+      "semibold": { "$value": "600", "$type": "fontWeight" },
+      "bold":     { "$value": "700", "$type": "fontWeight" }
+    },
+    "lineHeight": {
+      "tight":   { "$value": "1.25", "$type": "lineHeight" },
+      "normal":  { "$value": "1.5",  "$type": "lineHeight" },
+      "relaxed": { "$value": "1.75", "$type": "lineHeight" }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,15 +1,23 @@
 {
   "name": "cubelite",
-  "version": "0.1.0",
   "private": true,
-  "type": "module",
-  "packageManager": "pnpm@9",
+  "version": "0.1.0",
+  "description": "Kubernetes context aggregator — discover, switch, and manage k8s contexts",
   "scripts": {
-    "dev": "pnpm --filter desktop tauri:dev",
-    "build": "pnpm --filter desktop tauri:build",
+    "dev": "pnpm --filter desktop dev",
+    "build": "pnpm --filter desktop build",
     "test": "pnpm --filter desktop test",
     "lint": "pnpm --filter desktop lint",
     "typecheck": "pnpm --filter desktop typecheck",
     "design:tokens": "tsx design/export-tokens.ts"
-  }
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2"
+  },
+  "engines": {
+    "node": ">=20.0.0",
+    "pnpm": ">=9.0.0"
+  },
+  "packageManager": "pnpm@9.15.0"
 }


### PR DESCRIPTION
Closes #6

## What

- `design/tokens.json` — W3C DTCG-style token file: zinc primitives (50–950), semantic light/dark aliases (background, foreground, card, muted, border, ring, primary, destructive, sidebar), spacing scale (0–24), border-radius (none→full), shadows (sm→xl), typography (family, size, weight, lineHeight)
- `design/export-tokens.ts` — tsx script that reads `tokens.json`, builds `@theme` and `@layer base` blocks, and rewrites `apps/desktop/src/app.css` between `/* @generated:*-start/end */` markers; run via `pnpm design:tokens`
- `apps/desktop/src/app.css` — expanded `@theme` block with all spacing / radius / shadow / font tokens; full `@layer base :root / .dark` with shadcn-svelte zinc semantic variables including sidebar tokens
- `package.json` (root) — adds `tsx` + `@types/node` devDependencies, wires `design:tokens` script

## Accessibility

All semantic pairings satisfy WCAG 2.1 AA (≥ 4.5:1 for text, ≥ 3:1 for non-text).