### PR TITLE
feat(macos): M2 — Lens-like UI with namespace browser, pod/deployment lists, resource detail

### DIFF
--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -4,7 +4,7 @@ persona: Simone
 description: >
   Cross-cutting security agent. Performs dependency audits, secret scanning,
   OWASP compliance checks, and security reviews across all stacks.
-model: ["Claude Sonnet 4.6", "Claude Opus 4.6"]
+model: ["Claude Opus 4.6", "Claude Sonnet 4.6"]
 tools:
   [
     vscode/extensions,

--- a/apps/macos/cubelite/cubelite/CubeliteApp.swift
+++ b/apps/macos/cubelite/cubelite/CubeliteApp.swift
@@ -5,14 +5,21 @@ import AppKit
 struct CubeliteApp: App {
 
     @State private var clusterState = ClusterState()
-    private let kubeconfigService = KubeconfigService()
+    private let kubeconfigService: KubeconfigService
+    private let kubeAPIService: KubeAPIService
+
+    init() {
+        let ks = KubeconfigService()
+        self.kubeconfigService = ks
+        self.kubeAPIService = KubeAPIService(kubeconfigService: ks)
+    }
 
     var body: some Scene {
         WindowGroup("CubeLite") {
-            MainView(kubeconfigService: kubeconfigService)
+            MainView(kubeconfigService: kubeconfigService, kubeAPIService: kubeAPIService)
                 .environment(clusterState)
         }
-        .defaultSize(width: 1000, height: 600)
+        .defaultSize(width: 1200, height: 700)
 
         MenuBarExtra("CubeLite", systemImage: "square.3.layers.3d") {
             MenuBarContextView(

--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -15,7 +15,7 @@ final class ClusterState {
     /// Pods in the selected namespace (or all namespaces).
     var pods: [PodInfo] = []
 
-    /// Available namespaces.
+    /// Available namespaces for the currently browsed context.
     var namespaces: [NamespaceInfo] = []
 
     /// Deployments in the selected namespace.
@@ -24,13 +24,36 @@ final class ClusterState {
     /// Selected namespace filter (`nil` means all namespaces).
     var selectedNamespace: String?
 
-    /// Whether data is currently being loaded.
+    /// Whether kubeconfig is currently being loaded.
     var isLoading = false
+
+    /// Whether K8s resources (pods/deployments) are being fetched.
+    var isLoadingResources = false
 
     /// Whether no kubeconfig file was found at any of the searched paths.
     /// When `true`, the app is healthy but has no cluster configuration yet.
     var noConfig = false
 
-    /// Last error message, if any.
+    /// Last kubeconfig load error message, if any.
     var errorMessage: String?
+
+    /// Last resource fetch error message, if any.
+    var resourceError: String?
+}
+
+// MARK: - Resource Type
+
+/// Resource categories available in the browse pane.
+enum ResourceType: String, CaseIterable, Identifiable {
+    case pods = "Pods"
+    case deployments = "Deployments"
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .pods: "cube.box"
+        case .deployments: "arrow.triangle.2.circlepath"
+        }
+    }
 }

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -11,6 +11,8 @@ struct PodInfo: Codable, Sendable, Identifiable {
     let phase: String?
     let ready: Bool
     let restarts: Int
+    /// ISO 8601 creation timestamp, used to compute pod age.
+    let creationTimestamp: String?
 }
 
 /// Information about a Kubernetes namespace.
@@ -90,6 +92,7 @@ struct K8sDeploymentStatus: Codable, Sendable {
 struct K8sObjectMeta: Codable, Sendable {
     let name: String?
     let namespace: String?
+    let creationTimestamp: String?
 }
 
 // MARK: - Mapping Extensions
@@ -105,7 +108,8 @@ extension K8sPod {
             namespace: metadata?.namespace ?? "",
             phase: status?.phase,
             ready: allReady,
-            restarts: totalRestarts
+            restarts: totalRestarts,
+            creationTimestamp: metadata?.creationTimestamp
         )
     }
 }

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -25,17 +25,22 @@ actor KubeAPIService {
 
     // MARK: - Public API
 
-    /// Lists all namespaces visible to the current context.
-    func listNamespaces() async throws -> [NamespaceInfo] {
-        let response: K8sListResponse<K8sNamespace> = try await fetch(path: "/api/v1/namespaces")
+    /// Lists all namespaces visible to the given context (or the active context when `nil`).
+    func listNamespaces(inContext contextName: String? = nil) async throws -> [NamespaceInfo] {
+        let response: K8sListResponse<K8sNamespace> = try await fetch(
+            path: "/api/v1/namespaces",
+            contextName: contextName
+        )
         return response.items.map { $0.toNamespaceInfo() }
     }
 
-    /// Lists pods, optionally scoped to a specific namespace.
+    /// Lists pods, optionally scoped to a namespace and/or context.
     ///
-    /// - Parameter namespace: If provided, only pods in this namespace are returned.
-    ///   When `nil`, pods across all namespaces are listed.
-    func listPods(namespace: String? = nil) async throws -> [PodInfo] {
+    /// - Parameters:
+    ///   - namespace: If provided, only pods in this namespace are returned.
+    ///     Passing `nil` lists pods across all namespaces.
+    ///   - contextName: Kubeconfig context to use; defaults to the active context.
+    func listPods(namespace: String? = nil, inContext contextName: String? = nil) async throws -> [PodInfo] {
         let path: String
         if let ns = namespace {
             let encoded = ns.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ns
@@ -43,26 +48,37 @@ actor KubeAPIService {
         } else {
             path = "/api/v1/pods"
         }
-        let response: K8sListResponse<K8sPod> = try await fetch(path: path)
+        let response: K8sListResponse<K8sPod> = try await fetch(path: path, contextName: contextName)
         return response.items.map { $0.toPodInfo() }
     }
 
-    /// Lists deployments in a given namespace.
+    /// Lists deployments, optionally scoped to a namespace and/or context.
     ///
-    /// - Parameter namespace: The namespace to query.
-    func listDeployments(namespace: String) async throws -> [DeploymentInfo] {
-        let encoded = namespace.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? namespace
-        let path = "/apis/apps/v1/namespaces/\(encoded)/deployments"
-        let response: K8sListResponse<K8sDeployment> = try await fetch(path: path)
+    /// - Parameters:
+    ///   - namespace: Namespace to query. Passing `nil` lists across all namespaces.
+    ///   - contextName: Kubeconfig context to use; defaults to the active context.
+    func listDeployments(namespace: String? = nil, inContext contextName: String? = nil) async throws -> [DeploymentInfo] {
+        let path: String
+        if let ns = namespace {
+            let encoded = ns.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ns
+            path = "/apis/apps/v1/namespaces/\(encoded)/deployments"
+        } else {
+            path = "/apis/apps/v1/deployments"
+        }
+        let response: K8sListResponse<K8sDeployment> = try await fetch(path: path, contextName: contextName)
         return response.items.map { $0.toDeploymentInfo() }
     }
 
     // MARK: - Internal Networking
 
     /// Fetches and decodes a JSON response from the Kubernetes API.
-    private func fetch<T: Codable & Sendable>(path: String) async throws -> T {
+    ///
+    /// - Parameters:
+    ///   - path: API path to request.
+    ///   - contextName: Override which kubeconfig context is used.
+    private func fetch<T: Codable & Sendable>(path: String, contextName: String? = nil) async throws -> T {
         let config = try await kubeconfigService.load()
-        let (cluster, user) = try resolveConnectionInfo(from: config)
+        let (cluster, user) = try resolveConnectionInfo(from: config, contextName: contextName)
 
         guard let serverString = cluster.server, !serverString.isEmpty else {
             throw CubeliteError.clientError(reason: "Cluster has no valid server URL")
@@ -115,24 +131,34 @@ actor KubeAPIService {
 
     // MARK: - Connection Resolution
 
-    /// Resolves the cluster and user details for the active context.
+    /// Resolves the cluster and user details for the given or active context.
+    ///
+    /// - Parameters:
+    ///   - config: Parsed kubeconfig.
+    ///   - contextName: Override which context to resolve. Defaults to `config.currentContext`.
     private func resolveConnectionInfo(
-        from config: KubeConfig
+        from config: KubeConfig,
+        contextName: String? = nil
     ) throws -> (ClusterDetails, UserDetails) {
-        guard let contextName = config.currentContext else {
+        let resolvedContext: String
+        if let name = contextName {
+            resolvedContext = name
+        } else if let name = config.currentContext {
+            resolvedContext = name
+        } else {
             throw CubeliteError.contextNotFound(name: "<none> — no active context set")
         }
 
-        guard let namedContext = config.raw.contexts?.first(where: { $0.name == contextName }),
+        guard let namedContext = config.raw.contexts?.first(where: { $0.name == resolvedContext }),
               let contextDetails = namedContext.context else {
-            throw CubeliteError.contextNotFound(name: contextName)
+            throw CubeliteError.contextNotFound(name: resolvedContext)
         }
 
         guard let clusterName = contextDetails.cluster,
               let namedCluster = config.raw.clusters?.first(where: { $0.name == clusterName }),
               let cluster = namedCluster.cluster else {
             throw CubeliteError.clientError(
-                reason: "Cluster definition not found for context '\(contextName)'"
+                reason: "Cluster definition not found for context '\(resolvedContext)'"
             )
         }
 
@@ -140,7 +166,7 @@ actor KubeAPIService {
               let namedUser = config.raw.users?.first(where: { $0.name == userName }),
               let user = namedUser.user else {
             throw CubeliteError.clientError(
-                reason: "User definition not found for context '\(contextName)'"
+                reason: "User definition not found for context '\(resolvedContext)'"
             )
         }
 

--- a/apps/macos/cubelite/cubelite/Views/DeploymentListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/DeploymentListView.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// Table listing Kubernetes deployments for the selected context and namespace.
+///
+/// Columns: Name, Ready (ready/desired replicas), Namespace.
+/// Selecting a row updates `selectedDeploymentID` for ``ResourceDetailView``.
+struct DeploymentListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+    @Binding var selectedDeploymentID: DeploymentInfo.ID?
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                loadingView
+            } else if let error = clusterState.resourceError {
+                errorView(error)
+            } else if clusterState.deployments.isEmpty {
+                emptyView
+            } else {
+                deploymentTable
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - States
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Loading deployments…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 32))
+                .foregroundStyle(.orange)
+            Text("Failed to load deployments")
+                .font(.headline)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+        }
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.system(size: 36))
+                .foregroundStyle(.quinary)
+            Text("No deployments found")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text("There are no deployments in this namespace.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: - Table
+
+    private var deploymentTable: some View {
+        Table(clusterState.deployments, selection: $selectedDeploymentID) {
+            TableColumn("") { dep in
+                DeploymentStatusDot(ready: dep.readyReplicas, desired: dep.replicas)
+            }
+            .width(16)
+
+            TableColumn("Name") { dep in
+                Text(dep.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+            .width(min: 120, ideal: 220)
+
+            TableColumn("Namespace") { dep in
+                Text(dep.namespace)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .width(min: 80, ideal: 120)
+
+            TableColumn("Ready") { dep in
+                replicasBadge(ready: dep.readyReplicas, desired: dep.replicas)
+            }
+            .width(ideal: 80)
+
+            TableColumn("Available") { dep in
+                Text("\(dep.readyReplicas)")
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .width(ideal: 72)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func replicasBadge(ready: Int, desired: Int) -> some View {
+        let allReady = ready == desired && desired > 0
+        return HStack(spacing: 3) {
+            Text("\(ready)/\(desired)")
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(allReady ? .green : .orange)
+        }
+    }
+}
+
+// MARK: - Deployment Status Dot
+
+/// Coloured circle reflecting replica health.
+private struct DeploymentStatusDot: View {
+    let ready: Int
+    let desired: Int
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+            .help(helpText)
+    }
+
+    private var color: Color {
+        if desired == 0 { return .secondary }
+        return ready == desired ? .green : .orange
+    }
+
+    private var helpText: String {
+        "\(ready)/\(desired) replicas ready"
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    @Previewable @State var selectedID: DeploymentInfo.ID? = nil
+    let state = ClusterState()
+    state.deployments = [
+        DeploymentInfo(name: "nginx", namespace: "default", replicas: 3, readyReplicas: 3),
+        DeploymentInfo(name: "api-server", namespace: "backend", replicas: 2, readyReplicas: 1),
+        DeploymentInfo(name: "worker", namespace: "jobs", replicas: 5, readyReplicas: 5),
+        DeploymentInfo(name: "pending-dep", namespace: "default", replicas: 1, readyReplicas: 0),
+    ]
+    return DeploymentListView(selectedDeploymentID: $selectedID)
+        .environment(state)
+        .frame(width: 600, height: 260)
+}

--- a/apps/macos/cubelite/cubelite/Views/K8sFormatters.swift
+++ b/apps/macos/cubelite/cubelite/Views/K8sFormatters.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+// MARK: - Age Formatting
+
+extension Optional where Wrapped == String {
+    /// Converts an optional ISO 8601 timestamp to a human-readable Kubernetes age string.
+    ///
+    /// Returns compact strings like `"3d"`, `"12h"`, `"5m"`, `"42s"`, or `"—"` when
+    /// the value is `nil` or cannot be parsed as a valid ISO 8601 date.
+    var k8sAge: String {
+        guard let iso = self else { return "—" }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
+        guard let createdAt = date else { return "—" }
+        let elapsed = Int(Date().timeIntervalSince(createdAt))
+        if elapsed < 60 { return "\(elapsed)s" }
+        if elapsed < 3_600 { return "\(elapsed / 60)m" }
+        if elapsed < 86_400 { return "\(elapsed / 3_600)h" }
+        return "\(elapsed / 86_400)d"
+    }
+}
+
+// MARK: - Pod Phase Color
+
+extension Color {
+    /// Returns the display colour for a given Kubernetes pod phase string.
+    ///
+    /// | Phase       | Color        |
+    /// |-------------|--------------|
+    /// | `Running`   | `.green`     |
+    /// | `Pending`   | `.orange`    |
+    /// | `Succeeded` | `.blue`      |
+    /// | `Failed`    | `.red`       |
+    /// | *(other)*   | `.secondary` |
+    static func podPhase(_ phase: String?) -> Color {
+        switch phase {
+        case "Running":   return .green
+        case "Pending":   return .orange
+        case "Succeeded": return .blue
+        case "Failed":    return .red
+        default:          return .secondary
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MainView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView.swift
@@ -2,39 +2,62 @@ import SwiftUI
 
 /// Primary application window — Lens-like Kubernetes IDE layout.
 ///
-/// Uses a ``NavigationSplitView`` with a sidebar listing all kubeconfig contexts,
-/// and a detail pane that shows information about the selected context.
-/// Future iterations will replace the detail placeholder with resource views
-/// (Pods, Deployments, Services, etc.).
+/// Uses a two-column ``NavigationSplitView``:
+/// - **Sidebar** (left): kubeconfig contexts with expandable namespace browsers.
+/// - **Detail** (right): resource browse pane (Pods / Deployments tabs) and,
+///   when a resource is selected, a trailing detail panel.
 ///
 /// Layout:
 /// ```
-/// ┌──────────────────────────────────────────────┐
-/// │  Toolbar: CubeLite logo + status + reload     │
-/// ├────────────┬─────────────────────────────────┤
-/// │  Sidebar   │  Detail area                     │
-/// │            │                                  │
-/// │  Contexts: │  (context info / placeholder)   │
-/// │  · ctx-1 ✓ │                                  │
-/// │  · ctx-2   │  "Select a context to begin"    │
-/// │  · ctx-3   │                                  │
-/// └────────────┴─────────────────────────────────┘
+/// ┌──────────────────────────────────────────────────────────┐
+/// │  Toolbar: CubeLite logo + status + reload                │
+/// ├──────────────────┬───────────────────────┬───────────────┤
+/// │  Sidebar         │  Resource list        │  Detail panel │
+/// │                  │                       │               │
+/// │  ▼ my-cluster ✓  │  [Pods|Deployments]   │  name: …      │
+/// │      All NS      │  ┌────────────────┐   │  namespace: … │
+/// │    • default ←   │  │ nginx    Run   │   │  phase: …     │
+/// │    • kube-sys    │  │ worker   Pend  │   │  restarts: …  │
+/// │  ▶ dev-cluster   │  └────────────────┘   │               │
+/// └──────────────────┴───────────────────────┴───────────────┘
 /// ```
 struct MainView: View {
 
     let kubeconfigService: KubeconfigService
+    let kubeAPIService: KubeAPIService
 
     @Environment(ClusterState.self) private var clusterState
-    @State private var selectedContext: String?
+
+    // MARK: - Sidebar State
+
+    /// Which context is currently expanded to show its namespace list.
+    @State private var expandedContext: String?
+    /// The (context, namespace) pair the user has selected in the sidebar.
+    @State private var sidebarSelection: SidebarSelection?
+    /// Whether namespaces for `expandedContext` are currently being fetched.
+    @State private var isLoadingNamespaces: Bool = false
+    /// Namespace fetch error, if any.
+    @State private var namespaceError: String?
+
+    // MARK: - Resource Browse State
+
+    /// Active resource tab: Pods or Deployments.
+    @State private var selectedResourceType: ResourceType = .pods
+    /// Row ID of the selected pod.
+    @State private var selectedPodID: PodInfo.ID?
+    /// Row ID of the selected deployment.
+    @State private var selectedDeploymentID: DeploymentInfo.ID?
+
+    // MARK: - Body
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {
             sidebar
-                .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 320)
+                .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 300)
         } detail: {
-            detailPane
+            detailArea
         }
-        .frame(minWidth: 800, minHeight: 500)
+        .frame(minWidth: 900, minHeight: 550)
         .toolbar { toolbarContent }
         .task { await loadKubeconfig() }
     }
@@ -52,17 +75,25 @@ struct MainView: View {
             }
         }
         ToolbarItem(placement: .primaryAction) {
-            if clusterState.isLoading {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Button {
-                    Task { await loadKubeconfig() }
-                } label: {
+            Button {
+                Task {
+                    await loadKubeconfig()
+                    if let ctx = expandedContext {
+                        await loadNamespaces(for: ctx)
+                    }
+                    if let sel = sidebarSelection {
+                        await loadResources(context: sel.context, namespace: sel.namespace)
+                    }
+                }
+            } label: {
+                if clusterState.isLoading || clusterState.isLoadingResources || isLoadingNamespaces {
+                    ProgressView().controlSize(.small)
+                } else {
                     Image(systemName: "arrow.clockwise")
                 }
-                .help("Reload kubeconfig")
             }
+            .help("Refresh all")
+            .disabled(clusterState.isLoading || clusterState.isLoadingResources)
         }
         if let error = clusterState.errorMessage {
             ToolbarItem(placement: .status) {
@@ -104,11 +135,51 @@ struct MainView: View {
     }
 
     private var contextList: some View {
-        List(clusterState.contexts, id: \.self, selection: $selectedContext) { context in
-            contextRow(for: context)
-                .tag(context)
+        List {
+            ForEach(clusterState.contexts, id: \.self) { context in
+                contextSection(context)
+            }
         }
-        .navigationTitle("Contexts")
+        .listStyle(.sidebar)
+        .navigationTitle("Clusters")
+    }
+
+    // MARK: - Context DisclosureGroup
+
+    private func contextSection(_ context: String) -> some View {
+        DisclosureGroup(
+            isExpanded: expandedBinding(for: context),
+            content: {
+                NamespaceListView(
+                    contextName: context,
+                    namespaces: context == expandedContext ? clusterState.namespaces : [],
+                    isLoading: context == expandedContext && isLoadingNamespaces,
+                    error: context == expandedContext ? namespaceError : nil,
+                    selection: $sidebarSelection
+                )
+            },
+            label: {
+                contextRow(for: context)
+            }
+        )
+    }
+
+    private func expandedBinding(for context: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedContext == context },
+            set: { isExpanded in
+                if isExpanded {
+                    if expandedContext != context {
+                        expandedContext = context
+                        clusterState.namespaces = []
+                        namespaceError = nil
+                        Task { await loadNamespaces(for: context) }
+                    }
+                } else if expandedContext == context {
+                    expandedContext = nil
+                }
+            }
+        )
     }
 
     private func contextRow(for context: String) -> some View {
@@ -129,15 +200,38 @@ struct MainView: View {
         .contentShape(Rectangle())
     }
 
-    // MARK: - Detail
+    // MARK: - Detail Area
 
     @ViewBuilder
-    private var detailPane: some View {
-        if let context = selectedContext {
-            contextDetail(for: context)
+    private var detailArea: some View {
+        if let sel = sidebarSelection {
+            resourceBrowserView(context: sel.context, namespace: sel.namespace)
+                .task(id: selectionKey) { @MainActor in
+                    selectedPodID = nil
+                    selectedDeploymentID = nil
+                    await loadResources(context: sel.context, namespace: sel.namespace)
+                }
+        } else if expandedContext != nil {
+            selectNamespacePlaceholder
         } else {
             emptyDetail
         }
+    }
+
+    private var selectNamespacePlaceholder: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "tray.2")
+                .font(.system(size: 48))
+                .foregroundStyle(.quinary)
+            Text("Select a namespace")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("Choose a namespace from the sidebar to browse resources.")
+                .font(.subheadline)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var emptyDetail: some View {
@@ -148,61 +242,7 @@ struct MainView: View {
             Text("Select a context to begin")
                 .font(.title2)
                 .foregroundStyle(.secondary)
-            Text("Choose a Kubernetes context from the sidebar.")
-                .font(.subheadline)
-                .foregroundStyle(.tertiary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private func contextDetail(for context: String) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            contextDetailHeader(context)
-            Divider()
-            resourcePlaceholder
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .navigationTitle(context)
-    }
-
-    private func contextDetailHeader(_ context: String) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "server.rack")
-                .font(.largeTitle)
-                .foregroundStyle(.tint)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(context)
-                    .font(.title2.bold())
-                if context == clusterState.currentContext {
-                    Label("Active context", systemImage: "checkmark.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                }
-            }
-
-            Spacer()
-
-            if context != clusterState.currentContext {
-                Button("Switch to this context") {
-                    Task { await switchContext(to: context) }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
-            }
-        }
-        .padding(20)
-    }
-
-    private var resourcePlaceholder: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "square.grid.2x2")
-                .font(.system(size: 40))
-                .foregroundStyle(.quinary)
-            Text("Resource views coming soon")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("Pods, Deployments, Services, ConfigMaps and more will appear here.")
+            Text("Expand a cluster in the sidebar to browse its namespaces.")
                 .font(.subheadline)
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
@@ -210,20 +250,119 @@ struct MainView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    // MARK: - Actions
+    // MARK: - Resource Browser
+
+    private var selectionKey: String {
+        guard let sel = sidebarSelection else { return "" }
+        return "\(sel.context)/\(sel.namespace ?? "*")"
+    }
+
+    private func resourceBrowserView(context: String, namespace: String?) -> some View {
+        HStack(spacing: 0) {
+            // Left column: resource type picker + resource list
+            VStack(spacing: 0) {
+                resourceBrowserHeader(context: context, namespace: namespace)
+                Divider()
+                resourceList
+            }
+
+            // Right column: detail panel (shown when a resource is selected)
+            if let detail = currentSelectedResource {
+                Divider()
+                ResourceDetailView(resource: detail)
+                    .frame(minWidth: 260, idealWidth: 340, maxWidth: 420)
+            }
+        }
+    }
+
+    private func resourceBrowserHeader(context: String, namespace: String?) -> some View {
+        HStack(spacing: 12) {
+            Label {
+                HStack(spacing: 4) {
+                    Text(context)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let ns = namespace {
+                        Image(systemName: "chevron.compact.right")
+                            .imageScale(.small)
+                            .foregroundStyle(.tertiary)
+                        Text(ns)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    } else {
+                        Image(systemName: "chevron.compact.right")
+                            .imageScale(.small)
+                            .foregroundStyle(.tertiary)
+                        Text("All Namespaces")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } icon: {
+                Image(systemName: "server.rack")
+                    .foregroundStyle(.secondary)
+            }
+            .font(.callout)
+
+            Spacer()
+
+            Picker("Resource type", selection: $selectedResourceType) {
+                ForEach(ResourceType.allCases) { type in
+                    Label(type.rawValue, systemImage: type.systemImage)
+                        .tag(type)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 220)
+            .labelsHidden()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var resourceList: some View {
+        switch selectedResourceType {
+        case .pods:
+            PodListView(selectedPodID: $selectedPodID)
+                .onChange(of: selectedPodID) { _, _ in
+                    selectedDeploymentID = nil
+                }
+        case .deployments:
+            DeploymentListView(selectedDeploymentID: $selectedDeploymentID)
+                .onChange(of: selectedDeploymentID) { _, _ in
+                    selectedPodID = nil
+                }
+        }
+    }
+
+    private var currentSelectedResource: SelectedResource? {
+        if let podID = selectedPodID,
+           let pod = clusterState.pods.first(where: { $0.id == podID }) {
+            return .pod(pod)
+        }
+        if let depID = selectedDeploymentID,
+           let dep = clusterState.deployments.first(where: { $0.id == depID }) {
+            return .deployment(dep)
+        }
+        return nil
+    }
+
+    // MARK: - Data Loading
 
     @MainActor
     private func loadKubeconfig() async {
         clusterState.isLoading = true
+        clusterState.errorMessage = nil
         defer { clusterState.isLoading = false }
         do {
             let config = try await kubeconfigService.load()
             clusterState.noConfig = false
             clusterState.contexts = config.contexts
             clusterState.currentContext = config.currentContext
-            // Auto-select the active context on first load
-            if selectedContext == nil {
-                selectedContext = config.currentContext
+            // Auto-expand the active context on first load
+            if expandedContext == nil, let active = config.currentContext {
+                expandedContext = active
+                Task { await loadNamespaces(for: active) }
             }
         } catch CubeliteError.fileNotFound {
             clusterState.noConfig = true
@@ -233,14 +372,37 @@ struct MainView: View {
     }
 
     @MainActor
-    private func switchContext(to context: String) async {
+    private func loadNamespaces(for context: String) async {
+        isLoadingNamespaces = true
+        namespaceError = nil
+        defer { isLoadingNamespaces = false }
         do {
-            var config = try await kubeconfigService.load()
-            try await kubeconfigService.setActiveContext(context, in: &config)
-            try await kubeconfigService.save(config)
-            clusterState.currentContext = context
+            let namespaces = try await kubeAPIService.listNamespaces(inContext: context)
+            clusterState.namespaces = namespaces.sorted { $0.name < $1.name }
         } catch {
-            clusterState.errorMessage = error.localizedDescription
+            namespaceError = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func loadResources(context: String, namespace: String?) async {
+        clusterState.isLoadingResources = true
+        clusterState.resourceError = nil
+        defer { clusterState.isLoadingResources = false }
+        do {
+            let pods = try await kubeAPIService.listPods(
+                namespace: namespace,
+                inContext: context
+            )
+            clusterState.pods = pods
+            let deployments = try await kubeAPIService.listDeployments(
+                namespace: namespace,
+                inContext: context
+            )
+            clusterState.deployments = deployments
+            clusterState.selectedNamespace = namespace
+        } catch {
+            clusterState.resourceError = error.localizedDescription
         }
     }
 }
@@ -251,13 +413,25 @@ struct MainView: View {
     let state = ClusterState()
     state.contexts = ["prod-us-east", "staging-eu", "dev-local"]
     state.currentContext = "staging-eu"
-    return MainView(kubeconfigService: KubeconfigService())
+    state.namespaces = [
+        NamespaceInfo(name: "default", phase: "Active"),
+        NamespaceInfo(name: "kube-system", phase: "Active"),
+    ]
+    state.pods = [
+        PodInfo(name: "nginx-abc", namespace: "default", phase: "Running",
+                ready: true, restarts: 0, creationTimestamp: nil),
+        PodInfo(name: "api-xyz", namespace: "default", phase: "Pending",
+                ready: false, restarts: 1, creationTimestamp: nil),
+    ]
+    let ks = KubeconfigService()
+    return MainView(kubeconfigService: ks, kubeAPIService: KubeAPIService(kubeconfigService: ks))
         .environment(state)
 }
 
 #Preview("No kubeconfig") {
     let state = ClusterState()
     state.noConfig = true
-    return MainView(kubeconfigService: KubeconfigService())
+    let ks = KubeconfigService()
+    return MainView(kubeconfigService: ks, kubeAPIService: KubeAPIService(kubeconfigService: ks))
         .environment(state)
 }

--- a/apps/macos/cubelite/cubelite/Views/NamespaceListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/NamespaceListView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+// MARK: - Sidebar Selection
+
+/// Identifies a (context, namespace) pair selected in the sidebar.
+struct SidebarSelection: Hashable, Sendable {
+    /// The kubeconfig context being browsed.
+    let context: String
+    /// Selected namespace, or `nil` for all namespaces.
+    let namespace: String?
+}
+
+// MARK: - NamespaceListView
+
+/// Displays an expandable list of namespaces for a single kubeconfig context
+/// inside the main sidebar.
+///
+/// Shows a "All Namespaces" catch-all row followed by individual namespace rows.
+/// Loading and error states are handled inline.
+struct NamespaceListView: View {
+
+    let contextName: String
+    let namespaces: [NamespaceInfo]
+    let isLoading: Bool
+    let error: String?
+
+    @Binding var selection: SidebarSelection?
+
+    var body: some View {
+        Group {
+            if isLoading {
+                loadingRow
+            } else if let error {
+                errorRow(error)
+            } else {
+                allNamespacesRow
+                ForEach(namespaces) { ns in
+                    namespaceRow(ns.name)
+                }
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    private var loadingRow: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Loading namespaces…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 3)
+        .padding(.leading, 4)
+    }
+
+    private func errorRow(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle")
+            .font(.caption)
+            .foregroundStyle(.orange)
+            .lineLimit(2)
+            .padding(.vertical, 3)
+            .padding(.leading, 4)
+    }
+
+    private var allNamespacesRow: some View {
+        namespaceRowView(namespace: nil, label: "All Namespaces", icon: "tray.2")
+    }
+
+    private func namespaceRow(_ name: String) -> some View {
+        namespaceRowView(namespace: name, label: name, icon: "square.dashed")
+    }
+
+    @ViewBuilder
+    private func namespaceRowView(namespace: String?, label: String, icon: String) -> some View {
+        let item = SidebarSelection(context: contextName, namespace: namespace)
+        let isSelected = selection == item
+
+        Button {
+            selection = item
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .imageScale(.small)
+                    .frame(width: 14)
+                Text(label)
+                    .font(.callout)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 2)
+        .padding(.horizontal, 4)
+        .background(
+            isSelected
+                ? RoundedRectangle(cornerRadius: 5).fill(Color.accentColor.opacity(0.18))
+                : nil
+        )
+        .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    @Previewable @State var selection: SidebarSelection? = SidebarSelection(context: "my-cluster", namespace: "default")
+    let state = ClusterState()
+    state.namespaces = [
+        NamespaceInfo(name: "default", phase: "Active"),
+        NamespaceInfo(name: "kube-system", phase: "Active"),
+        NamespaceInfo(name: "monitoring", phase: "Active"),
+    ]
+    return List {
+        NamespaceListView(
+            contextName: "my-cluster",
+            namespaces: state.namespaces,
+            isLoading: false,
+            error: nil,
+            selection: $selection
+        )
+    }
+    .listStyle(.sidebar)
+    .frame(width: 220, height: 300)
+    .environment(state)
+}

--- a/apps/macos/cubelite/cubelite/Views/PodListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PodListView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+/// Table listing pods for the selected context and namespace.
+///
+/// Columns: Status indicator, Name, Namespace, Restarts, Age.
+/// Selecting a row updates the `selectedPodID` binding, which the parent
+/// view uses to show ``ResourceDetailView``.
+struct PodListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+    @Binding var selectedPodID: PodInfo.ID?
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                loadingView
+            } else if let error = clusterState.resourceError {
+                errorView(error)
+            } else if clusterState.pods.isEmpty {
+                emptyView
+            } else {
+                podTable
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - States
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Loading pods…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 32))
+                .foregroundStyle(.orange)
+            Text("Failed to load pods")
+                .font(.headline)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+        }
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "cube.box")
+                .font(.system(size: 36))
+                .foregroundStyle(.quinary)
+            Text("No pods found")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text("There are no pods in this namespace.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: - Table
+
+    private var podTable: some View {
+        Table(clusterState.pods, selection: $selectedPodID) {
+            TableColumn("") { pod in
+                PodStatusDot(phase: pod.phase)
+            }
+            .width(16)
+
+            TableColumn("Name") { pod in
+                Text(pod.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+            .width(min: 120, ideal: 200)
+
+            TableColumn("Namespace") { pod in
+                Text(pod.namespace)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .width(min: 80, ideal: 120)
+
+            TableColumn("Status") { pod in
+                Text(pod.phase ?? "—")
+                    .font(.callout)
+                    .foregroundStyle(phaseColor(pod.phase))
+            }
+            .width(min: 60, ideal: 90)
+
+            TableColumn("Restarts") { pod in
+                Text("\(pod.restarts)")
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(pod.restarts > 5 ? Color.orange : Color.secondary)
+            }
+            .width(ideal: 70)
+
+            TableColumn("Age") { pod in
+                Text(ageString(from: pod.creationTimestamp))
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .width(ideal: 60)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func phaseColor(_ phase: String?) -> Color {
+        switch phase {
+        case "Running": return .green
+        case "Pending": return .orange
+        case "Succeeded": return .secondary
+        case "Failed": return .red
+        default: return .secondary
+        }
+    }
+
+    private func ageString(from isoTimestamp: String?) -> String {
+        guard let iso = isoTimestamp else { return "—" }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
+        guard let createdAt = date else { return "—" }
+        let elapsed = Int(Date().timeIntervalSince(createdAt))
+        if elapsed < 60 { return "\(elapsed)s" }
+        if elapsed < 3_600 { return "\(elapsed / 60)m" }
+        if elapsed < 86_400 { return "\(elapsed / 3_600)h" }
+        return "\(elapsed / 86_400)d"
+    }
+}
+
+// MARK: - Pod Status Dot
+
+/// Coloured circle reflecting pod phase.
+private struct PodStatusDot: View {
+    let phase: String?
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+            .help(phase ?? "Unknown")
+    }
+
+    private var color: Color {
+        switch phase {
+        case "Running": return .green
+        case "Pending": return .orange
+        case "Succeeded": return .blue
+        case "Failed": return .red
+        default: return .secondary
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    @Previewable @State var selectedID: PodInfo.ID? = nil
+    let state = ClusterState()
+    state.pods = [
+        PodInfo(name: "nginx-abc12", namespace: "default", phase: "Running",
+                ready: true, restarts: 0, creationTimestamp: "2024-01-10T08:00:00Z"),
+        PodInfo(name: "api-xyz99", namespace: "default", phase: "Running",
+                ready: true, restarts: 2, creationTimestamp: nil),
+        PodInfo(name: "worker-pending", namespace: "jobs", phase: "Pending",
+                ready: false, restarts: 0, creationTimestamp: nil),
+        PodInfo(name: "crashed-pod", namespace: "default", phase: "Failed",
+                ready: false, restarts: 12, creationTimestamp: nil),
+    ]
+    return PodListView(selectedPodID: $selectedID)
+        .environment(state)
+        .frame(width: 700, height: 300)
+}

--- a/apps/macos/cubelite/cubelite/Views/PodListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PodListView.swift
@@ -92,7 +92,7 @@ struct PodListView: View {
             TableColumn("Status") { pod in
                 Text(pod.phase ?? "—")
                     .font(.callout)
-                    .foregroundStyle(phaseColor(pod.phase))
+                    .foregroundStyle(Color.podPhase(pod.phase))
             }
             .width(min: 60, ideal: 90)
 
@@ -104,7 +104,7 @@ struct PodListView: View {
             .width(ideal: 70)
 
             TableColumn("Age") { pod in
-                Text(ageString(from: pod.creationTimestamp))
+                Text(pod.creationTimestamp.k8sAge)
                     .font(.callout.monospacedDigit())
                     .foregroundStyle(.secondary)
             }
@@ -112,30 +112,6 @@ struct PodListView: View {
         }
     }
 
-    // MARK: - Helpers
-
-    private func phaseColor(_ phase: String?) -> Color {
-        switch phase {
-        case "Running": return .green
-        case "Pending": return .orange
-        case "Succeeded": return .secondary
-        case "Failed": return .red
-        default: return .secondary
-        }
-    }
-
-    private func ageString(from isoTimestamp: String?) -> String {
-        guard let iso = isoTimestamp else { return "—" }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
-        guard let createdAt = date else { return "—" }
-        let elapsed = Int(Date().timeIntervalSince(createdAt))
-        if elapsed < 60 { return "\(elapsed)s" }
-        if elapsed < 3_600 { return "\(elapsed / 60)m" }
-        if elapsed < 86_400 { return "\(elapsed / 3_600)h" }
-        return "\(elapsed / 86_400)d"
-    }
 }
 
 // MARK: - Pod Status Dot
@@ -151,15 +127,7 @@ private struct PodStatusDot: View {
             .help(phase ?? "Unknown")
     }
 
-    private var color: Color {
-        switch phase {
-        case "Running": return .green
-        case "Pending": return .orange
-        case "Succeeded": return .blue
-        case "Failed": return .red
-        default: return .secondary
-        }
-    }
+    private var color: Color { Color.podPhase(phase) }
 }
 
 // MARK: - Preview

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -83,14 +83,14 @@ struct ResourceDetailView: View {
             DetailRow(label: "Phase") {
                 HStack(spacing: 6) {
                     Circle()
-                        .fill(podPhaseColor(pod.phase))
+                        .fill(Color.podPhase(pod.phase))
                         .frame(width: 8, height: 8)
                     Text(pod.phase ?? "Unknown")
                 }
             }
             DetailRow(label: "Ready", value: pod.ready ? "Yes" : "No")
             DetailRow(label: "Restarts", value: "\(pod.restarts)")
-            DetailRow(label: "Age", value: ageString(from: pod.creationTimestamp))
+            DetailRow(label: "Age", value: pod.creationTimestamp.k8sAge)
             if let ts = pod.creationTimestamp {
                 DetailRow(label: "Created", value: friendlyDate(ts))
             }
@@ -116,29 +116,6 @@ struct ResourceDetailView: View {
     }
 
     // MARK: - Helpers
-
-    private func podPhaseColor(_ phase: String?) -> Color {
-        switch phase {
-        case "Running": return .green
-        case "Pending": return .orange
-        case "Succeeded": return .blue
-        case "Failed": return .red
-        default: return .secondary
-        }
-    }
-
-    private func ageString(from isoTimestamp: String?) -> String {
-        guard let iso = isoTimestamp else { return "—" }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
-        guard let createdAt = date else { return "—" }
-        let elapsed = Int(Date().timeIntervalSince(createdAt))
-        if elapsed < 60 { return "\(elapsed)s" }
-        if elapsed < 3_600 { return "\(elapsed / 60)m" }
-        if elapsed < 86_400 { return "\(elapsed / 3_600)h" }
-        return "\(elapsed / 86_400)d"
-    }
 
     private func friendlyDate(_ iso: String) -> String {
         let formatter = ISO8601DateFormatter()

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -1,0 +1,226 @@
+import SwiftUI
+
+// MARK: - Selected Resource
+
+/// Discriminated union holding whichever resource is currently selected.
+enum SelectedResource: Sendable {
+    case pod(PodInfo)
+    case deployment(DeploymentInfo)
+}
+
+// MARK: - ResourceDetailView
+
+/// Detail panel shown in the trailing column when a resource is selected.
+///
+/// Displays a formatted grid of key properties for the elected pod or deployment.
+struct ResourceDetailView: View {
+
+    let resource: SelectedResource
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                Divider()
+                    .padding(.bottom, 12)
+                switch resource {
+                case .pod(let pod): podDetail(pod)
+                case .deployment(let dep): deploymentDetail(dep)
+                }
+            }
+            .padding(20)
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: headerIcon)
+                .font(.system(size: 28))
+                .foregroundStyle(.tint)
+                .frame(width: 36, height: 36)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(resourceName)
+                    .font(.title3.bold())
+                    .lineLimit(2)
+                Text(resourceKind)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.bottom, 14)
+    }
+
+    private var headerIcon: String {
+        switch resource {
+        case .pod: return "cube.box.fill"
+        case .deployment: return "arrow.triangle.2.circlepath"
+        }
+    }
+
+    private var resourceName: String {
+        switch resource {
+        case .pod(let p): return p.name
+        case .deployment(let d): return d.name
+        }
+    }
+
+    private var resourceKind: String {
+        switch resource {
+        case .pod: return "Pod"
+        case .deployment: return "Deployment"
+        }
+    }
+
+    // MARK: - Pod Detail
+
+    private func podDetail(_ pod: PodInfo) -> some View {
+        DetailGrid {
+            DetailRow(label: "Namespace", value: pod.namespace)
+            DetailRow(label: "Phase") {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(podPhaseColor(pod.phase))
+                        .frame(width: 8, height: 8)
+                    Text(pod.phase ?? "Unknown")
+                }
+            }
+            DetailRow(label: "Ready", value: pod.ready ? "Yes" : "No")
+            DetailRow(label: "Restarts", value: "\(pod.restarts)")
+            DetailRow(label: "Age", value: ageString(from: pod.creationTimestamp))
+            if let ts = pod.creationTimestamp {
+                DetailRow(label: "Created", value: friendlyDate(ts))
+            }
+        }
+    }
+
+    // MARK: - Deployment Detail
+
+    private func deploymentDetail(_ dep: DeploymentInfo) -> some View {
+        DetailGrid {
+            DetailRow(label: "Namespace", value: dep.namespace)
+            DetailRow(label: "Replicas", value: "\(dep.replicas)")
+            DetailRow(label: "Ready") {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(dep.readyReplicas == dep.replicas && dep.replicas > 0 ? Color.green : Color.orange)
+                        .frame(width: 8, height: 8)
+                    Text("\(dep.readyReplicas) / \(dep.replicas)")
+                }
+            }
+            DetailRow(label: "Available", value: "\(dep.readyReplicas)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func podPhaseColor(_ phase: String?) -> Color {
+        switch phase {
+        case "Running": return .green
+        case "Pending": return .orange
+        case "Succeeded": return .blue
+        case "Failed": return .red
+        default: return .secondary
+        }
+    }
+
+    private func ageString(from isoTimestamp: String?) -> String {
+        guard let iso = isoTimestamp else { return "—" }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
+        guard let createdAt = date else { return "—" }
+        let elapsed = Int(Date().timeIntervalSince(createdAt))
+        if elapsed < 60 { return "\(elapsed)s" }
+        if elapsed < 3_600 { return "\(elapsed / 60)m" }
+        if elapsed < 86_400 { return "\(elapsed / 3_600)h" }
+        return "\(elapsed / 86_400)d"
+    }
+
+    private func friendlyDate(_ iso: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso) else {
+            return iso
+        }
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        display.timeStyle = .short
+        return display.string(from: date)
+    }
+}
+
+// MARK: - Detail Grid / Rows
+
+/// Container that lays out ``DetailRow`` items in a two-column grid.
+private struct DetailGrid<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            content
+        }
+    }
+}
+
+/// A label + value row used inside ``DetailGrid``.
+private struct DetailRow<Value: View>: View {
+    let label: String
+    let value: Value
+
+    init(label: String, @ViewBuilder value: () -> Value) {
+        self.label = label
+        self.value = value()
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(width: 90, alignment: .leading)
+            value
+                .font(.callout)
+        }
+    }
+}
+
+/// Convenience overload for plain string values.
+private extension DetailRow where Value == Text {
+    init(label: String, value: String) {
+        self.init(label: label) { Text(value) }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Pod") {
+    let pod = PodInfo(
+        name: "nginx-abc123-xyz",
+        namespace: "default",
+        phase: "Running",
+        ready: true,
+        restarts: 3,
+        creationTimestamp: "2024-01-10T08:00:00Z"
+    )
+    return ResourceDetailView(resource: .pod(pod))
+        .frame(width: 340, height: 400)
+}
+
+#Preview("Deployment") {
+    let dep = DeploymentInfo(
+        name: "api-server",
+        namespace: "backend",
+        replicas: 3,
+        readyReplicas: 2
+    )
+    return ResourceDetailView(resource: .deployment(dep))
+        .frame(width: 340, height: 300)
+}

--- a/apps/macos/cubelite/cubeliteTests/cubeliteTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/cubeliteTests.swift
@@ -281,7 +281,7 @@ final class ResourceModelTests: XCTestCase {
 
     func testK8sPod_toPodInfo_allContainersReady() {
         let pod = K8sPod(
-            metadata: K8sObjectMeta(name: "nginx-abc", namespace: "production"),
+            metadata: K8sObjectMeta(name: "nginx-abc", namespace: "production", creationTimestamp: nil),
             status: K8sPodStatus(
                 phase: "Running",
                 containerStatuses: [
@@ -302,7 +302,7 @@ final class ResourceModelTests: XCTestCase {
 
     func testK8sPod_toPodInfo_oneContainerNotReady_isNotReady() {
         let pod = K8sPod(
-            metadata: K8sObjectMeta(name: "app", namespace: "default"),
+            metadata: K8sObjectMeta(name: "app", namespace: "default", creationTimestamp: nil),
             status: K8sPodStatus(
                 phase: "Running",
                 containerStatuses: [
@@ -320,7 +320,7 @@ final class ResourceModelTests: XCTestCase {
 
     func testK8sPod_toPodInfo_noContainers_isNotReady() {
         let pod = K8sPod(
-            metadata: K8sObjectMeta(name: "pending", namespace: "kube-system"),
+            metadata: K8sObjectMeta(name: "pending", namespace: "kube-system", creationTimestamp: nil),
             status: K8sPodStatus(phase: "Pending", containerStatuses: [])
         )
 
@@ -340,7 +340,7 @@ final class ResourceModelTests: XCTestCase {
 
     func testK8sNamespace_toNamespaceInfo_mapsCorrectly() {
         let ns = K8sNamespace(
-            metadata: K8sObjectMeta(name: "kube-system", namespace: nil),
+            metadata: K8sObjectMeta(name: "kube-system", namespace: nil, creationTimestamp: nil),
             status: K8sNamespaceStatus(phase: "Active")
         )
 
@@ -352,7 +352,7 @@ final class ResourceModelTests: XCTestCase {
     }
 
     func testPodInfo_id_combinesNamespaceAndName() {
-        let pod = PodInfo(name: "my-app", namespace: "staging", phase: "Running", ready: true, restarts: 0)
+        let pod = PodInfo(name: "my-app", namespace: "staging", phase: "Running", ready: true, restarts: 0, creationTimestamp: nil)
         XCTAssertEqual(pod.id, "staging/my-app")
     }
 


### PR DESCRIPTION
## Summary

Complete M2 milestone for the macOS native app — full **Lens-like UI** with `NavigationSplitView`, namespace browsing, resource tables, and detail pane.

Closes #28

## Changes

### New Views
| File | Description |
|---|---|
| `Views/MainView.swift` | Full rewrite — sidebar with context `DisclosureGroup`, namespace browser, resource browse pane |
| `Views/NamespaceListView.swift` | **NEW** — sidebar namespace list with loading/error states |
| `Views/PodListView.swift` | **NEW** — Table with status dot, name, namespace, phase, restarts, age |
| `Views/DeploymentListView.swift` | **NEW** — Table with status dot, name, namespace, ready/total replicas |
| `Views/ResourceDetailView.swift` | **NEW** — Detail panel with `SelectedResource` discriminated union |

### Model Updates
| File | Description |
|---|---|
| `Models/ResourceModels.swift` | Fixed `toPodInfo()` — empty `containerStatuses` now correctly returns `ready: false` |
| `Models/ClusterState.swift` | `@Observable @MainActor` state container |

### Infrastructure
- Pinned `dtolnay/rust-toolchain` to full SHA for SonarCloud compliance
- Fixed security agent model order (Opus 4.6 first)
- Added Branching Base Rule to AGENTS.md and copilot-instructions.md

## Quality Gates

- ✅ `xcodebuild test` — all tests pass
- ✅ No force-unwrap (`!`) in production code
- ✅ `@Observable` used (not `ObservableObject`)
- ✅ Strict concurrency checking enabled