### PR TITLE
feat(core): bootstrap cubelite-core with kubeconfig parsing and context switching

### DIFF
--- a/crates/cubelite-core/Cargo.toml
+++ b/crates/cubelite-core/Cargo.toml
@@ -2,7 +2,6 @@
 name = "cubelite-core"
 version.workspace = true
 edition.workspace = true
-authors.workspace = true
 license.workspace = true
 
 [dependencies]

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -1,3 +1,8 @@
+//! Async Kubernetes client wrapper built on top of `kube-rs`.
+//!
+//! [`KubeClient`] wraps a configured `kube::Client` and exposes high-level
+//! methods for listing the most common Kubernetes resources.
+
 use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{Namespace, Pod};
 use kube::{
@@ -7,11 +12,14 @@ use kube::{
 use std::path::Path;
 
 use crate::{
-    error::ConfigError,
+    error::KubeconfigError,
     resources::{DeploymentInfo, NamespaceInfo, PodInfo},
 };
 
-/// Async Kubernetes client wrapper pre-configured from a kubeconfig file.
+/// An async Kubernetes client pre-configured from a kubeconfig file.
+///
+/// Use [`KubeClient::new`] to construct an instance, then call the async
+/// `list_*` methods to query cluster resources.
 pub struct KubeClient {
     inner: Client,
 }
@@ -19,14 +27,20 @@ pub struct KubeClient {
 impl KubeClient {
     /// Build a [`KubeClient`] from the kubeconfig at `path`.
     ///
-    /// `context` selects a named context; if `None` the file's `current-context` is used.
-    pub async fn new(path: &Path, context: Option<&str>) -> Result<Self, ConfigError> {
+    /// `context` selects a named context; when `None` the file's
+    /// `current-context` is used.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError`] when the file cannot be read, parsed, or
+    /// when the client cannot be initialised from the resulting config.
+    pub async fn new(path: &Path, context: Option<&str>) -> Result<Self, KubeconfigError> {
         let raw = tokio::fs::read_to_string(path)
             .await
-            .map_err(|source| ConfigError::Io { source })?;
+            .map_err(|source| KubeconfigError::Io { source })?;
 
         let kubeconfig: Kubeconfig =
-            serde_yaml::from_str(&raw).map_err(|source| ConfigError::ParseError { source })?;
+            serde_yaml::from_str(&raw).map_err(|source| KubeconfigError::ParseError { source })?;
 
         let options = KubeConfigOptions {
             context: context.map(str::to_string),
@@ -35,19 +49,27 @@ impl KubeClient {
 
         let config = Config::from_custom_kubeconfig(kubeconfig, &options)
             .await
-            .map_err(|e| ConfigError::MergeError {
+            .map_err(|e| KubeconfigError::MergeError {
                 reason: e.to_string(),
             })?;
 
-        let inner = Client::try_from(config).map_err(|e| ConfigError::ClientError {
+        let inner = Client::try_from(config).map_err(|e| KubeconfigError::ClientError {
             reason: e.to_string(),
         })?;
 
         Ok(Self { inner })
     }
 
-    /// List pods in `namespace`, or across all namespaces when `namespace` is `None`.
-    pub async fn list_pods(&self, namespace: Option<&str>) -> Result<Vec<PodInfo>, ConfigError> {
+    /// List pods in `namespace`, or across all namespaces when `namespace` is
+    /// `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_pods(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<PodInfo>, KubeconfigError> {
         let api: Api<Pod> = match namespace {
             Some(ns) => Api::namespaced(self.inner.clone(), ns),
             None => Api::all(self.inner.clone()),
@@ -56,7 +78,7 @@ impl KubeClient {
         let pod_list =
             api.list(&Default::default())
                 .await
-                .map_err(|e| ConfigError::ClientError {
+                .map_err(|e| KubeconfigError::ClientError {
                     reason: e.to_string(),
                 })?;
 
@@ -87,14 +109,18 @@ impl KubeClient {
         Ok(pods)
     }
 
-    /// List all namespaces.
-    pub async fn list_namespaces(&self) -> Result<Vec<NamespaceInfo>, ConfigError> {
+    /// List all namespaces visible to the authenticated user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_namespaces(&self) -> Result<Vec<NamespaceInfo>, KubeconfigError> {
         let api: Api<Namespace> = Api::all(self.inner.clone());
 
         let ns_list =
             api.list(&Default::default())
                 .await
-                .map_err(|e| ConfigError::ClientError {
+                .map_err(|e| KubeconfigError::ClientError {
                     reason: e.to_string(),
                 })?;
 
@@ -111,17 +137,21 @@ impl KubeClient {
         Ok(namespaces)
     }
 
-    /// List all deployments in `namespace`.
+    /// List all deployments in the given `namespace`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
     pub async fn list_deployments(
         &self,
         namespace: &str,
-    ) -> Result<Vec<DeploymentInfo>, ConfigError> {
+    ) -> Result<Vec<DeploymentInfo>, KubeconfigError> {
         let api: Api<Deployment> = Api::namespaced(self.inner.clone(), namespace);
 
         let deploy_list =
             api.list(&Default::default())
                 .await
-                .map_err(|e| ConfigError::ClientError {
+                .map_err(|e| KubeconfigError::ClientError {
                     reason: e.to_string(),
                 })?;
 

--- a/crates/cubelite-core/src/context.rs
+++ b/crates/cubelite-core/src/context.rs
@@ -90,7 +90,11 @@ mod tests {
     use super::*;
     use std::env;
     use std::io::Write;
+    use std::sync::Mutex;
     use tempfile::NamedTempFile;
+
+    /// Prevent parallel tests from racing on the `KUBECONFIG` env var.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn write_temp(content: &str) -> NamedTempFile {
         let mut f = NamedTempFile::new().expect("tempfile");
@@ -99,6 +103,7 @@ mod tests {
     }
 
     fn with_kubeconfig<F: FnOnce()>(yaml: &str, f: F) {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         let tmp = write_temp(yaml);
         env::set_var("KUBECONFIG", tmp.path().to_string_lossy().as_ref());
         f();

--- a/crates/cubelite-core/src/context.rs
+++ b/crates/cubelite-core/src/context.rs
@@ -1,0 +1,265 @@
+//! Context listing and switching operations.
+//!
+//! This module provides the primary high-level API for discovering and
+//! activating Kubernetes contexts.  All file I/O is delegated to
+//! [`crate::kubeconfig`].
+
+use crate::error::{ContextError, KubeconfigError};
+use crate::kubeconfig::KubeConfig;
+use crate::types::ContextInfo;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Return all context names from the default kubeconfig.
+///
+/// Respects the `KUBECONFIG` environment variable (`:` separated paths) and
+/// falls back to `~/.kube/config`.
+///
+/// # Errors
+///
+/// Returns [`ContextError::Kubeconfig`] wrapping any [`KubeconfigError`] that
+/// occurs during loading.
+pub fn list_contexts() -> Result<Vec<String>, ContextError> {
+    let cfg = KubeConfig::load()?;
+    Ok(cfg.context_names())
+}
+
+/// Return rich [`ContextInfo`] for every context in the default kubeconfig.
+///
+/// Unlike [`list_contexts`], this includes the cluster server URL, default
+/// namespace, and whether each context is currently active.
+///
+/// # Errors
+///
+/// Returns [`ContextError::Kubeconfig`] on load failure.
+pub fn list_context_infos() -> Result<Vec<ContextInfo>, ContextError> {
+    let cfg = KubeConfig::load()?;
+    Ok(cfg.list_contexts())
+}
+
+/// Return the name of the currently active context, if one is set.
+///
+/// # Errors
+///
+/// Returns [`ContextError::Kubeconfig`] on load failure.
+pub fn current_context() -> Result<Option<String>, ContextError> {
+    let cfg = KubeConfig::load()?;
+    Ok(cfg.current_context().map(str::to_string))
+}
+
+/// Switch the active context to `name` and persist the change to disk.
+///
+/// On success the first kubeconfig file (from `KUBECONFIG` or `~/.kube/config`)
+/// is rewritten with the new `current-context` value.
+///
+/// # Errors
+///
+/// * [`ContextError::NotFound`] — `name` does not exist in the loaded config.
+/// * [`ContextError::Kubeconfig`] — a load or save I/O / parse error occurred.
+pub fn set_active_context(name: &str) -> Result<(), ContextError> {
+    let mut cfg = KubeConfig::load()?;
+    cfg.set_active_context(name).map_err(|e| match e {
+        KubeconfigError::MergeError { .. } => ContextError::NotFound {
+            name: name.to_string(),
+        },
+        other => ContextError::Kubeconfig(other),
+    })?;
+    cfg.save()?;
+    Ok(())
+}
+
+/// Return `true` if a context with the given `name` exists in the default
+/// kubeconfig.
+///
+/// # Errors
+///
+/// Returns [`ContextError::Kubeconfig`] on load failure.
+pub fn context_exists(name: &str) -> Result<bool, ContextError> {
+    let cfg = KubeConfig::load()?;
+    Ok(cfg.get_context(name).is_some())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        f.write_all(content.as_bytes()).expect("write");
+        f
+    }
+
+    fn with_kubeconfig<F: FnOnce()>(yaml: &str, f: F) {
+        let tmp = write_temp(yaml);
+        env::set_var("KUBECONFIG", tmp.path().to_string_lossy().as_ref());
+        f();
+        env::remove_var("KUBECONFIG");
+        // Keep `tmp` alive until here so the file is not deleted before use.
+        drop(tmp);
+    }
+
+    #[test]
+    fn list_contexts_returns_all_names() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: dev
+contexts:
+  - name: dev
+    context: {}
+  - name: prod
+    context: {}
+"#;
+        with_kubeconfig(yaml, || {
+            let names = list_contexts().expect("list_contexts");
+            assert!(names.contains(&"dev".to_string()));
+            assert!(names.contains(&"prod".to_string()));
+        });
+    }
+
+    #[test]
+    fn current_context_returns_active() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: staging
+contexts:
+  - name: staging
+    context: {}
+"#;
+        with_kubeconfig(yaml, || {
+            let active = current_context().expect("current_context");
+            assert_eq!(active.as_deref(), Some("staging"));
+        });
+    }
+
+    #[test]
+    fn current_context_none_when_unset() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+contexts:
+  - name: dev
+    context: {}
+"#;
+        with_kubeconfig(yaml, || {
+            let active = current_context().expect("current_context");
+            assert!(active.is_none());
+        });
+    }
+
+    #[test]
+    fn context_exists_true_for_known_name() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+contexts:
+  - name: dev
+    context: {}
+"#;
+        with_kubeconfig(yaml, || {
+            assert!(context_exists("dev").expect("context_exists"));
+        });
+    }
+
+    #[test]
+    fn context_exists_false_for_unknown_name() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+contexts:
+  - name: dev
+    context: {}
+"#;
+        with_kubeconfig(yaml, || {
+            assert!(!context_exists("nonexistent").expect("context_exists"));
+        });
+    }
+
+    #[test]
+    fn set_active_context_unknown_name_returns_not_found() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+contexts:
+  - name: dev
+    context: {}
+"#;
+        let tmp = write_temp(yaml);
+        env::set_var("KUBECONFIG", tmp.path().to_string_lossy().as_ref());
+        let result = set_active_context("ghost");
+        env::remove_var("KUBECONFIG");
+        drop(tmp);
+
+        assert!(
+            matches!(result, Err(ContextError::NotFound { .. })),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn set_active_context_and_persists() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: dev
+contexts:
+  - name: dev
+    context: {}
+  - name: prod
+    context: {}
+"#;
+        let tmp = write_temp(yaml);
+        let path = tmp.path().to_path_buf();
+        env::set_var("KUBECONFIG", path.to_string_lossy().as_ref());
+        set_active_context("prod").expect("set_active_context");
+        env::remove_var("KUBECONFIG");
+
+        // Reload and verify persistence.
+        let cfg = KubeConfig::load_from_paths(&[path]).expect("reload");
+        assert_eq!(cfg.current_context(), Some("prod"));
+    }
+
+    #[test]
+    fn list_context_infos_includes_active_flag() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: dev
+contexts:
+  - name: dev
+    context:
+      cluster: dev-cluster
+      user: dev-user
+  - name: prod
+    context:
+      cluster: prod-cluster
+      user: prod-user
+clusters:
+  - name: dev-cluster
+    cluster:
+      server: https://dev:6443
+  - name: prod-cluster
+    cluster:
+      server: https://prod:6443
+users: []
+"#;
+        with_kubeconfig(yaml, || {
+            let infos = list_context_infos().expect("list_context_infos");
+            let dev = infos.iter().find(|i| i.name == "dev").expect("dev");
+            let prod = infos.iter().find(|i| i.name == "prod").expect("prod");
+            assert!(dev.is_active);
+            assert!(!prod.is_active);
+            assert_eq!(dev.cluster_server.as_deref(), Some("https://dev:6443"));
+        });
+    }
+}

--- a/crates/cubelite-core/src/error.rs
+++ b/crates/cubelite-core/src/error.rs
@@ -1,28 +1,43 @@
 use thiserror::Error;
 
+/// Errors that can occur while locating, loading, or parsing a kubeconfig file.
 #[derive(Debug, Error)]
-pub enum ConfigError {
+pub enum KubeconfigError {
+    /// A required kubeconfig file path does not exist on disk.
     #[error("kubeconfig file not found: {path}")]
     FileNotFound { path: String },
 
+    /// The YAML content of a kubeconfig file could not be deserialised.
     #[error("failed to parse kubeconfig: {source}")]
     ParseError {
         #[from]
         source: serde_yaml::Error,
     },
 
-    #[error("context '{name}' not found in kubeconfig")]
-    ContextNotFound { name: String },
-
-    #[error("failed to merge or load kubeconfig: {reason}")]
+    /// Two or more kubeconfig files could not be merged.
+    #[error("failed to merge kubeconfig files: {reason}")]
     MergeError { reason: String },
 
+    /// A Kubernetes client could not be constructed from the config.
     #[error("kubernetes client error: {reason}")]
     ClientError { reason: String },
 
+    /// An underlying I/O error occurred while reading or writing a kubeconfig.
     #[error("I/O error: {source}")]
     Io {
         #[from]
         source: std::io::Error,
     },
+}
+
+/// Errors that can occur during context selection or switching operations.
+#[derive(Debug, Error)]
+pub enum ContextError {
+    /// The requested context name does not exist in the loaded kubeconfig(s).
+    #[error("context '{name}' not found in kubeconfig")]
+    NotFound { name: String },
+
+    /// An error was propagated from a kubeconfig load or save operation.
+    #[error(transparent)]
+    Kubeconfig(#[from] KubeconfigError),
 }

--- a/crates/cubelite-core/src/kubeconfig.rs
+++ b/crates/cubelite-core/src/kubeconfig.rs
@@ -1,149 +1,273 @@
+//! Kubeconfig file loading, parsing, and manipulation.
+//!
+//! Supports:
+//! - Single-file load from `~/.kube/config`
+//! - Multi-file merge via `KUBECONFIG` environment variable (`:` separated)
+//! - Context switching with optional disk persistence
+
 use std::env;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
-
-use crate::error::ConfigError;
-
-// ---------------------------------------------------------------------------
-// Serde models (minimal — covers what we need from the kubeconfig spec)
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
-pub struct RawKubeConfig {
-    #[serde(default)]
-    pub contexts: Vec<NamedContext>,
-    #[serde(rename = "current-context", default)]
-    pub current_context: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct NamedContext {
-    pub name: String,
-    // We don't need the inner `context` object for listing/switching purposes.
-    #[serde(default)]
-    pub context: Option<serde_yaml::Value>,
-}
+use crate::error::KubeconfigError;
+use crate::types::{ContextDetails, ContextInfo, KubeConfigFile, NamedContext};
 
 // ---------------------------------------------------------------------------
-// Public surface
+// Public surface: KubeConfig
 // ---------------------------------------------------------------------------
 
-/// High-level kubeconfig state.
+/// High-level kubeconfig state produced after loading and merging one or more
+/// kubeconfig files.
+///
+/// # Example
+///
+/// ```no_run
+/// use cubelite_core::KubeConfig;
+///
+/// let cfg = KubeConfig::load()?;
+/// for name in cfg.list_context_names() {
+///     println!("{name}");
+/// }
+/// # Ok::<(), cubelite_core::KubeconfigError>(())
+/// ```
 #[derive(Debug, Clone)]
 pub struct KubeConfig {
-    /// All context names gathered from the loaded kubeconfig(s).
-    pub contexts: Vec<String>,
-    /// The currently active context, if any.
-    pub current_context: Option<String>,
-    /// The raw merged config (kept so we can serialise back on context switch).
-    raw: RawKubeConfig,
-    /// Paths that were actually loaded (first path wins for current-context).
+    /// Parsed, merged kubeconfig document.
+    raw: KubeConfigFile,
+    /// Paths that were actually loaded (first path wins for `current-context`).
     paths: Vec<PathBuf>,
 }
 
 impl KubeConfig {
-    /// Load kubeconfig from the path(s) specified by `KUBECONFIG`, falling back
-    /// to `~/.kube/config`.  Multiple paths separated by `:` are merged.
-    pub fn load() -> Result<Self, ConfigError> {
+    /// Load kubeconfig from the path(s) specified by the `KUBECONFIG`
+    /// environment variable, falling back to `~/.kube/config` when the
+    /// variable is absent or empty.
+    ///
+    /// Multiple paths in `KUBECONFIG` are `:` separated.  The first file's
+    /// `current-context` takes precedence during merging.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::FileNotFound`] when a path does not exist,
+    /// [`KubeconfigError::ParseError`] on invalid YAML, or
+    /// [`KubeconfigError::Io`] for other filesystem errors.
+    pub fn load() -> Result<Self, KubeconfigError> {
         let paths = resolve_kubeconfig_paths()?;
         Self::load_from_paths(&paths)
     }
 
-    /// Load kubeconfig from an explicit list of paths.
-    pub fn load_from_paths(paths: &[PathBuf]) -> Result<Self, ConfigError> {
+    /// Load kubeconfig from an explicit list of file paths.
+    ///
+    /// Contexts, clusters, and users are merged across all files; name
+    /// collisions are resolved by keeping the first occurrence (first-wins).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::FileNotFound`] when any path is missing, or
+    /// [`KubeconfigError::ParseError`] on invalid YAML content.
+    pub fn load_from_paths(paths: &[PathBuf]) -> Result<Self, KubeconfigError> {
         if paths.is_empty() {
-            return Err(ConfigError::FileNotFound {
-                path: "(no kubeconfig paths)".to_string(),
+            return Err(KubeconfigError::FileNotFound {
+                path: "(no kubeconfig paths provided)".to_string(),
             });
         }
 
-        let mut merged = RawKubeConfig::default();
+        let mut merged = KubeConfigFile::default();
         let mut first_current_context: Option<String> = None;
 
         for path in paths {
             if !path.exists() {
-                return Err(ConfigError::FileNotFound {
+                return Err(KubeconfigError::FileNotFound {
                     path: path.display().to_string(),
                 });
             }
 
             let content = std::fs::read_to_string(path)?;
-            let raw: RawKubeConfig = serde_yaml::from_str(&content)?;
+            let raw: KubeConfigFile = serde_yaml::from_str(&content)?;
 
-            // The first file's current-context takes precedence.
+            // First file's current-context takes precedence.
             if first_current_context.is_none() {
                 first_current_context = raw.current_context.clone();
             }
 
-            // Merge contexts, skipping name collisions.
+            // Merge contexts — first occurrence wins on name collision.
             for ctx in raw.contexts {
                 if !merged.contexts.iter().any(|c| c.name == ctx.name) {
                     merged.contexts.push(ctx);
+                }
+            }
+
+            // Merge clusters.
+            for cluster in raw.clusters {
+                if !merged.clusters.iter().any(|c| c.name == cluster.name) {
+                    merged.clusters.push(cluster);
+                }
+            }
+
+            // Merge users.
+            for user in raw.users {
+                if !merged.users.iter().any(|u| u.name == user.name) {
+                    merged.users.push(user);
                 }
             }
         }
 
         merged.current_context = first_current_context;
 
-        let contexts: Vec<String> = merged.contexts.iter().map(|c| c.name.clone()).collect();
-        let current_context = merged.current_context.clone();
-
         Ok(Self {
-            contexts,
-            current_context,
             raw: merged,
             paths: paths.to_vec(),
         })
     }
 
-    /// Return all context names.
-    pub fn list_contexts(&self) -> &[String] {
-        &self.contexts
+    // -----------------------------------------------------------------------
+    // Accessors
+    // -----------------------------------------------------------------------
+
+    /// Return an iterator over all context names in the loaded config.
+    pub fn list_context_names(&self) -> impl Iterator<Item = &str> {
+        self.raw.contexts.iter().map(|c| c.name.as_str())
     }
 
-    /// Switch the active context for this in-memory config.
-    /// The change is **not** persisted back to disk; see `save()` for that.
-    pub fn set_active_context(&mut self, name: &str) -> Result<(), ConfigError> {
-        if self.contexts.iter().any(|c| c == name) {
-            self.current_context = Some(name.to_string());
+    /// Return all context names as an owned `Vec<String>`.
+    pub fn context_names(&self) -> Vec<String> {
+        self.raw.contexts.iter().map(|c| c.name.clone()).collect()
+    }
+
+    /// Return the name of the currently active context, if any.
+    pub fn current_context(&self) -> Option<&str> {
+        self.raw.current_context.as_deref()
+    }
+
+    /// Return rich [`ContextInfo`] for every context in the config.
+    ///
+    /// Each entry includes the resolved cluster server URL (if available),
+    /// the default namespace, and whether it is the currently active context.
+    pub fn list_contexts(&self) -> Vec<ContextInfo> {
+        self.raw
+            .contexts
+            .iter()
+            .map(|named| self.resolve_context_info(named))
+            .collect()
+    }
+
+    /// Look up a single [`ContextInfo`] by name.
+    ///
+    /// Returns `None` when no context with the given `name` exists.
+    pub fn get_context(&self, name: &str) -> Option<ContextInfo> {
+        self.raw
+            .contexts
+            .iter()
+            .find(|c| c.name == name)
+            .map(|named| self.resolve_context_info(named))
+    }
+
+    // -----------------------------------------------------------------------
+    // Mutation
+    // -----------------------------------------------------------------------
+
+    /// Switch the active context to `name` in memory.
+    ///
+    /// The change is **not** persisted to disk; call [`Self::save`] afterwards
+    /// to make the switch durable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::MergeError`] when `name` is not present in
+    /// the loaded configuration.
+    pub fn set_active_context(&mut self, name: &str) -> Result<(), KubeconfigError> {
+        if self.raw.contexts.iter().any(|c| c.name == name) {
             self.raw.current_context = Some(name.to_string());
             Ok(())
         } else {
-            Err(ConfigError::ContextNotFound {
-                name: name.to_string(),
+            Err(KubeconfigError::MergeError {
+                reason: format!("context '{name}' not found in kubeconfig"),
             })
         }
     }
 
     /// Persist the (potentially modified) merged config back to the **first**
-    /// path in `paths`.  This mirrors how `kubectl` behaves.
-    pub fn save(&self) -> Result<(), ConfigError> {
+    /// kubeconfig path that was loaded.
+    ///
+    /// This mirrors how `kubectl` behaves when `KUBECONFIG` specifies multiple
+    /// paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::FileNotFound`] when no load path is known,
+    /// [`KubeconfigError::ParseError`] if serialisation fails, or
+    /// [`KubeconfigError::Io`] on write failure.
+    pub fn save(&self) -> Result<(), KubeconfigError> {
         let primary = self
             .paths
             .first()
-            .ok_or_else(|| ConfigError::FileNotFound {
-                path: "(no kubeconfig paths)".to_string(),
+            .ok_or_else(|| KubeconfigError::FileNotFound {
+                path: "(no kubeconfig paths known — cannot save)".to_string(),
             })?;
-        let yaml =
-            serde_yaml::to_string(&self.raw).map_err(|e| ConfigError::ParseError { source: e })?;
+        let yaml = serde_yaml::to_string(&self.raw)?;
         std::fs::write(primary, yaml)?;
         Ok(())
+    }
+
+    /// Return a reference to the raw merged [`KubeConfigFile`].
+    ///
+    /// Useful for callers that need direct access to cluster or user details
+    /// without going through the higher-level helpers.
+    pub fn raw(&self) -> &KubeConfigFile {
+        &self.raw
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    fn resolve_context_info(&self, named: &NamedContext) -> ContextInfo {
+        let details: Option<&ContextDetails> = named.context.as_ref();
+        let cluster_name = details.map(|d| d.cluster.as_str()).unwrap_or("");
+        let namespace = details
+            .and_then(|d| d.namespace.clone())
+            .unwrap_or_else(|| "default".to_string());
+
+        let cluster_server = self
+            .raw
+            .clusters
+            .iter()
+            .find(|c| c.name == cluster_name)
+            .and_then(|c| c.cluster.as_ref())
+            .map(|cl| cl.server.clone());
+
+        ContextInfo {
+            name: named.name.clone(),
+            cluster_server,
+            namespace,
+            is_active: self.raw.current_context.as_deref() == Some(named.name.as_str()),
+        }
     }
 }
 
 // ---------------------------------------------------------------------------
-// Module-level convenience wrappers
+// Module-level convenience functions
 // ---------------------------------------------------------------------------
 
 /// Load the default kubeconfig and return all context names.
-pub fn list_contexts() -> Result<Vec<String>, ConfigError> {
+///
+/// Convenience wrapper around [`KubeConfig::load`] + [`KubeConfig::context_names`].
+///
+/// # Errors
+///
+/// Propagates any [`KubeconfigError`] encountered during loading.
+pub fn list_contexts() -> Result<Vec<String>, KubeconfigError> {
     let cfg = KubeConfig::load()?;
-    Ok(cfg.contexts)
+    Ok(cfg.context_names())
 }
 
-/// Load the default kubeconfig, switch the active context, and save.
-pub fn set_active_context(name: &str) -> Result<(), ConfigError> {
+/// Load the default kubeconfig, switch the active context to `name`, and
+/// persist the change to disk.
+///
+/// # Errors
+///
+/// Returns [`KubeconfigError::MergeError`] when the context is not found, or
+/// propagates any I/O / parse error from load or save.
+pub fn set_active_context(name: &str) -> Result<(), KubeconfigError> {
     let mut cfg = KubeConfig::load()?;
     cfg.set_active_context(name)?;
     cfg.save()
@@ -153,10 +277,15 @@ pub fn set_active_context(name: &str) -> Result<(), ConfigError> {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-fn resolve_kubeconfig_paths() -> Result<Vec<PathBuf>, ConfigError> {
+/// Resolve the ordered list of kubeconfig file paths to load.
+///
+/// Reads `KUBECONFIG` env var (`:` separated) when set; falls back to
+/// `~/.kube/config` otherwise.
+fn resolve_kubeconfig_paths() -> Result<Vec<PathBuf>, KubeconfigError> {
     if let Ok(val) = env::var("KUBECONFIG") {
-        if !val.trim().is_empty() {
-            return Ok(val
+        let trimmed = val.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed
                 .split(':')
                 .filter(|s| !s.is_empty())
                 .map(PathBuf::from)
@@ -164,9 +293,8 @@ fn resolve_kubeconfig_paths() -> Result<Vec<PathBuf>, ConfigError> {
         }
     }
 
-    // Fallback: ~/.kube/config
-    let home = dirs::home_dir().ok_or_else(|| ConfigError::FileNotFound {
-        path: "~/.kube/config".to_string(),
+    let home = dirs::home_dir().ok_or_else(|| KubeconfigError::FileNotFound {
+        path: "~/.kube/config (home directory not found)".to_string(),
     })?;
     Ok(vec![home.join(".kube").join("config")])
 }
@@ -187,22 +315,73 @@ mod tests {
         f
     }
 
+    // -- Error cases ---------------------------------------------------------
+
     #[test]
-    fn missing_file_returns_error() {
+    fn empty_paths_returns_file_not_found() {
+        let result = KubeConfig::load_from_paths(&[]);
+        assert!(
+            matches!(result, Err(KubeconfigError::FileNotFound { .. })),
+            "expected FileNotFound, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn missing_file_returns_file_not_found() {
         let path = PathBuf::from("/tmp/does-not-exist-cubelite-test-99999.yaml");
         let result = KubeConfig::load_from_paths(&[path]);
-        assert!(matches!(result, Err(ConfigError::FileNotFound { .. })));
+        assert!(matches!(result, Err(KubeconfigError::FileNotFound { .. })));
     }
 
     #[test]
     fn malformed_yaml_returns_parse_error() {
         let f = write_temp("{ not valid yaml: [");
         let result = KubeConfig::load_from_paths(&[f.path().to_path_buf()]);
-        assert!(matches!(result, Err(ConfigError::ParseError { .. })));
+        assert!(matches!(result, Err(KubeconfigError::ParseError { .. })));
+    }
+
+    // -- Single-file loading -------------------------------------------------
+
+    #[test]
+    fn single_context_round_trip() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: dev
+contexts:
+  - name: dev
+    context:
+      cluster: dev-cluster
+      user: dev-user
+      namespace: kube-system
+clusters:
+  - name: dev-cluster
+    cluster:
+      server: https://192.168.1.1:6443
+users:
+  - name: dev-user
+    user:
+      token: fake-token
+"#;
+        let f = write_temp(yaml);
+        let cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("should load");
+
+        assert_eq!(cfg.context_names(), vec!["dev".to_string()]);
+        assert_eq!(cfg.current_context(), Some("dev"));
+
+        let infos = cfg.list_contexts();
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].name, "dev");
+        assert_eq!(infos[0].namespace, "kube-system");
+        assert_eq!(
+            infos[0].cluster_server.as_deref(),
+            Some("https://192.168.1.1:6443")
+        );
+        assert!(infos[0].is_active);
     }
 
     #[test]
-    fn valid_single_context() {
+    fn context_with_no_namespace_defaults_to_default() {
         let yaml = r#"
 apiVersion: v1
 kind: Config
@@ -214,20 +393,24 @@ contexts:
       user: dev-user
 "#;
         let f = write_temp(yaml);
-        let cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("should load");
-        assert_eq!(cfg.list_contexts(), &["dev".to_string()]);
-        assert_eq!(cfg.current_context.as_deref(), Some("dev"));
+        let cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+        let info = cfg.get_context("dev").expect("should find dev");
+        assert_eq!(info.namespace, "default");
     }
 
+    // -- Multi-file merge ----------------------------------------------------
+
     #[test]
-    fn valid_multi_context_merge() {
+    fn multi_file_merge_deduplicates_contexts() {
         let yaml_a = r#"
 apiVersion: v1
 kind: Config
 current-context: dev
 contexts:
   - name: dev
-    context: {}
+    context:
+      cluster: dev-cluster
+      user: dev-user
 "#;
         let yaml_b = r#"
 apiVersion: v1
@@ -235,19 +418,180 @@ kind: Config
 current-context: staging
 contexts:
   - name: staging
-    context: {}
+    context:
+      cluster: staging-cluster
+      user: staging-user
   - name: dev
-    context: {}
+    context:
+      cluster: dev-cluster
+      user: dev-user
 "#;
         let fa = write_temp(yaml_a);
         let fb = write_temp(yaml_b);
         let cfg = KubeConfig::load_from_paths(&[fa.path().to_path_buf(), fb.path().to_path_buf()])
             .expect("should merge");
 
-        let mut names = cfg.list_contexts().to_vec();
+        let mut names = cfg.context_names();
         names.sort();
         assert_eq!(names, vec!["dev".to_string(), "staging".to_string()]);
-        // First file's current-context wins.
-        assert_eq!(cfg.current_context.as_deref(), Some("dev"));
+        assert_eq!(cfg.current_context(), Some("dev"));
+    }
+
+    #[test]
+    fn multi_file_merge_combines_clusters_and_users() {
+        let yaml_a = r#"
+apiVersion: v1
+kind: Config
+contexts: []
+clusters:
+  - name: cluster-a
+    cluster:
+      server: https://a:6443
+users:
+  - name: user-a
+    user:
+      token: token-a
+"#;
+        let yaml_b = r#"
+apiVersion: v1
+kind: Config
+contexts: []
+clusters:
+  - name: cluster-b
+    cluster:
+      server: https://b:6443
+users:
+  - name: user-b
+    user:
+      token: token-b
+"#;
+        let fa = write_temp(yaml_a);
+        let fb = write_temp(yaml_b);
+        let cfg = KubeConfig::load_from_paths(&[fa.path().to_path_buf(), fb.path().to_path_buf()])
+            .expect("merge");
+
+        let raw = cfg.raw();
+        assert_eq!(raw.clusters.len(), 2);
+        assert_eq!(raw.users.len(), 2);
+    }
+
+    // -- Context switching ---------------------------------------------------
+
+    #[test]
+    fn set_active_context_updates_current() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: dev
+contexts:
+  - name: dev
+    context: {}
+  - name: prod
+    context: {}
+"#;
+        let f = write_temp(yaml);
+        let mut cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+        cfg.set_active_context("prod").expect("switch");
+        assert_eq!(cfg.current_context(), Some("prod"));
+    }
+
+    #[test]
+    fn set_active_context_unknown_returns_error() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+contexts:
+  - name: dev
+    context: {}
+"#;
+        let f = write_temp(yaml);
+        let mut cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+        let result = cfg.set_active_context("nonexistent");
+        assert!(
+            matches!(result, Err(KubeconfigError::MergeError { .. })),
+            "expected MergeError, got {result:?}"
+        );
+    }
+
+    // -- Persistence ---------------------------------------------------------
+
+    #[test]
+    fn save_persists_context_switch() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: dev
+contexts:
+  - name: dev
+    context: {}
+  - name: staging
+    context: {}
+"#;
+        let f = write_temp(yaml);
+        let path = f.path().to_path_buf();
+
+        let mut cfg = KubeConfig::load_from_paths(std::slice::from_ref(&path)).expect("load");
+        cfg.set_active_context("staging").expect("switch");
+        cfg.save().expect("save");
+
+        let reloaded = KubeConfig::load_from_paths(std::slice::from_ref(&path)).expect("reload");
+        assert_eq!(reloaded.current_context(), Some("staging"));
+    }
+
+    // -- KUBECONFIG env var --------------------------------------------------
+
+    #[test]
+    fn kubeconfig_env_var_single_path() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: env-ctx
+contexts:
+  - name: env-ctx
+    context: {}
+"#;
+        let f = write_temp(yaml);
+        let path_str = f.path().to_string_lossy().to_string();
+
+        env::set_var("KUBECONFIG", &path_str);
+        let cfg = KubeConfig::load().expect("load via KUBECONFIG");
+        env::remove_var("KUBECONFIG");
+
+        assert_eq!(cfg.current_context(), Some("env-ctx"));
+    }
+
+    #[test]
+    fn kubeconfig_env_var_multiple_paths() {
+        let yaml_a = r#"
+apiVersion: v1
+kind: Config
+current-context: ctx-a
+contexts:
+  - name: ctx-a
+    context: {}
+"#;
+        let yaml_b = r#"
+apiVersion: v1
+kind: Config
+contexts:
+  - name: ctx-b
+    context: {}
+"#;
+        let fa = write_temp(yaml_a);
+        let fb = write_temp(yaml_b);
+        let kubeconfig_val = format!(
+            "{}:{}",
+            fa.path().to_string_lossy(),
+            fb.path().to_string_lossy()
+        );
+
+        env::set_var("KUBECONFIG", &kubeconfig_val);
+        let cfg = KubeConfig::load().expect("multi-path KUBECONFIG");
+        env::remove_var("KUBECONFIG");
+
+        let mut names = cfg.context_names();
+        names.sort();
+        assert_eq!(names, vec!["ctx-a".to_string(), "ctx-b".to_string()]);
+        assert_eq!(cfg.current_context(), Some("ctx-a"));
     }
 }

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -1,9 +1,45 @@
+//! # cubelite-core
+//!
+//! Core Kubernetes context management library for CubeLite.
+//!
+//! ## Modules
+//!
+//! | Module | Purpose |
+//! |---|---|
+//! | [`kubeconfig`] | Load and manipulate kubeconfig files |
+//! | [`context`]    | List and switch Kubernetes contexts |
+//! | [`client`]     | Async `kube-rs` client wrapper |
+//! | [`resources`]  | Lightweight resource info types |
+//! | [`types`]      | Domain types mirroring the kubeconfig spec |
+//! | [`error`]      | Error types: [`KubeconfigError`], [`ContextError`] |
+//!
+//! ## Quick Start
+//!
+//! ```no_run
+//! use cubelite_core::{context, KubeconfigError};
+//!
+//! // List all available contexts.
+//! let names = context::list_contexts()?;
+//! println!("{names:?}");
+//!
+//! // Switch to a specific context (persists to disk).
+//! context::set_active_context("my-cluster")?;
+//! # Ok::<(), cubelite_core::error::ContextError>(())
+//! ```
+
 pub mod client;
+pub mod context;
 pub mod error;
 pub mod kubeconfig;
 pub mod resources;
+pub mod types;
 
+// Re-export the most commonly used items at the crate root.
 pub use client::KubeClient;
-pub use error::ConfigError;
-pub use kubeconfig::{list_contexts, set_active_context, KubeConfig};
+pub use error::{ContextError, KubeconfigError};
+pub use kubeconfig::KubeConfig;
 pub use resources::{DeploymentInfo, NamespaceInfo, PodInfo};
+pub use types::{
+    ClusterDetails, ContextDetails, ContextInfo, KubeConfigFile, NamedCluster, NamedContext,
+    NamedUser, UserDetails,
+};

--- a/crates/cubelite-core/src/resources.rs
+++ b/crates/cubelite-core/src/resources.rs
@@ -3,25 +3,36 @@ use serde::{Deserialize, Serialize};
 /// Lightweight representation of a Kubernetes Pod for display purposes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PodInfo {
+    /// The pod's name within its namespace.
     pub name: String,
+    /// The namespace the pod belongs to.
     pub namespace: String,
+    /// The pod phase string (e.g. `"Running"`, `"Pending"`, `"Succeeded"`).
     pub phase: Option<String>,
+    /// `true` when all containers in the pod are ready.
     pub ready: bool,
+    /// Total number of container restarts across all containers in the pod.
     pub restarts: i32,
 }
 
 /// Lightweight representation of a Kubernetes Namespace.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NamespaceInfo {
+    /// The namespace name.
     pub name: String,
+    /// The namespace phase string (e.g. `"Active"`, `"Terminating"`).
     pub phase: Option<String>,
 }
 
 /// Lightweight representation of a Kubernetes Deployment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeploymentInfo {
+    /// The deployment name.
     pub name: String,
+    /// The namespace the deployment belongs to.
     pub namespace: String,
+    /// Desired number of pod replicas as specified in the deployment spec.
     pub replicas: i32,
+    /// Number of replicas currently reporting as ready.
     pub ready_replicas: i32,
 }

--- a/crates/cubelite-core/src/types.rs
+++ b/crates/cubelite-core/src/types.rs
@@ -1,0 +1,194 @@
+//! Domain types that model a Kubernetes kubeconfig file.
+//!
+//! These types map closely to the [kubeconfig v1 API spec] but are stripped
+//! down to the fields relevant for context discovery and switching.
+//!
+//! [kubeconfig v1 API spec]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Top-level kubeconfig document
+// ---------------------------------------------------------------------------
+
+/// A fully parsed Kubernetes kubeconfig document.
+///
+/// This struct is the internal representation produced after loading and
+/// (optionally) merging one or more kubeconfig files.  All context, cluster,
+/// and user entries discovered across the input files are collected here.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KubeConfigFile {
+    /// All named contexts discovered in the kubeconfig(s).
+    #[serde(default)]
+    pub contexts: Vec<NamedContext>,
+
+    /// All named clusters discovered in the kubeconfig(s).
+    #[serde(default)]
+    pub clusters: Vec<NamedCluster>,
+
+    /// All named users / credentials discovered in the kubeconfig(s).
+    #[serde(default)]
+    pub users: Vec<NamedUser>,
+
+    /// The name of the currently active context, if any.
+    #[serde(rename = "current-context", default)]
+    pub current_context: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Named entries — the standard kubeconfig "named" wrappers
+// ---------------------------------------------------------------------------
+
+/// A named context entry inside a kubeconfig file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedContext {
+    /// The unique name used to reference this context (e.g. `"prod-us-east"`).
+    pub name: String,
+
+    /// The context details (cluster + user + optional namespace).
+    #[serde(default)]
+    pub context: Option<ContextDetails>,
+}
+
+/// A named cluster entry inside a kubeconfig file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedCluster {
+    /// The unique name used to reference this cluster.
+    pub name: String,
+
+    /// The cluster connection details.
+    #[serde(default)]
+    pub cluster: Option<ClusterDetails>,
+}
+
+/// A named user / credentials entry inside a kubeconfig file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedUser {
+    /// The unique name used to reference these credentials.
+    pub name: String,
+
+    /// The authentication details for this user.
+    #[serde(default)]
+    pub user: Option<UserDetails>,
+}
+
+// ---------------------------------------------------------------------------
+// Inner detail structs
+// ---------------------------------------------------------------------------
+
+/// The inner details of a kubeconfig context.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ContextDetails {
+    /// Name of the cluster this context points to.
+    #[serde(default)]
+    pub cluster: String,
+
+    /// Name of the user / credentials to authenticate as.
+    #[serde(default)]
+    pub user: String,
+
+    /// Optional default namespace for this context.
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+/// The inner details of a kubeconfig cluster entry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ClusterDetails {
+    /// The API server URL (e.g. `"https://192.168.1.10:6443"`).
+    #[serde(rename = "server", default)]
+    pub server: String,
+
+    /// PEM-encoded CA certificate data (base64, inline).
+    #[serde(rename = "certificate-authority-data", default)]
+    pub certificate_authority_data: Option<String>,
+
+    /// Path to a CA certificate file on disk.
+    #[serde(rename = "certificate-authority", default)]
+    pub certificate_authority: Option<String>,
+
+    /// Whether to skip TLS verification (insecure; not recommended in production).
+    #[serde(rename = "insecure-skip-tls-verify", default)]
+    pub insecure_skip_tls_verify: bool,
+}
+
+/// Authentication details for a kubeconfig user entry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserDetails {
+    /// A bearer token used to authenticate with the API server.
+    #[serde(default)]
+    pub token: Option<String>,
+
+    /// PEM-encoded client certificate data (base64, inline).
+    #[serde(rename = "client-certificate-data", default)]
+    pub client_certificate_data: Option<String>,
+
+    /// Path to a client certificate file on disk.
+    #[serde(rename = "client-certificate", default)]
+    pub client_certificate: Option<String>,
+
+    /// PEM-encoded client private key data (base64, inline).
+    #[serde(rename = "client-key-data", default)]
+    pub client_key_data: Option<String>,
+
+    /// Path to a client private key file on disk.
+    #[serde(rename = "client-key", default)]
+    pub client_key: Option<String>,
+
+    /// Optional username for basic authentication.
+    #[serde(default)]
+    pub username: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// High-level context descriptor (returned by public APIs)
+// ---------------------------------------------------------------------------
+
+/// A resolved, self-contained description of a single Kubernetes context.
+///
+/// Unlike [`NamedContext`], this struct includes the cluster server URL and
+/// namespace so callers can display or filter contexts without extra lookups.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextInfo {
+    /// The unique name of this context.
+    pub name: String,
+
+    /// The API server URL for the cluster this context points to, if resolvable.
+    pub cluster_server: Option<String>,
+
+    /// The default namespace, falling back to `"default"` when absent.
+    pub namespace: String,
+
+    /// Whether this is the currently active context.
+    pub is_active: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kubeconfig_file_default_is_empty() {
+        let cfg = KubeConfigFile::default();
+        assert!(cfg.contexts.is_empty());
+        assert!(cfg.clusters.is_empty());
+        assert!(cfg.users.is_empty());
+        assert!(cfg.current_context.is_none());
+    }
+
+    #[test]
+    fn context_details_default_namespace_is_none() {
+        let details = ContextDetails::default();
+        assert!(details.namespace.is_none());
+    }
+
+    #[test]
+    fn cluster_details_insecure_defaults_to_false() {
+        let details = ClusterDetails::default();
+        assert!(!details.insecure_skip_tls_verify);
+    }
+}

--- a/crates/cubelite-core/tests/kubeconfig_integration.rs
+++ b/crates/cubelite-core/tests/kubeconfig_integration.rs
@@ -1,0 +1,306 @@
+//! Integration tests for kubeconfig loading and context switching.
+//!
+//! These tests exercise the public API end-to-end, using real temp files on
+//! disk to simulate `~/.kube/config` and multi-path `KUBECONFIG` setups.
+
+use std::env;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tempfile::NamedTempFile;
+
+/// Serialises all tests that read or write the `KUBECONFIG` environment
+/// variable. `env::set_var` is not thread-safe; without this lock, tests that
+/// set the variable can race with other tests that read it.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+use cubelite_core::{
+    context,
+    error::{ContextError, KubeconfigError},
+    KubeConfig,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn write_temp(content: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("tempfile");
+    f.write_all(content.as_bytes()).expect("write");
+    f
+}
+
+fn minimal_kubeconfig(current: &str, contexts: &[&str]) -> String {
+    let ctx_list: String = contexts
+        .iter()
+        .map(|name| {
+            format!(
+                "  - name: {name}\n    context:\n      cluster: {name}-cluster\n      user: {name}-user\n"
+            )
+        })
+        .collect();
+    let cluster_list: String = contexts
+        .iter()
+        .map(|name| {
+            format!("  - name: {name}-cluster\n    cluster:\n      server: https://{name}:6443\n")
+        })
+        .collect();
+    let user_list: String = contexts
+        .iter()
+        .map(|name| format!("  - name: {name}-user\n    user:\n      token: token-{name}\n"))
+        .collect();
+
+    format!(
+        "apiVersion: v1\nkind: Config\ncurrent-context: {current}\ncontexts:\n{ctx_list}clusters:\n{cluster_list}users:\n{user_list}"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// KubeConfig: load / list
+// ---------------------------------------------------------------------------
+
+#[test]
+fn load_from_paths_single_file() {
+    let yaml = minimal_kubeconfig("dev", &["dev", "staging"]);
+    let f = write_temp(&yaml);
+    let cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+
+    let mut names = cfg.context_names();
+    names.sort();
+    assert_eq!(names, vec!["dev".to_string(), "staging".to_string()]);
+    assert_eq!(cfg.current_context(), Some("dev"));
+}
+
+#[test]
+fn load_returns_rich_context_info() {
+    let yaml = minimal_kubeconfig("dev", &["dev"]);
+    let f = write_temp(&yaml);
+    let cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+
+    let info = cfg.get_context("dev").expect("get_context");
+    assert_eq!(info.name, "dev");
+    assert_eq!(info.cluster_server.as_deref(), Some("https://dev:6443"));
+    assert!(info.is_active);
+    assert_eq!(info.namespace, "default");
+}
+
+#[test]
+fn missing_file_produces_file_not_found_error() {
+    let bad = PathBuf::from("/tmp/cubelite-no-such-file-99999999.yaml");
+    let err = KubeConfig::load_from_paths(&[bad]).expect_err("should fail");
+    assert!(
+        matches!(err, KubeconfigError::FileNotFound { .. }),
+        "expected FileNotFound, got {err:?}"
+    );
+}
+
+#[test]
+fn invalid_yaml_produces_parse_error() {
+    let f = write_temp("{ bad yaml: [[[");
+    let err = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect_err("should fail");
+    assert!(
+        matches!(err, KubeconfigError::ParseError { .. }),
+        "expected ParseError, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Multi-file merge
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_files_merge_without_duplicates() {
+    let yaml_a = minimal_kubeconfig("dev", &["dev"]);
+    let yaml_b = minimal_kubeconfig("staging", &["staging", "dev"]);
+
+    let fa = write_temp(&yaml_a);
+    let fb = write_temp(&yaml_b);
+
+    let cfg = KubeConfig::load_from_paths(&[fa.path().to_path_buf(), fb.path().to_path_buf()])
+        .expect("merge");
+
+    let mut names = cfg.context_names();
+    names.sort();
+    assert_eq!(names, vec!["dev".to_string(), "staging".to_string()]);
+    // First file wins for current-context.
+    assert_eq!(cfg.current_context(), Some("dev"));
+}
+
+#[test]
+fn three_files_all_clusters_present() {
+    let yaml_a = minimal_kubeconfig("a", &["a"]);
+    let yaml_b = minimal_kubeconfig("b", &["b"]);
+    let yaml_c = minimal_kubeconfig("c", &["c"]);
+
+    let fa = write_temp(&yaml_a);
+    let fb = write_temp(&yaml_b);
+    let fc = write_temp(&yaml_c);
+
+    let cfg = KubeConfig::load_from_paths(&[
+        fa.path().to_path_buf(),
+        fb.path().to_path_buf(),
+        fc.path().to_path_buf(),
+    ])
+    .expect("three-way merge");
+
+    let raw = cfg.raw();
+    assert_eq!(raw.clusters.len(), 3);
+    assert_eq!(raw.users.len(), 3);
+
+    let mut names = cfg.context_names();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Context switching
+// ---------------------------------------------------------------------------
+
+#[test]
+fn switch_context_updates_in_memory() {
+    let yaml = minimal_kubeconfig("dev", &["dev", "prod"]);
+    let f = write_temp(&yaml);
+    let mut cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+
+    cfg.set_active_context("prod").expect("switch");
+    assert_eq!(cfg.current_context(), Some("prod"));
+
+    // is_active must reflect the new active context.
+    let infos = cfg.list_contexts();
+    let prod_info = infos.iter().find(|i| i.name == "prod").expect("prod info");
+    let dev_info = infos.iter().find(|i| i.name == "dev").expect("dev info");
+    assert!(prod_info.is_active);
+    assert!(!dev_info.is_active);
+}
+
+#[test]
+fn switch_context_save_reload_roundtrip() {
+    let yaml = minimal_kubeconfig("dev", &["dev", "staging", "prod"]);
+    let f = write_temp(&yaml);
+    let path = f.path().to_path_buf();
+
+    let mut cfg = KubeConfig::load_from_paths(std::slice::from_ref(&path)).expect("load");
+    cfg.set_active_context("prod").expect("switch");
+    cfg.save().expect("save");
+
+    let reloaded = KubeConfig::load_from_paths(std::slice::from_ref(&path)).expect("reload");
+    assert_eq!(reloaded.current_context(), Some("prod"));
+}
+
+#[test]
+fn switch_to_nonexistent_context_fails() {
+    let yaml = minimal_kubeconfig("dev", &["dev"]);
+    let f = write_temp(&yaml);
+    let mut cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+
+    let err = cfg.set_active_context("ghost").expect_err("should fail");
+    assert!(
+        matches!(err, KubeconfigError::MergeError { .. }),
+        "expected MergeError, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// KUBECONFIG env var
+// ---------------------------------------------------------------------------
+
+#[test]
+fn kubeconfig_env_var_overrides_default() {
+    let yaml = minimal_kubeconfig("env-ctx", &["env-ctx"]);
+    let f = write_temp(&yaml);
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    env::set_var("KUBECONFIG", f.path().to_string_lossy().as_ref());
+    let cfg = KubeConfig::load().expect("load via KUBECONFIG");
+    env::remove_var("KUBECONFIG");
+
+    assert_eq!(cfg.current_context(), Some("env-ctx"));
+}
+
+#[test]
+fn kubeconfig_env_var_colon_separated() {
+    let yaml_a = minimal_kubeconfig("first", &["first"]);
+    let yaml_b = minimal_kubeconfig("second", &["second"]);
+    let fa = write_temp(&yaml_a);
+    let fb = write_temp(&yaml_b);
+
+    let val = format!(
+        "{}:{}",
+        fa.path().to_string_lossy(),
+        fb.path().to_string_lossy()
+    );
+    let _guard = ENV_LOCK.lock().unwrap();
+    env::set_var("KUBECONFIG", &val);
+    let cfg = KubeConfig::load().expect("multi-path KUBECONFIG");
+    env::remove_var("KUBECONFIG");
+
+    let mut names = cfg.context_names();
+    names.sort();
+    assert_eq!(names, vec!["first".to_string(), "second".to_string()]);
+    assert_eq!(cfg.current_context(), Some("first"));
+}
+
+// ---------------------------------------------------------------------------
+// context module (public API)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn context_list_contexts_via_module() {
+    let yaml = minimal_kubeconfig("alpha", &["alpha", "beta"]);
+    let f = write_temp(&yaml);
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    env::set_var("KUBECONFIG", f.path().to_string_lossy().as_ref());
+    let names = context::list_contexts().expect("list_contexts");
+    env::remove_var("KUBECONFIG");
+
+    assert!(names.contains(&"alpha".to_string()));
+    assert!(names.contains(&"beta".to_string()));
+}
+
+#[test]
+fn context_set_active_context_via_module() {
+    let yaml = minimal_kubeconfig("alpha", &["alpha", "beta"]);
+    let f = write_temp(&yaml);
+    let path = f.path().to_path_buf();
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    env::set_var("KUBECONFIG", path.to_string_lossy().as_ref());
+    context::set_active_context("beta").expect("set_active_context");
+    env::remove_var("KUBECONFIG");
+
+    let reloaded = KubeConfig::load_from_paths(&[path]).expect("reload");
+    assert_eq!(reloaded.current_context(), Some("beta"));
+}
+
+#[test]
+fn context_set_active_context_not_found_error() {
+    let yaml = minimal_kubeconfig("alpha", &["alpha"]);
+    let f = write_temp(&yaml);
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    env::set_var("KUBECONFIG", f.path().to_string_lossy().as_ref());
+    let err = context::set_active_context("ghost").expect_err("should fail");
+    env::remove_var("KUBECONFIG");
+
+    assert!(
+        matches!(err, ContextError::NotFound { .. }),
+        "expected ContextError::NotFound, got {err:?}"
+    );
+}
+
+#[test]
+fn context_current_context_via_module() {
+    let yaml = minimal_kubeconfig("active-one", &["active-one", "other"]);
+    let f = write_temp(&yaml);
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    env::set_var("KUBECONFIG", f.path().to_string_lossy().as_ref());
+    let active = context::current_context().expect("current_context");
+    env::remove_var("KUBECONFIG");
+
+    assert_eq!(active.as_deref(), Some("active-one"));
+}


### PR DESCRIPTION
## Summary

Bootstrap the `cubelite-core` Rust library as the shared backend for macOS and desktop apps.

Closes #29

## Changes

| File | Description |
|---|---|
| `crates/cubelite-core/src/error.rs` | `KubeconfigError` + `ContextError` with `thiserror 2` |
| `crates/cubelite-core/src/types.rs` | **NEW** — `KubeConfigFile`, `ContextInfo`, domain types |
| `crates/cubelite-core/src/context.rs` | **NEW** — `list_contexts`, `current_context`, `set_active_context`, `context_exists` |
| `crates/cubelite-core/src/kubeconfig.rs` | Full rewrite — multi-file merge, `KUBECONFIG` env var, persistence |
| `crates/cubelite-core/src/client.rs` | Updated error type + doc comments |
| `crates/cubelite-core/src/resources.rs` | Field-level doc comments |
| `crates/cubelite-core/src/lib.rs` | All new types re-exported |
| `crates/cubelite-core/tests/kubeconfig_integration.rs` | **NEW** — 15 integration tests |

## Quality Gates

- ✅ `cargo clippy -p cubelite-core -- -D warnings` — clean
- ✅ `cargo test -p cubelite-core` — 40 tests passed (23 unit + 15 integration + 2 doc)
- ✅ `cargo fmt -p cubelite-core --check` — clean