### PR TITLE
feat(desktop): M4 — functional Svelte UI with context sidebar, resource tables, and watch integration

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -138,3 +138,33 @@ pub async fn unwatch_resources(app: AppHandle, watch_id: String) -> Result<(), S
     }
     Ok(())
 }
+
+/// List all contexts from the kubeconfig.
+#[tauri::command]
+pub async fn list_contexts() -> Result<Vec<cubelite_core::ContextInfo>, String> {
+    tokio::task::spawn_blocking(|| {
+        cubelite_core::context::list_context_infos().map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Get the name of the currently active context.
+#[tauri::command]
+pub async fn get_current_context() -> Result<Option<String>, String> {
+    tokio::task::spawn_blocking(|| {
+        cubelite_core::context::current_context().map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Switch to a different kubeconfig context (persists to disk).
+#[tauri::command]
+pub async fn set_context(context_name: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        cubelite_core::context::set_active_context(&context_name).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod commands;
 
 use commands::kubernetes::{
-    list_deployments, list_namespaces, list_pods, unwatch_resources, watch_resources, WatchState,
+    get_current_context, list_contexts, list_deployments, list_namespaces, list_pods, set_context,
+    unwatch_resources, watch_resources, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -14,6 +15,9 @@ pub fn run() {
             list_deployments,
             watch_resources,
             unwatch_resources,
+            list_contexts,
+            get_current_context,
+            set_context,
         ])
         .run(tauri::generate_context!())
     {

--- a/apps/desktop/src/lib/components/DeploymentTable.svelte
+++ b/apps/desktop/src/lib/components/DeploymentTable.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import type { DeploymentInfo } from '$lib/tauri';
+
+	type Props = {
+		deployments: DeploymentInfo[];
+	};
+
+	let { deployments }: Props = $props();
+</script>
+
+<div class="overflow-x-auto">
+	<table class="w-full text-xs">
+		<thead>
+			<tr class="border-b text-left" style="border-color: hsl(var(--border));">
+				<th class="pb-2 pr-4 font-semibold" style="color: hsl(var(--muted-foreground));">Name</th>
+				<th class="pb-2 pr-4 font-semibold" style="color: hsl(var(--muted-foreground));">Namespace</th>
+				<th class="pb-2 pr-4 font-semibold" style="color: hsl(var(--muted-foreground));">Ready</th>
+				<th class="pb-2 font-semibold" style="color: hsl(var(--muted-foreground));">Replicas</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#if deployments.length === 0}
+				<tr>
+					<td colspan="4" class="py-6 text-center text-xs" style="color: hsl(var(--muted-foreground));">
+						No deployments found.
+					</td>
+				</tr>
+			{:else}
+				{#each deployments as dep (dep.namespace + '/' + dep.name)}
+					<tr class="border-b transition-colors hover:bg-[hsl(var(--accent))]" style="border-color: hsl(var(--border));">
+						<td class="py-2 pr-4 font-medium" style="color: hsl(var(--foreground));">{dep.name}</td>
+						<td class="py-2 pr-4" style="color: hsl(var(--muted-foreground));">{dep.namespace}</td>
+						<td class="py-2 pr-4">
+							<span
+								class="font-medium"
+								style={dep.ready_replicas >= dep.replicas && dep.replicas > 0
+									? 'color: hsl(142 71% 45%);'
+									: 'color: hsl(38 92% 50%);'}
+							>
+								{dep.ready_replicas}/{dep.replicas}
+							</span>
+						</td>
+						<td class="py-2" style="color: hsl(var(--foreground));">{dep.replicas}</td>
+					</tr>
+				{/each}
+			{/if}
+		</tbody>
+	</table>
+</div>

--- a/apps/desktop/src/lib/components/KubeContextSidebar.svelte
+++ b/apps/desktop/src/lib/components/KubeContextSidebar.svelte
@@ -1,7 +1,104 @@
 <script lang="ts">
-	// Placeholder — context list will be implemented in a follow-up issue
+	import { listContexts, setContext } from '$lib/tauri';
+	import type { ContextInfo } from '$lib/tauri';
+
+	type Props = {
+		onContextSelect?: (context: ContextInfo) => void;
+	};
+
+	let { onContextSelect }: Props = $props();
+
+	let contexts: ContextInfo[] = $state([]);
+	let loading = $state(true);
+	let error: string | null = $state(null);
+
+	async function loadContexts() {
+		loading = true;
+		error = null;
+		try {
+			contexts = await listContexts();
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function handleSelect(ctx: ContextInfo) {
+		if (ctx.is_active) return;
+		try {
+			await setContext(ctx.name);
+			await loadContexts();
+			onContextSelect?.(ctx);
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	$effect(() => {
+		loadContexts();
+	});
 </script>
 
-<aside class="w-64 border-r border-[var(--border)] bg-[var(--card)]">
-	<p class="p-4 text-sm" style="color: var(--foreground);">Contexts</p>
+<aside class="flex w-64 flex-shrink-0 flex-col overflow-hidden border-r" style="border-color: hsl(var(--border)); background-color: hsl(var(--card));">
+	<header class="flex items-center justify-between border-b px-4 py-3" style="border-color: hsl(var(--border));">
+		<span class="text-xs font-semibold uppercase tracking-wider" style="color: hsl(var(--muted-foreground));">Contexts</span>
+		<button
+			onclick={loadContexts}
+			class="rounded p-1 transition-colors hover:bg-[hsl(var(--accent))]"
+			title="Refresh contexts"
+		>
+			<svg class="h-3.5 w-3.5" style="color: hsl(var(--muted-foreground));" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+			</svg>
+		</button>
+	</header>
+
+	<div class="flex-1 overflow-y-auto">
+		{#if loading}
+			<div class="flex items-center justify-center p-6">
+				<span class="text-xs" style="color: hsl(var(--muted-foreground));">Loading…</span>
+			</div>
+		{:else if error}
+			<div class="p-4">
+				<p class="text-xs" style="color: hsl(var(--destructive));">{error}</p>
+			</div>
+		{:else if contexts.length === 0}
+			<div class="p-4">
+				<p class="text-xs" style="color: hsl(var(--muted-foreground));">No contexts found.</p>
+			</div>
+		{:else}
+			<ul class="py-1">
+				{#each contexts as ctx (ctx.name)}
+					<li>
+						<button
+							class="w-full cursor-pointer px-3 py-2 text-left transition-colors hover:bg-[hsl(var(--accent))] {ctx.is_active ? 'border-l-2' : 'border-l-2 border-transparent'}"
+							style={ctx.is_active ? 'border-left-color: hsl(var(--primary));' : ''}
+							onclick={() => handleSelect(ctx)}
+						>
+							<div class="flex items-center gap-2">
+								{#if ctx.is_active}
+									<span class="h-1.5 w-1.5 flex-shrink-0 rounded-full" style="background-color: hsl(var(--primary));"></span>
+								{:else}
+									<span class="h-1.5 w-1.5 flex-shrink-0 rounded-full" style="background-color: hsl(var(--muted-foreground));"></span>
+								{/if}
+								<span
+									class="truncate text-xs font-medium"
+									style={ctx.is_active ? 'color: hsl(var(--foreground));' : 'color: hsl(var(--muted-foreground));'}
+								>
+									{ctx.name}
+								</span>
+							</div>
+							{#if ctx.cluster_server}
+								<p class="mt-0.5 truncate pl-3.5 text-xs" style="color: hsl(var(--muted-foreground));">
+									{ctx.cluster_server.replace(/^https?:\/\//, '')}
+								</p>
+							{/if}
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
 </aside>
+

--- a/apps/desktop/src/lib/components/MainView.svelte
+++ b/apps/desktop/src/lib/components/MainView.svelte
@@ -1,7 +1,149 @@
 <script lang="ts">
-	// Placeholder — main content will be implemented in a follow-up issue
+	import { listen } from '@tauri-apps/api/event';
+	import { listPods, listDeployments } from '$lib/tauri';
+	import type { PodInfo, DeploymentInfo } from '$lib/tauri';
+	import NamespaceSelector from './NamespaceSelector.svelte';
+	import PodTable from './PodTable.svelte';
+	import DeploymentTable from './DeploymentTable.svelte';
+
+	type Props = {
+		kubeconfigPath: string;
+		context: string;
+	};
+
+	let { kubeconfigPath, context }: Props = $props();
+
+	let namespace: string | null = $state(null);
+	let pods: PodInfo[] = $state([]);
+	let deployments: DeploymentInfo[] = $state([]);
+	let loadingPods = $state(false);
+	let loadingDeployments = $state(false);
+	let podError: string | null = $state(null);
+	let deploymentError: string | null = $state(null);
+
+	async function loadResources(kc: string, ctx: string, ns: string | null) {
+		loadingPods = true;
+		loadingDeployments = true;
+		podError = null;
+		deploymentError = null;
+
+		const podPromise = listPods(kc, ns ?? undefined, ctx)
+			.then((p) => {
+				pods = p;
+			})
+			.catch((e: unknown) => {
+				podError = e instanceof Error ? e.message : String(e);
+			})
+			.finally(() => {
+				loadingPods = false;
+			});
+
+		const depPromise = ns
+			? listDeployments(kc, ns, ctx)
+					.then((d) => {
+						deployments = d;
+					})
+					.catch((e: unknown) => {
+						deploymentError = e instanceof Error ? e.message : String(e);
+					})
+					.finally(() => {
+						loadingDeployments = false;
+					})
+			: Promise.resolve().then(() => {
+					deployments = [];
+					loadingDeployments = false;
+				});
+
+		await Promise.all([podPromise, depPromise]);
+	}
+
+	function handleNamespaceSelect(ns: string | null) {
+		namespace = ns;
+	}
+
+	// Watch integration: listen for resource-updated / resource-deleted events
+	$effect(() => {
+		if (!kubeconfigPath || !context) return;
+
+		pods = [];
+		deployments = [];
+		namespace = null;
+
+		const unlistenUpdated = listen<unknown>('resource-updated', () => {
+			loadResources(kubeconfigPath, context, namespace);
+		});
+		const unlistenDeleted = listen<unknown>('resource-deleted', () => {
+			loadResources(kubeconfigPath, context, namespace);
+		});
+
+		return () => {
+			unlistenUpdated.then((fn) => fn());
+			unlistenDeleted.then((fn) => fn());
+		};
+	});
+
+	// Reload when namespace changes
+	$effect(() => {
+		if (kubeconfigPath && context) {
+			loadResources(kubeconfigPath, context, namespace);
+		}
+	});
 </script>
 
-<main class="flex-1 p-6">
-	<p class="text-sm" style="color: var(--foreground);">Select a context to get started.</p>
+<main class="flex flex-1 flex-col overflow-hidden" style="background-color: hsl(var(--background));">
+	{#if !context}
+		<div class="flex flex-1 items-center justify-center">
+			<p class="text-sm" style="color: hsl(var(--muted-foreground));">Select a context to get started.</p>
+		</div>
+	{:else}
+		<!-- Toolbar -->
+		<div class="flex items-center gap-4 border-b px-6 py-3" style="border-color: hsl(var(--border)); background-color: hsl(var(--card));">
+			<span class="text-xs font-semibold" style="color: hsl(var(--foreground));">{context}</span>
+			<div class="ml-auto">
+				<NamespaceSelector
+					{kubeconfigPath}
+					{context}
+					onSelect={handleNamespaceSelect}
+				/>
+			</div>
+		</div>
+
+		<!-- Content -->
+		<div class="flex-1 overflow-y-auto p-6">
+			<!-- Pods section -->
+			<section class="mb-8">
+				<h2 class="mb-3 text-xs font-semibold uppercase tracking-wider" style="color: hsl(var(--muted-foreground));">
+					Pods {#if loadingPods}<span class="normal-case font-normal">— loading…</span>{/if}
+				</h2>
+				{#if podError}
+					<p class="text-xs" style="color: hsl(var(--destructive));">{podError}</p>
+				{:else}
+					<div class="rounded-lg border" style="border-color: hsl(var(--border)); background-color: hsl(var(--card));">
+						<div class="p-4">
+							<PodTable {pods} />
+						</div>
+					</div>
+				{/if}
+			</section>
+
+			<!-- Deployments section -->
+			<section>
+				<h2 class="mb-3 text-xs font-semibold uppercase tracking-wider" style="color: hsl(var(--muted-foreground));">
+					Deployments {#if loadingDeployments}<span class="normal-case font-normal">— loading…</span>{/if}
+				</h2>
+				{#if !namespace}
+					<p class="text-xs" style="color: hsl(var(--muted-foreground));">Select a namespace to list deployments.</p>
+				{:else if deploymentError}
+					<p class="text-xs" style="color: hsl(var(--destructive));">{deploymentError}</p>
+				{:else}
+					<div class="rounded-lg border" style="border-color: hsl(var(--border)); background-color: hsl(var(--card));">
+						<div class="p-4">
+							<DeploymentTable {deployments} />
+						</div>
+					</div>
+				{/if}
+			</section>
+		</div>
+	{/if}
 </main>
+

--- a/apps/desktop/src/lib/components/NamespaceSelector.svelte
+++ b/apps/desktop/src/lib/components/NamespaceSelector.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { listNamespaces } from '$lib/tauri';
+	import type { NamespaceInfo } from '$lib/tauri';
+
+	type Props = {
+		kubeconfigPath: string;
+		context: string;
+		onSelect?: (namespace: string | null) => void;
+	};
+
+	let { kubeconfigPath, context, onSelect }: Props = $props();
+
+	let namespaces: NamespaceInfo[] = $state([]);
+	let selected: string = $state('');
+	let loading = $state(false);
+	let error: string | null = $state(null);
+
+	async function loadNamespaces(kc: string, ctx: string) {
+		loading = true;
+		error = null;
+		namespaces = [];
+		selected = '';
+		try {
+			namespaces = await listNamespaces(kc, ctx);
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleChange(e: Event) {
+		const target = e.currentTarget as HTMLSelectElement;
+		selected = target.value;
+		onSelect?.(selected || null);
+	}
+
+	$effect(() => {
+		if (kubeconfigPath && context) {
+			loadNamespaces(kubeconfigPath, context);
+		}
+	});
+</script>
+
+<div class="flex items-center gap-2">
+	<label
+		for="namespace-select"
+		class="text-xs font-medium"
+		style="color: hsl(var(--muted-foreground));"
+	>
+		Namespace
+	</label>
+	{#if loading}
+		<span class="text-xs" style="color: hsl(var(--muted-foreground));">Loading…</span>
+	{:else if error}
+		<span class="text-xs" style="color: hsl(var(--destructive));">{error}</span>
+	{:else}
+		<select
+			id="namespace-select"
+			value={selected}
+			onchange={handleChange}
+			class="rounded border px-2 py-1 text-xs focus:outline-none focus:ring-1"
+			style="border-color: hsl(var(--border)); background-color: hsl(var(--card)); color: hsl(var(--foreground)); focus-ring-color: hsl(var(--ring));"
+		>
+			<option value="">All namespaces</option>
+			{#each namespaces as ns (ns.name)}
+				<option value={ns.name}>{ns.name}</option>
+			{/each}
+		</select>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/PodTable.svelte
+++ b/apps/desktop/src/lib/components/PodTable.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import type { PodInfo } from '$lib/tauri';
+
+	type Props = {
+		pods: PodInfo[];
+	};
+
+	let { pods }: Props = $props();
+
+	function phaseColor(phase: string | null): string {
+		switch (phase?.toLowerCase()) {
+			case 'running':
+				return 'hsl(142 71% 45%)';
+			case 'pending':
+				return 'hsl(38 92% 50%)';
+			case 'failed':
+			case 'error':
+				return 'hsl(var(--destructive))';
+			case 'succeeded':
+				return 'hsl(var(--muted-foreground))';
+			default:
+				return 'hsl(var(--muted-foreground))';
+		}
+	}
+</script>
+
+<div class="overflow-x-auto">
+	<table class="w-full text-xs">
+		<thead>
+			<tr class="border-b text-left" style="border-color: hsl(var(--border));">
+				<th class="pb-2 pr-4 font-semibold" style="color: hsl(var(--muted-foreground));">Name</th>
+				<th class="pb-2 pr-4 font-semibold" style="color: hsl(var(--muted-foreground));">Namespace</th>
+				<th class="pb-2 pr-4 font-semibold" style="color: hsl(var(--muted-foreground));">Phase</th>
+				<th class="pb-2 pr-4 font-semibold" style="color: hsl(var(--muted-foreground));">Ready</th>
+				<th class="pb-2 font-semibold" style="color: hsl(var(--muted-foreground));">Restarts</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#if pods.length === 0}
+				<tr>
+					<td colspan="5" class="py-6 text-center text-xs" style="color: hsl(var(--muted-foreground));">
+						No pods found.
+					</td>
+				</tr>
+			{:else}
+				{#each pods as pod (pod.namespace + '/' + pod.name)}
+					<tr class="border-b transition-colors hover:bg-[hsl(var(--accent))]" style="border-color: hsl(var(--border));">
+						<td class="py-2 pr-4 font-medium" style="color: hsl(var(--foreground));">{pod.name}</td>
+						<td class="py-2 pr-4" style="color: hsl(var(--muted-foreground));">{pod.namespace}</td>
+						<td class="py-2 pr-4">
+							<span class="font-medium" style="color: {phaseColor(pod.phase)};">
+								{pod.phase ?? '—'}
+							</span>
+						</td>
+						<td class="py-2 pr-4">
+							<span
+								class="font-medium"
+								style={pod.ready ? 'color: hsl(142 71% 45%);' : 'color: hsl(var(--destructive));'}
+							>
+								{pod.ready ? 'Yes' : 'No'}
+							</span>
+						</td>
+						<td class="py-2">
+							<span
+								class="font-medium"
+								style={pod.restarts > 0 ? 'color: hsl(38 92% 50%);' : 'color: hsl(var(--muted-foreground));'}
+							>
+								{pod.restarts}
+							</span>
+						</td>
+					</tr>
+				{/each}
+			{/if}
+		</tbody>
+	</table>
+</div>

--- a/apps/desktop/src/lib/index.ts
+++ b/apps/desktop/src/lib/index.ts
@@ -1,2 +1,5 @@
 export { default as KubeContextSidebar } from './components/KubeContextSidebar.svelte';
 export { default as MainView } from './components/MainView.svelte';
+export { default as NamespaceSelector } from './components/NamespaceSelector.svelte';
+export { default as PodTable } from './components/PodTable.svelte';
+export { default as DeploymentTable } from './components/DeploymentTable.svelte';

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1,0 +1,96 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// --- Types matching Rust structs ---
+
+export type PodInfo = {
+  name: string;
+  namespace: string;
+  phase: string | null;
+  ready: boolean;
+  restarts: number;
+};
+
+export type NamespaceInfo = {
+  name: string;
+  phase: string | null;
+};
+
+export type DeploymentInfo = {
+  name: string;
+  namespace: string;
+  replicas: number;
+  ready_replicas: number;
+};
+
+export type ContextInfo = {
+  name: string;
+  cluster_server: string | null;
+  namespace: string;
+  is_active: boolean;
+};
+
+// --- Invoke wrappers ---
+
+export function listContexts(): Promise<ContextInfo[]> {
+  return invoke<ContextInfo[]>("list_contexts");
+}
+
+export function getCurrentContext(): Promise<string | null> {
+  return invoke<string | null>("get_current_context");
+}
+
+export function setContext(contextName: string): Promise<void> {
+  return invoke("set_context", { contextName });
+}
+
+export function listPods(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<PodInfo[]> {
+  return invoke<PodInfo[]>("list_pods", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listNamespaces(
+  kubeconfigPath: string,
+  context?: string,
+): Promise<NamespaceInfo[]> {
+  return invoke<NamespaceInfo[]>("list_namespaces", {
+    kubeconfigPath,
+    context: context ?? null,
+  });
+}
+
+export function listDeployments(
+  kubeconfigPath: string,
+  namespace: string,
+  context?: string,
+): Promise<DeploymentInfo[]> {
+  return invoke<DeploymentInfo[]>("list_deployments", {
+    kubeconfigPath,
+    namespace,
+    context: context ?? null,
+  });
+}
+
+export function watchResources(
+  kubeconfigPath: string,
+  resourceType: string,
+  namespace?: string,
+  context?: string,
+): Promise<string> {
+  return invoke<string>("watch_resources", {
+    kubeconfigPath,
+    resourceType,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function unwatchResources(watchId: string): Promise<void> {
+  return invoke("unwatch_resources", { watchId });
+}

--- a/apps/desktop/src/routes/+page.svelte
+++ b/apps/desktop/src/routes/+page.svelte
@@ -1,9 +1,26 @@
 <script lang="ts">
+	import { homeDir } from '@tauri-apps/api/path';
 	import KubeContextSidebar from '$lib/components/KubeContextSidebar.svelte';
 	import MainView from '$lib/components/MainView.svelte';
+	import type { ContextInfo } from '$lib/tauri';
+
+	let kubeconfigPath: string = $state('');
+	let selectedContext: string = $state('');
+
+	$effect(() => {
+		homeDir().then((dir) => {
+			kubeconfigPath = `${dir}/.kube/config`;
+		});
+	});
+
+	function handleContextSelect(ctx: ContextInfo) {
+		selectedContext = ctx.name;
+	}
 </script>
 
-<div class="flex h-screen">
-	<KubeContextSidebar />
-	<MainView />
+<div class="flex h-screen overflow-hidden" style="background-color: hsl(var(--background));">
+	<KubeContextSidebar onContextSelect={handleContextSelect} />
+	<MainView {kubeconfigPath} context={selectedContext} />
 </div>
+
+

--- a/crates/cubelite-core/src/types.rs
+++ b/crates/cubelite-core/src/types.rs
@@ -148,7 +148,7 @@ pub struct UserDetails {
 ///
 /// Unlike [`NamedContext`], this struct includes the cluster server URL and
 /// namespace so callers can display or filter contexts without extra lookups.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContextInfo {
     /// The unique name of this context.
     pub name: String,


### PR DESCRIPTION
## Summary

Milestone 4 — builds the functional Svelte 5 frontend for the CubeLite Tauri desktop app, bringing it from scaffolded placeholders to a working Kubernetes context manager.

## Changes

### Rust (core + Tauri commands)
- Add `Serialize, Deserialize` to `ContextInfo` for Tauri serialization
- Add three new Tauri commands: `list_contexts`, `get_current_context`, `set_context` (using `spawn_blocking` for sync core functions)

### TypeScript bindings
- Create `src/lib/tauri.ts` with typed `invoke` wrappers for all 8 Tauri commands
- Strict types matching Rust structs: `PodInfo`, `NamespaceInfo`, `DeploymentInfo`, `ContextInfo`

### Svelte 5 components
- **KubeContextSidebar** — loads contexts on mount, scrollable list with active highlight, click-to-switch, cluster server URL display, refresh button
- **NamespaceSelector** — dropdown populated from `listNamespaces()`, reloads on context change
- **PodTable** — semantic table with phase color-coding, ready status, restart count
- **DeploymentTable** — table showing `ready_replicas/replicas` with health indicator
- **MainView** — namespace toolbar, pods + deployments sections, loading states, Tauri watch event listeners with `$effect` cleanup
- **+page.svelte** — `homeDir()` from Tauri path API for kubeconfig detection, context selection flow

### Quality gates
- ✅ `cargo check --workspace`
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo test --workspace` (48 tests pass)
- ✅ `cargo fmt --check`
- ✅ `pnpm --filter desktop lint`
- ✅ `svelte-check` (0 errors, 0 warnings)

Closes #52, closes #53, closes #54, closes #55, closes #56