### PR TITLE
feat(config): integrate Penpot MCP replacing Figma

### DIFF
--- a/.github/agents/design.agent.md
+++ b/.github/agents/design.agent.md
@@ -4,6 +4,7 @@ persona: Luca
 description: >
   Owns UI design for apps/desktop/. Manages design tokens,
   shadcn-svelte components, Tailwind configuration, and accessibility.
+  Uses Penpot (open-source) via MCP for design-to-code workflows.
 model: ["Claude Sonnet 4.6", "Claude Opus 4.6"]
 tools:
   [
@@ -47,23 +48,6 @@ tools:
     search/usages,
     web/fetch,
     web/githubRepo,
-    com.figma.mcp/mcp/add_code_connect_map,
-    com.figma.mcp/mcp/create_design_system_rules,
-    com.figma.mcp/mcp/create_new_file,
-    com.figma.mcp/mcp/generate_diagram,
-    com.figma.mcp/mcp/generate_figma_design,
-    com.figma.mcp/mcp/get_code_connect_map,
-    com.figma.mcp/mcp/get_code_connect_suggestions,
-    com.figma.mcp/mcp/get_context_for_code_connect,
-    com.figma.mcp/mcp/get_design_context,
-    com.figma.mcp/mcp/get_figjam,
-    com.figma.mcp/mcp/get_metadata,
-    com.figma.mcp/mcp/get_screenshot,
-    com.figma.mcp/mcp/get_variable_defs,
-    com.figma.mcp/mcp/search_design_system,
-    com.figma.mcp/mcp/send_code_connect_mappings,
-    com.figma.mcp/mcp/use_figma,
-    com.figma.mcp/mcp/whoami,
     github/add_comment_to_pending_review,
     github/add_issue_comment,
     github/add_reply_to_pull_request_comment,
@@ -118,6 +102,25 @@ tools:
 
 You own the UI layer of `apps/desktop/`. You work alongside the desktop-agent.
 
+## Design Tool — Penpot MCP
+
+This project uses **Penpot** (open-source design platform) instead of Figma.
+The Penpot MCP server is configured in `.vscode/mcp.json` and provides
+design-to-code and code-to-design workflows via the Model Context Protocol.
+
+### How it works
+
+1. **Start the server**: `npx -y @penpot/mcp@">=0"` (requires Node.js v22+)
+2. **Load the plugin** in Penpot (Plugins → `http://localhost:4400/manifest.json`)
+3. **Connect** the plugin to the MCP server (click "Connect to MCP server")
+4. VS Code connects automatically via `.vscode/mcp.json` (SSE on `localhost:4401`)
+
+The Penpot MCP tools are dynamically discovered at runtime when the server is
+running. They enable querying, transforming, and creating design elements
+directly from the AI agent.
+
+See `docs/penpot-mcp-setup.md` for the full setup guide.
+
 ## Responsibilities
 
 - Design tokens and theme configuration
@@ -125,6 +128,7 @@ You own the UI layer of `apps/desktop/`. You work alongside the desktop-agent.
 - Tailwind v4 configuration and utility patterns
 - Accessibility (WCAG 2.1 AA compliance)
 - Color schemes (light + dark mode)
+- Penpot ↔ code design workflows
 
 ## Key Rules
 
@@ -132,3 +136,4 @@ You own the UI layer of `apps/desktop/`. You work alongside the desktop-agent.
 - Color contrast ratio ≥ 4.5:1 for normal text
 - Use semantic HTML elements in Svelte components
 - Design tokens in `design/tokens.json`
+- Ensure Penpot MCP server is running before using design tools

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,8 @@ cubelite/
 │   ├── copilot-instructions.md
 │   ├── instructions/        ← Path-scoped Copilot instructions
 │   └── workflows/           ← GitHub Actions CI/CD
+├── .vscode/
+│   └── mcp.json             ← MCP server config (Penpot)
 ├── AGENTS.md                ← Root agent routing table
 └── Makefile                 ← Dev task shortcuts
 ```
@@ -123,7 +125,7 @@ cubelite/
 | `core-agent` | `crates/**` | Rust logic, k8s API, domain models, error types |
 | `desktop-agent` | `apps/desktop/**` | Svelte components, Tauri commands, frontend tests |
 | `macos-agent` | `apps/macos/**` | Swift/SwiftUI, menu-bar, macOS APIs |
-| `design-agent` | `apps/desktop/**` UI only | Design tokens, shadcn-svelte, Tailwind, accessibility |
+| `design-agent` | `apps/desktop/**` UI only | Design tokens, shadcn-svelte, Tailwind, accessibility, Penpot MCP |
 | `devops-agent` | `.github/**` | GitHub Actions, CI/CD workflows, secret handling |
 | `ai-agent` | Any | Cross-cutting AI assistance, architecture decisions |
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,12 @@
+{
+  "servers": {
+    "penpot": {
+      "type": "sse",
+      "url": "http://localhost:4401/sse",
+      "environmentVariables": {
+        "PENPOT_MCP_SERVER_PORT": "4401",
+        "PENPOT_MCP_WEBSOCKET_PORT": "4402"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ use the inter-agent protocol described below.
 | `core-agent` | `crates/**` | Claude Sonnet 4.6 | `cargo test`, `cargo clippy --deny warnings`, `cargo build` |
 | `desktop-agent` | `apps/desktop/**` | Claude Sonnet 4.6 | `pnpm --filter desktop test`, Vitest, Playwright |
 | `macos-agent` | `apps/macos/**` | Claude Sonnet 4.6 | `xcodebuild build`, `xcodebuild test`, Xcode |
-| `design-agent` | `apps/desktop/**` (UI only) | Claude Sonnet 4.6 | Figma MCP, shadcn-svelte, Tailwind tokens |
+| `design-agent` | `apps/desktop/**` (UI only) | Claude Sonnet 4.6 | Penpot MCP, shadcn-svelte, Tailwind tokens |
 | `devops-agent` | `.github/**` | Claude Sonnet 4.6 | GitHub Actions, secret scanning, YAML lint |
 | `qa-agent` | Any / quality | Claude Sonnet 4.6 | Test coverage, CI validation, security review |
 | `docs-agent` | `docs/`, README, CHANGELOG | Claude Sonnet 4.6 | `cargo doc`, documentation generation, Mermaid diagrams |

--- a/docs/penpot-mcp-setup.md
+++ b/docs/penpot-mcp-setup.md
@@ -1,0 +1,161 @@
+# Penpot MCP Setup Guide
+
+This guide explains how to set up and use the **Penpot MCP Server** for
+design-to-code and code-to-design workflows in the CubeLite workspace.
+
+CubeLite uses [Penpot](https://penpot.app/) (open-source design platform) with
+the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) to enable
+AI-powered design interactions directly from VS Code.
+
+---
+
+## Architecture
+
+```
+┌─────────────────┐     MCP (SSE)     ┌──────────────────┐
+│  VS Code / LLM  │◄─────────────────►│  Penpot MCP      │
+│  (MCP Client)   │   localhost:4401   │  Server           │
+└─────────────────┘                    └────────┬─────────┘
+                                                │ WebSocket
+                                                │ localhost:4402
+                                       ┌────────▼─────────┐
+                                       │  Penpot MCP      │
+                                       │  Plugin (browser) │
+                                       └────────┬─────────┘
+                                                │ Plugin API
+                                       ┌────────▼─────────┐
+                                       │     Penpot        │
+                                       │  (design.penpot.app)│
+                                       └──────────────────┘
+```
+
+The MCP server acts as a bridge between the LLM (via VS Code) and Penpot.
+The Penpot MCP Plugin runs inside the browser and connects to the MCP server
+via WebSocket, enabling the LLM to query, transform, and create design elements.
+
+---
+
+## Prerequisites
+
+- **Node.js v22+** — required to run the MCP server
+- **Browser** — to access Penpot and load the MCP plugin
+- **Penpot account** — free at [design.penpot.app](https://design.penpot.app/)
+
+---
+
+## Quick Start
+
+### 1. Start the MCP Server
+
+The easiest way is using `npx` (no local install needed):
+
+```bash
+npx -y @penpot/mcp@">=0"
+```
+
+This starts both:
+- **MCP Server** on `http://localhost:4401` (HTTP/SSE endpoints)
+- **Plugin Server** on `http://localhost:4400` (serves the Penpot plugin)
+
+### 2. Load the Plugin in Penpot
+
+1. Open [design.penpot.app](https://design.penpot.app/) in your browser
+2. Navigate to a design file
+3. Open the **Plugins** menu
+4. Load the plugin URL: `http://localhost:4400/manifest.json`
+5. Open the plugin UI
+6. Click **"Connect to MCP server"** — status should change to "Connected"
+
+> **Important**: Do not close the plugin UI while using the MCP server.
+
+> **Note (Chromium 142+)**: You may need to approve a local network access
+> popup. In Brave, disable the Shield for the Penpot website.
+
+### 3. VS Code Connection
+
+The workspace is pre-configured in `.vscode/mcp.json` to connect automatically
+via SSE on `localhost:4401`. Once the MCP server is running, VS Code will
+discover all available Penpot MCP tools.
+
+No additional setup is needed — just ensure the server is running before
+starting a design workflow.
+
+---
+
+## Endpoints
+
+| Endpoint | URL | Transport |
+|---|---|---|
+| Streamable HTTP | `http://localhost:4401/mcp` | Modern clients |
+| SSE (legacy) | `http://localhost:4401/sse` | VS Code default |
+| WebSocket | `ws://localhost:4402` | Plugin connection |
+| Plugin manifest | `http://localhost:4400/manifest.json` | Browser plugin |
+
+---
+
+## Configuration
+
+The MCP server can be configured via environment variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `PENPOT_MCP_SERVER_PORT` | HTTP/SSE server port | `4401` |
+| `PENPOT_MCP_WEBSOCKET_PORT` | WebSocket port (plugin) | `4402` |
+| `PENPOT_MCP_REPL_PORT` | REPL port (dev/debug) | `4403` |
+| `PENPOT_MCP_SERVER_HOST` | Server bind address | `localhost` |
+| `PENPOT_MCP_LOG_LEVEL` | Log level (trace/debug/info/warn/error) | `info` |
+| `PENPOT_MCP_LOG_DIR` | Log file directory | `logs` |
+
+---
+
+## VS Code MCP Configuration
+
+The workspace config is at `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "penpot": {
+      "type": "sse",
+      "url": "http://localhost:4401/sse",
+      "environmentVariables": {
+        "PENPOT_MCP_SERVER_PORT": "4401",
+        "PENPOT_MCP_WEBSOCKET_PORT": "4402"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Capabilities
+
+The Penpot MCP server provides tools for:
+
+- **Querying designs** — read component data, properties, styles
+- **Transforming elements** — modify positions, sizes, colors, text
+- **Creating elements** — add shapes, frames, text, components
+- **Code execution** — run arbitrary Plugin API code in the Penpot context
+
+Tools are dynamically discovered via MCP protocol when the server is running.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|---|---|
+| Plugin won't connect | Check that MCP server is running on port 4401 |
+| Browser blocks connection | Approve local network access popup (Chromium 142+) |
+| Tools not showing in VS Code | Ensure server is running, then reload VS Code window |
+| WebSocket timeout | Check port 4402 is not blocked by firewall |
+
+---
+
+## References
+
+- [Penpot MCP source](https://github.com/penpot/penpot/tree/develop/mcp)
+- [Penpot Plugin API](https://penpot.dev/plugins/)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Penpot MCP video playlist](https://www.youtube.com/playlist?list=PLgcCPfOv5v57SKMuw1NmS0-lkAXevpn10)


### PR DESCRIPTION
## Summary

Replace Figma with **Penpot** (open-source design platform) as the design tool integration, using the Model Context Protocol (MCP) for AI-powered design-to-code workflows.

## Changes

### `.vscode/mcp.json` (new)
- Configures the Penpot MCP server for automatic workspace connection
- SSE transport on `localhost:4401`
- VS Code discovers Penpot tools at runtime when server is running

### `.github/agents/design.agent.md`
- Remove all 17 Figma MCP tool entries (`com.figma.mcp/*`)
- Update description to reference Penpot
- Add "Design Tool — Penpot MCP" section with setup steps
- Add Penpot-specific responsibilities and rules

### `AGENTS.md`
- Update design-agent Primary Tools: `Figma MCP` → `Penpot MCP`

### `.github/copilot-instructions.md`
- Add `.vscode/mcp.json` to monorepo layout diagram
- Update agent routing table: `design-agent` now references Penpot MCP

### `docs/penpot-mcp-setup.md` (new)
- Full setup guide: architecture diagram, prerequisites, quick start
- Endpoint reference table (HTTP, SSE, WebSocket, Plugin)
- Environment variable configuration table
- Capabilities overview and troubleshooting guide

## Architecture

```
VS Code / LLM ←→ Penpot MCP Server (localhost:4401) ←→ Penpot Plugin (browser) ←→ Penpot
```

## How to Use

1. `npx -y @penpot/mcp@">=0"` — start the server
2. Load plugin in Penpot browser → connect to MCP server
3. VS Code connects automatically via `.vscode/mcp.json`

## Note on Dedicated MCP Agent

Evaluated whether a separate MCP agent is needed — concluded that updating the existing **design-agent (Luca)** with Penpot MCP capabilities is sufficient. The MCP server tools are dynamically discovered at runtime and don't require a dedicated management agent.