### PR TITLE
fix(docs): address PR #32 review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - macOS native app: `KubeconfigService`, `KubeAPIService`, `KeychainService` actors
-  - `KubeconfigService`: resolves `KUBECONFIG` env paths, merges multiple configs, sandboxbox-safe home directory resolution via `getpwuid`
+  - `KubeconfigService`: resolves `KUBECONFIG` env paths, merges multiple configs, sandbox-safe home directory resolution via `getpwuid`
   - `KubeAPIService`: typed access to Kubernetes REST API via `URLSession` (namespaces, pods, deployments); bearer token and custom CA trust
   - `KeychainService`: generic password items tagged by service + account; store, retrieve, delete, and update via Security framework
 - macOS GUI: `NavigationSplitView` Lens-like layout with sidebar context list and detail pane
@@ -30,4 +30,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agent roster: coordinator, core, desktop, macos, design, devops, qa, docs, pages, security
 - Repository governance: `CONTRIBUTING.md`, `CODEOWNERS`, branch protection rules, PR template
 
-[Unreleased]: https://github.com/massimilianolapuma/cubelite/compare/HEAD...HEAD
+[Unreleased]: https://github.com/massimilianolapuma/cubelite/compare/main...HEAD

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Unlike Lens (Electron-based, cloud account required) or k9s (terminal-only), Cub
 - **Menu bar quick-switch** — click the status-bar icon to switch context without opening the main window
 - **Lens-like GUI** — `NavigationSplitView` sidebar listing all contexts, detail pane for cluster resources
 - **Kubernetes resources** — Pods, Namespaces, Deployments (Pods: name, namespace, phase, ready, restarts)
-- **Secure credential storage** — bearer tokens and client certificates stored in the OS Keychain
+- **Secure credential storage** — OS Keychain integration for bearer tokens and client certificates (planned)
 - **Graceful no-config state** — informative UI when no kubeconfig is found
 
 ## Architecture


### PR DESCRIPTION
Fixes three documentation issues flagged in PR #32 review by Roberto.

## Changes

### Fix #37 — Typo in CHANGELOG (`sandboxbox-safe` → `sandbox-safe`)
- **File:** `CHANGELOG.md`
- Corrected double-`box` typo in the `KubeconfigService` description.

### Fix #40 — README Keychain claim softened to "planned"
- **File:** `README.md`
- Changed _"bearer tokens and client certificates stored in the OS Keychain"_ to _"OS Keychain integration for bearer tokens and client certificates (planned)"_, accurately reflecting that `KeychainService` exists but is not yet wired into the auth flow.

### Fix #42 — `[Unreleased]` diff link corrected (`HEAD...HEAD` → `main...HEAD`)
- **File:** `CHANGELOG.md`
- The comparison URL was pointing `HEAD...HEAD`, which is always empty. Now points to `main...HEAD` so the link shows all unreleased commits.

Closes #37, Closes #40, Closes #42