### PR TITLE
refactor(macos,core): M3 QA fixes + test race condition fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3432,6 +3433,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,6 +3506,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secrecy"
@@ -3736,6 +3752,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/macos/cubelite/cubelite/Helpers/K8sFormatters.swift
+++ b/apps/macos/cubelite/cubelite/Helpers/K8sFormatters.swift
@@ -2,6 +2,18 @@ import SwiftUI
 
 // MARK: - Age Formatting
 
+private enum K8sDateFormatters {
+    nonisolated(unsafe) static let fractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    nonisolated(unsafe) static let standard: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        return f
+    }()
+}
+
 extension Optional where Wrapped == String {
     /// Converts an optional ISO 8601 timestamp to a human-readable Kubernetes age string.
     ///
@@ -9,9 +21,7 @@ extension Optional where Wrapped == String {
     /// the value is `nil` or cannot be parsed as a valid ISO 8601 date.
     var k8sAge: String {
         guard let iso = self else { return "—" }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
+        let date = K8sDateFormatters.fractional.date(from: iso) ?? K8sDateFormatters.standard.date(from: iso)
         guard let createdAt = date else { return "—" }
         let elapsed = Int(Date().timeIntervalSince(createdAt))
         if elapsed < 60 { return "\(elapsed)s" }

--- a/apps/macos/cubelite/cubelite/Views/DeploymentListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/DeploymentListView.swift
@@ -93,12 +93,6 @@ struct DeploymentListView: View {
             }
             .width(ideal: 80)
 
-            TableColumn("Available") { dep in
-                Text("\(dep.readyReplicas)")
-                    .font(.callout.monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
-            .width(ideal: 72)
         }
     }
 

--- a/crates/cubelite-core/Cargo.toml
+++ b/crates/cubelite-core/Cargo.toml
@@ -17,3 +17,4 @@ k8s-openapi = { version = "0.23", features = ["v1_30"] }
 [dev-dependencies]
 tempfile = "3"
 serde_json = { workspace = true }
+serial_test = "3"

--- a/crates/cubelite-core/src/context.rs
+++ b/crates/cubelite-core/src/context.rs
@@ -88,13 +88,10 @@ pub fn context_exists(name: &str) -> Result<bool, ContextError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::env;
     use std::io::Write;
-    use std::sync::Mutex;
     use tempfile::NamedTempFile;
-
-    /// Prevent parallel tests from racing on the `KUBECONFIG` env var.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn write_temp(content: &str) -> NamedTempFile {
         let mut f = NamedTempFile::new().expect("tempfile");
@@ -103,16 +100,15 @@ mod tests {
     }
 
     fn with_kubeconfig<F: FnOnce()>(yaml: &str, f: F) {
-        let _guard = ENV_LOCK.lock().expect("env lock");
         let tmp = write_temp(yaml);
         env::set_var("KUBECONFIG", tmp.path().to_string_lossy().as_ref());
         f();
         env::remove_var("KUBECONFIG");
-        // Keep `tmp` alive until here so the file is not deleted before use.
         drop(tmp);
     }
 
     #[test]
+    #[serial]
     fn list_contexts_returns_all_names() {
         let yaml = r#"
 apiVersion: v1
@@ -132,6 +128,7 @@ contexts:
     }
 
     #[test]
+    #[serial]
     fn current_context_returns_active() {
         let yaml = r#"
 apiVersion: v1
@@ -148,6 +145,7 @@ contexts:
     }
 
     #[test]
+    #[serial]
     fn current_context_none_when_unset() {
         let yaml = r#"
 apiVersion: v1
@@ -163,6 +161,7 @@ contexts:
     }
 
     #[test]
+    #[serial]
     fn context_exists_true_for_known_name() {
         let yaml = r#"
 apiVersion: v1
@@ -177,6 +176,7 @@ contexts:
     }
 
     #[test]
+    #[serial]
     fn context_exists_false_for_unknown_name() {
         let yaml = r#"
 apiVersion: v1
@@ -191,6 +191,7 @@ contexts:
     }
 
     #[test]
+    #[serial]
     fn set_active_context_unknown_name_returns_not_found() {
         let yaml = r#"
 apiVersion: v1
@@ -212,6 +213,7 @@ contexts:
     }
 
     #[test]
+    #[serial]
     fn set_active_context_and_persists() {
         let yaml = r#"
 apiVersion: v1
@@ -235,6 +237,7 @@ contexts:
     }
 
     #[test]
+    #[serial]
     fn list_context_infos_includes_active_flag() {
         let yaml = r#"
 apiVersion: v1

--- a/crates/cubelite-core/src/kubeconfig.rs
+++ b/crates/cubelite-core/src/kubeconfig.rs
@@ -541,6 +541,7 @@ contexts:
     // -- KUBECONFIG env var --------------------------------------------------
 
     #[test]
+    #[serial_test::serial]
     fn kubeconfig_env_var_single_path() {
         let yaml = r#"
 apiVersion: v1
@@ -561,6 +562,7 @@ contexts:
     }
 
     #[test]
+    #[serial_test::serial]
     fn kubeconfig_env_var_multiple_paths() {
         let yaml_a = r#"
 apiVersion: v1


### PR DESCRIPTION
## Summary\n\nThree QA-deferred fixes from PR #33 review, plus a test race condition fix discovered during CI.\n\n### Fix 1 — ISO8601DateFormatter static let (#48)\n`K8sFormatters.swift`: replaced inline formatter creation with `K8sDateFormatters` enum holding two `nonisolated(unsafe) static let` formatters. Eliminates per-call allocation in table views.\n\n### Fix 2 — Remove misleading Available column (#47)\n`DeploymentListView.swift`: removed the `Available` column which showed `readyReplicas` (not K8s `availableReplicas`). The `Ready` column already shows this info as `ready/desired`.\n\n### Fix 3 — Move K8sFormatters to Helpers/ (#49)\n`Views/K8sFormatters.swift` → `Helpers/K8sFormatters.swift`. The file contains utility extensions, not view components. Xcode auto-syncs via `PBXFileSystemSynchronizedRootGroup`.\n\n### Fix 4 — Test race condition (flaky CI)\nAdded `serial_test` crate and `#[serial]` attribute to all tests that manipulate the `KUBECONFIG` env var in both `context.rs` and `kubeconfig.rs`. These tests were racing in parallel, causing flaky failures in CI.\n\n## Quality\n- `xcodebuild build` ✅\n- `cargo test --workspace` ✅\n- `cargo clippy --workspace -- -D warnings` ✅\n- `cargo fmt --check` ✅\n\nCloses #47, Closes #48, Closes #49