### PR TITLE
feat(core,desktop): add K8s watch stream and Tauri event bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,9 +570,11 @@ name = "cubelite-core"
 version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
+ "futures",
  "k8s-openapi",
  "kube",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
@@ -584,6 +586,7 @@ name = "cubelite-desktop"
 version = "0.1.0"
 dependencies = [
  "cubelite-core",
+ "futures",
  "serde",
  "serde_json",
  "tauri",
@@ -1072,6 +1075,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ tauri = { version = "2", features = [] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 cubelite-core = { path = "../../../crates/cubelite-core" }
 
 [build-dependencies]

--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -1,8 +1,26 @@
 use cubelite_core::{
     client::KubeClient,
     resources::{DeploymentInfo, NamespaceInfo, PodInfo},
+    ResourceType, ResourceWatcher, WatchEvent,
 };
+use futures::StreamExt;
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Monotonically increasing counter for generating unique watch IDs.
+static WATCH_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Tauri managed state holding all active watch task handles.
+///
+/// Keyed by the watch ID string returned from [`watch_resources`].
+#[derive(Default)]
+pub struct WatchState {
+    handles: Mutex<HashMap<String, JoinHandle<()>>>,
+}
 
 /// List pods in the given namespace for the specified kubeconfig context.
 #[tauri::command]
@@ -49,4 +67,74 @@ pub async fn list_deployments(
         .list_deployments(&namespace)
         .await
         .map_err(|e| e.to_string())
+}
+
+/// Start watching a Kubernetes resource type and emit Tauri events for each change.
+///
+/// `resource_type` must be one of `"pod"`, `"namespace"`, or `"deployment"`.
+/// Returns a unique watch ID that can be passed to [`unwatch_resources`] to stop
+/// the stream.
+///
+/// Emitted events:
+/// - `"resource-updated"` — resource created or updated
+/// - `"resource-deleted"` — resource deleted
+/// - `"watch-error"`     — watcher encountered an error
+#[tauri::command]
+pub async fn watch_resources(
+    app: AppHandle,
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    resource_type: String,
+    context: Option<String>,
+) -> Result<String, String> {
+    let rt: ResourceType = serde_json::from_value(serde_json::Value::String(resource_type))
+        .map_err(|e| format!("invalid resource_type: {e}"))?;
+
+    let kube_client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let watcher = ResourceWatcher::new(kube_client.client());
+    let mut stream = watcher.watch_resources(namespace.as_deref(), rt);
+
+    let watch_id = WATCH_COUNTER.fetch_add(1, Ordering::SeqCst).to_string();
+
+    let app_clone = app.clone();
+    let handle = tokio::spawn(async move {
+        while let Some(event) = stream.next().await {
+            let event_name = match &event {
+                WatchEvent::Applied(_) => "resource-updated",
+                WatchEvent::Deleted(_) => "resource-deleted",
+                WatchEvent::Error(_) => "watch-error",
+            };
+            // Ignore emit errors — the frontend window may have been closed.
+            let _ = app_clone.emit(event_name, event);
+        }
+    });
+
+    app.state::<WatchState>()
+        .handles
+        .lock()
+        .await
+        .insert(watch_id.clone(), handle);
+
+    Ok(watch_id)
+}
+
+/// Stop a running watch stream by its watch ID.
+///
+/// The spawned task is aborted and the handle is removed from managed state.
+/// Silently succeeds if `watch_id` is not found.
+#[tauri::command]
+pub async fn unwatch_resources(app: AppHandle, watch_id: String) -> Result<(), String> {
+    if let Some(handle) = app
+        .state::<WatchState>()
+        .handles
+        .lock()
+        .await
+        .remove(&watch_id)
+    {
+        handle.abort();
+    }
+    Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,14 +1,19 @@
 pub mod commands;
 
-use commands::kubernetes::{list_deployments, list_namespaces, list_pods};
+use commands::kubernetes::{
+    list_deployments, list_namespaces, list_pods, unwatch_resources, watch_resources, WatchState,
+};
 
 /// Entry point for the Tauri application.
 pub fn run() {
     if let Err(e) = tauri::Builder::default()
+        .manage(WatchState::default())
         .invoke_handler(tauri::generate_handler![
             list_pods,
             list_namespaces,
-            list_deployments
+            list_deployments,
+            watch_resources,
+            unwatch_resources,
         ])
         .run(tauri::generate_context!())
     {

--- a/crates/cubelite-core/Cargo.toml
+++ b/crates/cubelite-core/Cargo.toml
@@ -9,9 +9,11 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 dirs = "5"
 kube = { version = "0.97", features = ["runtime", "derive", "client"] }
 k8s-openapi = { version = "0.23", features = ["v1_30"] }
 
 [dev-dependencies]
 tempfile = "3"
+serde_json = { workspace = true }

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -19,12 +19,21 @@ use crate::{
 /// An async Kubernetes client pre-configured from a kubeconfig file.
 ///
 /// Use [`KubeClient::new`] to construct an instance, then call the async
-/// `list_*` methods to query cluster resources.
+/// `list_*` methods to query cluster resources.  Use [`KubeClient::client`]
+/// to obtain the underlying [`Client`] for use with [`crate::ResourceWatcher`].
 pub struct KubeClient {
     inner: Client,
 }
 
 impl KubeClient {
+    /// Return a clone of the underlying [`kube::Client`].
+    ///
+    /// The returned client shares the same connection pool and configuration.
+    /// Use it to construct a [`crate::ResourceWatcher`].
+    pub fn client(&self) -> Client {
+        self.inner.clone()
+    }
+
     /// Build a [`KubeClient`] from the kubeconfig at `path`.
     ///
     /// `context` selects a named context; when `None` the file's

--- a/crates/cubelite-core/src/error.rs
+++ b/crates/cubelite-core/src/error.rs
@@ -28,6 +28,10 @@ pub enum KubeconfigError {
         #[from]
         source: std::io::Error,
     },
+
+    /// An error was returned from a Kubernetes watch stream.
+    #[error("watch error: {reason}")]
+    WatchError { reason: String },
 }
 
 /// Errors that can occur during context selection or switching operations.

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -12,6 +12,7 @@
 //! | [`resources`]  | Lightweight resource info types |
 //! | [`types`]      | Domain types mirroring the kubeconfig spec |
 //! | [`error`]      | Error types: [`KubeconfigError`], [`ContextError`] |
+//! | [`watcher`]    | Watch streaming for Kubernetes resources |
 //!
 //! ## Quick Start
 //!
@@ -33,6 +34,7 @@ pub mod error;
 pub mod kubeconfig;
 pub mod resources;
 pub mod types;
+pub mod watcher;
 
 // Re-export the most commonly used items at the crate root.
 pub use client::KubeClient;
@@ -43,3 +45,4 @@ pub use types::{
     ClusterDetails, ContextDetails, ContextInfo, KubeConfigFile, NamedCluster, NamedContext,
     NamedUser, UserDetails,
 };
+pub use watcher::{ResourceInfo, ResourceType, ResourceWatcher, WatchEvent};

--- a/crates/cubelite-core/src/watcher.rs
+++ b/crates/cubelite-core/src/watcher.rs
@@ -1,0 +1,366 @@
+//! Watch streaming for Kubernetes resources.
+//!
+//! This module provides [`ResourceWatcher`], which wraps a [`kube::Client`] and
+//! emits a stream of [`WatchEvent`] items as resources change in the cluster.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use cubelite_core::{ResourceWatcher, ResourceType};
+//! use futures::StreamExt;
+//!
+//! # async fn example(client: kube::Client) {
+//! let watcher = ResourceWatcher::new(client);
+//! let mut stream = watcher.watch_resources(Some("default"), ResourceType::Pod);
+//! while let Some(event) = stream.next().await {
+//!     println!("{event:?}");
+//! }
+//! # }
+//! ```
+
+use std::pin::Pin;
+
+use futures::{Stream, StreamExt};
+use k8s_openapi::api::{
+    apps::v1::Deployment,
+    core::v1::{Namespace, Pod},
+};
+use kube::{runtime::watcher, Api, Client};
+use serde::{Deserialize, Serialize};
+
+use crate::resources::{DeploymentInfo, NamespaceInfo, PodInfo};
+
+/// Selects which Kubernetes resource type to watch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResourceType {
+    /// Watch pods.
+    Pod,
+    /// Watch namespaces.
+    Namespace,
+    /// Watch deployments.
+    Deployment,
+}
+
+/// A Kubernetes resource payload, discriminated by type.
+///
+/// Wraps the lightweight `*Info` structs from [`crate::resources`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum ResourceInfo {
+    /// A pod resource.
+    Pod(PodInfo),
+    /// A namespace resource.
+    Namespace(NamespaceInfo),
+    /// A deployment resource.
+    Deployment(DeploymentInfo),
+}
+
+/// A single watch event emitted from a [`ResourceWatcher`] stream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", content = "payload")]
+pub enum WatchEvent {
+    /// A resource was created or updated (including the initial listing phase).
+    Applied(ResourceInfo),
+    /// A resource was deleted.
+    Deleted(ResourceInfo),
+    /// A watch error occurred. The inner string contains the error description.
+    Error(String),
+}
+
+/// Wraps a [`kube::Client`] and exposes watch streams for Kubernetes resources.
+///
+/// Construct via [`ResourceWatcher::new`], then call [`watch_resources`] to
+/// obtain a streaming iterator of [`WatchEvent`] items.
+///
+/// [`watch_resources`]: ResourceWatcher::watch_resources
+pub struct ResourceWatcher {
+    client: Client,
+}
+
+impl ResourceWatcher {
+    /// Create a new [`ResourceWatcher`] backed by `client`.
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Return a stream of [`WatchEvent`] items for the given resource type.
+    ///
+    /// `namespace` scopes the watch to a single namespace.  Pass `None` to
+    /// watch across all namespaces (cluster-scoped watch).  Note that
+    /// [`ResourceType::Namespace`] is always cluster-scoped regardless.
+    ///
+    /// The stream yields [`WatchEvent::Applied`] for creates/updates (including
+    /// the initial list phase), [`WatchEvent::Deleted`] for deletions, and
+    /// [`WatchEvent::Error`] when the underlying `kube` watcher encounters an
+    /// error.  Internal lifecycle events (`Init`, `InitDone`) are suppressed.
+    pub fn watch_resources(
+        &self,
+        namespace: Option<&str>,
+        resource_type: ResourceType,
+    ) -> Pin<Box<dyn Stream<Item = WatchEvent> + Send>> {
+        let client = self.client.clone();
+        let config = watcher::Config::default();
+        // Own the namespace string so the returned stream is 'static.
+        let ns = namespace.map(str::to_owned);
+
+        match resource_type {
+            ResourceType::Pod => {
+                let api: Api<Pod> = match ns.as_deref() {
+                    Some(n) => Api::namespaced(client, n),
+                    None => Api::all(client),
+                };
+                Box::pin(
+                    watcher::watcher(api, config).filter_map(|ev| async move {
+                        map_event(ev, pod_to_info, ResourceInfo::Pod)
+                    }),
+                )
+            }
+            ResourceType::Namespace => {
+                // Namespaces are cluster-scoped; the namespace argument is ignored.
+                let api: Api<Namespace> = Api::all(client);
+                Box::pin(watcher::watcher(api, config).filter_map(|ev| async move {
+                    map_event(ev, namespace_to_info, ResourceInfo::Namespace)
+                }))
+            }
+            ResourceType::Deployment => {
+                let api: Api<Deployment> = match ns.as_deref() {
+                    Some(n) => Api::namespaced(client, n),
+                    None => Api::all(client),
+                };
+                Box::pin(watcher::watcher(api, config).filter_map(|ev| async move {
+                    map_event(ev, deployment_to_info, ResourceInfo::Deployment)
+                }))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Map a raw watcher event to a [`WatchEvent`], returning `None` for internal
+/// lifecycle bookkeeping events (`Init`, `InitDone`).
+fn map_event<K, T, F, W>(
+    event: Result<watcher::Event<K>, watcher::Error>,
+    convert: F,
+    wrap: W,
+) -> Option<WatchEvent>
+where
+    F: Fn(K) -> Option<T>,
+    W: Fn(T) -> ResourceInfo,
+{
+    match event {
+        Ok(watcher::Event::Apply(resource)) | Ok(watcher::Event::InitApply(resource)) => {
+            convert(resource).map(|info| WatchEvent::Applied(wrap(info)))
+        }
+        Ok(watcher::Event::Delete(resource)) => {
+            convert(resource).map(|info| WatchEvent::Deleted(wrap(info)))
+        }
+        Ok(watcher::Event::Init) | Ok(watcher::Event::InitDone) => None,
+        Err(e) => Some(WatchEvent::Error(e.to_string())),
+    }
+}
+
+/// Convert a raw [`Pod`] object into a [`PodInfo`], returning `None` if the
+/// pod has no name (which is invalid in a well-formed cluster response).
+fn pod_to_info(pod: Pod) -> Option<PodInfo> {
+    let name = pod.metadata.name?;
+    let namespace = pod.metadata.namespace.unwrap_or_default();
+    let phase = pod.status.as_ref().and_then(|s| s.phase.clone());
+    let container_statuses = pod
+        .status
+        .as_ref()
+        .and_then(|s| s.container_statuses.as_deref())
+        .unwrap_or(&[]);
+    let ready = container_statuses.iter().all(|cs| cs.ready);
+    let restarts = container_statuses.iter().map(|cs| cs.restart_count).sum();
+    Some(PodInfo {
+        name,
+        namespace,
+        phase,
+        ready,
+        restarts,
+    })
+}
+
+/// Convert a raw [`Namespace`] object into a [`NamespaceInfo`], returning
+/// `None` if there is no name.
+fn namespace_to_info(ns: Namespace) -> Option<NamespaceInfo> {
+    let name = ns.metadata.name?;
+    let phase = ns.status.as_ref().and_then(|s| s.phase.clone());
+    Some(NamespaceInfo { name, phase })
+}
+
+/// Convert a raw [`Deployment`] object into a [`DeploymentInfo`], returning
+/// `None` if there is no name.
+fn deployment_to_info(d: Deployment) -> Option<DeploymentInfo> {
+    let name = d.metadata.name?;
+    let namespace = d.metadata.namespace.unwrap_or_default();
+    let replicas = d.spec.as_ref().and_then(|s| s.replicas).unwrap_or(0);
+    let ready_replicas = d
+        .status
+        .as_ref()
+        .and_then(|s| s.ready_replicas)
+        .unwrap_or(0);
+    Some(DeploymentInfo {
+        name,
+        namespace,
+        replicas,
+        ready_replicas,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // ResourceType serialization
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn resource_type_roundtrip() {
+        let cases = [
+            (ResourceType::Pod, "\"pod\""),
+            (ResourceType::Namespace, "\"namespace\""),
+            (ResourceType::Deployment, "\"deployment\""),
+        ];
+        for (rt, expected_json) in cases {
+            let json = serde_json::to_string(&rt).unwrap();
+            assert_eq!(json, expected_json, "serialized form for {rt:?}");
+            let back: ResourceType = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, rt, "deserialized form for {rt:?}");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // WatchEvent serialization
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn watch_event_applied_pod_serialization() {
+        let event = WatchEvent::Applied(ResourceInfo::Pod(PodInfo {
+            name: "test-pod".to_string(),
+            namespace: "default".to_string(),
+            phase: Some("Running".to_string()),
+            ready: true,
+            restarts: 0,
+        }));
+
+        let json = serde_json::to_string(&event).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(v["event"], "Applied");
+        assert_eq!(v["payload"]["type"], "Pod");
+        assert_eq!(v["payload"]["data"]["name"], "test-pod");
+        assert_eq!(v["payload"]["data"]["namespace"], "default");
+        assert_eq!(v["payload"]["data"]["ready"], true);
+    }
+
+    #[test]
+    fn watch_event_error_serialization() {
+        let event = WatchEvent::Error("connection refused".to_string());
+        let json = serde_json::to_string(&event).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["event"], "Error");
+        assert_eq!(v["payload"], "connection refused");
+    }
+
+    // ------------------------------------------------------------------
+    // Conversion functions
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn pod_to_info_full() {
+        use k8s_openapi::api::core::v1::{ContainerStatus, Pod, PodStatus};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let pod = Pod {
+            metadata: ObjectMeta {
+                name: Some("my-pod".to_string()),
+                namespace: Some("kube-system".to_string()),
+                ..Default::default()
+            },
+            status: Some(PodStatus {
+                phase: Some("Running".to_string()),
+                container_statuses: Some(vec![ContainerStatus {
+                    name: "main".to_string(),
+                    ready: true,
+                    restart_count: 3,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let info = pod_to_info(pod).unwrap();
+        assert_eq!(info.name, "my-pod");
+        assert_eq!(info.namespace, "kube-system");
+        assert_eq!(info.phase.as_deref(), Some("Running"));
+        assert!(info.ready);
+        assert_eq!(info.restarts, 3);
+    }
+
+    #[test]
+    fn pod_to_info_no_name_returns_none() {
+        let pod = k8s_openapi::api::core::v1::Pod::default();
+        assert!(pod_to_info(pod).is_none());
+    }
+
+    #[test]
+    fn namespace_to_info_conversion() {
+        use k8s_openapi::api::core::v1::{Namespace, NamespaceStatus};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let ns = Namespace {
+            metadata: ObjectMeta {
+                name: Some("production".to_string()),
+                ..Default::default()
+            },
+            status: Some(NamespaceStatus {
+                phase: Some("Active".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let info = namespace_to_info(ns).unwrap();
+        assert_eq!(info.name, "production");
+        assert_eq!(info.phase.as_deref(), Some("Active"));
+    }
+
+    #[test]
+    fn deployment_to_info_conversion() {
+        use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStatus};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let d = Deployment {
+            metadata: ObjectMeta {
+                name: Some("my-app".to_string()),
+                namespace: Some("staging".to_string()),
+                ..Default::default()
+            },
+            spec: Some(DeploymentSpec {
+                replicas: Some(3),
+                ..Default::default()
+            }),
+            status: Some(DeploymentStatus {
+                ready_replicas: Some(2),
+                ..Default::default()
+            }),
+        };
+
+        let info = deployment_to_info(d).unwrap();
+        assert_eq!(info.name, "my-app");
+        assert_eq!(info.namespace, "staging");
+        assert_eq!(info.replicas, 3);
+        assert_eq!(info.ready_replicas, 2);
+    }
+}


### PR DESCRIPTION
## Summary\n\nImplement real-time Kubernetes resource watching via `kube::runtime::watcher` with Tauri event emission.\n\n## Core (`cubelite-core`)\n- New `watcher` module: `ResourceWatcher`, `WatchEvent`, `ResourceType`, `ResourceInfo`\n- `watch_resources()` returns `Pin<Box<dyn Stream<Item=WatchEvent> + Send>>`\n- Handles `Apply`, `InitApply`, `Delete` events; suppresses `Init`/`InitDone` lifecycle\n- Conversion helpers: `pod_to_info`, `namespace_to_info`, `deployment_to_info`\n- `WatchError` variant added to `KubeconfigError`\n- `KubeClient::client()` getter for inner `kube::Client`\n- 7 unit tests + doc-test for serialization and conversions\n\n## Desktop (`cubelite-desktop`)\n- `watch_resources` command: spawns background tokio task consuming watch stream\n- `unwatch_resources` command: aborts task by watch ID\n- `WatchState` managed state with `Mutex<HashMap<String, JoinHandle>>`\n- Emits `resource-updated`, `resource-deleted`, `watch-error` Tauri events\n\n## Quality\n- `cargo check --workspace` ✅\n- `cargo clippy --workspace -- -D warnings` ✅\n- `cargo test --workspace` ✅ (15 unit + 3 doc-tests)\n- `cargo fmt --check` ✅\n\nCloses #4