### PR TITLE
fix(macos): show "Cluster not reachable" with grey dot when API server is down

### DIFF
--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -39,6 +39,10 @@ final class ClusterState {
 
     /// Last resource fetch error message, if any.
     var resourceError: String?
+
+    /// Whether the active cluster's API server is reachable.
+    /// `nil` means not yet checked, `true` = connected, `false` = unreachable.
+    var clusterReachable: Bool?
 }
 
 // MARK: - Resource Type

--- a/apps/macos/cubelite/cubelite/Models/CubeliteError.swift
+++ b/apps/macos/cubelite/cubelite/Models/CubeliteError.swift
@@ -24,6 +24,9 @@ enum CubeliteError: LocalizedError, Sendable {
     /// Keychain operation failed.
     case keychainError(reason: String)
 
+    /// The cluster API server could not be reached (connection refused, timeout, DNS).
+    case clusterUnreachable
+
     var errorDescription: String? {
         switch self {
         case .fileNotFound(let path):
@@ -40,6 +43,8 @@ enum CubeliteError: LocalizedError, Sendable {
             "I/O error: \(reason)"
         case .keychainError(let reason):
             "Keychain error: \(reason)"
+        case .clusterUnreachable:
+            "Cluster not reachable"
         }
     }
 }

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -104,6 +104,8 @@ actor KubeAPIService {
         let (data, response): (Data, URLResponse)
         do {
             (data, response) = try await session.data(for: request)
+        } catch let urlError as URLError where Self.isConnectionError(urlError) {
+            throw CubeliteError.clusterUnreachable
         } catch {
             throw CubeliteError.clientError(reason: "Network request failed: \(error.localizedDescription)")
         }
@@ -126,6 +128,20 @@ actor KubeAPIService {
             throw CubeliteError.clientError(
                 reason: "Failed to decode API response: \(error.localizedDescription)"
             )
+        }
+    }
+
+    /// URL error codes that indicate the cluster server is unreachable.
+    private static func isConnectionError(_ error: URLError) -> Bool {
+        switch error.code {
+        case .cannotConnectToHost,     // -1004: connection refused
+             .timedOut,                // -1001: timeout
+             .cannotFindHost,          // -1003: DNS failure
+             .networkConnectionLost,   // -1005: connection dropped
+             .notConnectedToInternet:  // -1009: no network
+            return true
+        default:
+            return false
         }
     }
 

--- a/apps/macos/cubelite/cubelite/Views/MainView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView.swift
@@ -95,7 +95,13 @@ struct MainView: View {
             .help("Refresh all")
             .disabled(clusterState.isLoading || clusterState.isLoadingResources)
         }
-        if let error = clusterState.errorMessage {
+        if clusterState.clusterReachable == false {
+            ToolbarItem(placement: .status) {
+                Label("Cluster not reachable", systemImage: "network.slash")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        } else if let error = clusterState.errorMessage {
             ToolbarItem(placement: .status) {
                 Label(error, systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.red)
@@ -192,9 +198,10 @@ struct MainView: View {
                 .truncationMode(.middle)
             Spacer(minLength: 4)
             if context == clusterState.currentContext {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-                    .imageScale(.small)
+                Circle()
+                    .fill(clusterState.clusterReachable == true ? Color.green : Color.gray)
+                    .frame(width: 8, height: 8)
+                    .help(clusterState.clusterReachable == true ? "Connected" : "Not reachable")
             }
         }
         .contentShape(Rectangle())
@@ -353,6 +360,7 @@ struct MainView: View {
     private func loadKubeconfig() async {
         clusterState.isLoading = true
         clusterState.errorMessage = nil
+        clusterState.clusterReachable = nil
         defer { clusterState.isLoading = false }
         do {
             let config = try await kubeconfigService.load()
@@ -379,6 +387,10 @@ struct MainView: View {
         do {
             let namespaces = try await kubeAPIService.listNamespaces(inContext: context)
             clusterState.namespaces = namespaces.sorted { $0.name < $1.name }
+            clusterState.clusterReachable = true
+        } catch CubeliteError.clusterUnreachable {
+            clusterState.clusterReachable = false
+            namespaceError = CubeliteError.clusterUnreachable.localizedDescription
         } catch {
             namespaceError = error.localizedDescription
         }
@@ -401,6 +413,10 @@ struct MainView: View {
             )
             clusterState.deployments = deployments
             clusterState.selectedNamespace = namespace
+            clusterState.clusterReachable = true
+        } catch CubeliteError.clusterUnreachable {
+            clusterState.clusterReachable = false
+            clusterState.resourceError = CubeliteError.clusterUnreachable.localizedDescription
         } catch {
             clusterState.resourceError = error.localizedDescription
         }


### PR DESCRIPTION
## Summary

When the Kubernetes API server is unreachable (minikube stopped, connection refused, DNS failure, timeout), the macOS app now shows a clean **"Cluster not reachable"** message with a grey dot instead of the raw `NSURLError` text.

### Changes

| File | Change |
|---|---|
| `CubeliteError.swift` | New `clusterUnreachable` case with friendly error description |
| `ClusterState.swift` | New `clusterReachable: Bool?` observable property |
| `KubeAPIService.swift` | Detect `URLError` codes `-1004`, `-1001`, `-1003`, `-1005`, `-1009` → throw `.clusterUnreachable` |
| `MainView.swift` | Grey `network.slash` toolbar label, grey context dot, reachability reset on load |

### Behavior

| State | Toolbar | Context dot |
|---|---|---|
| Connected | *(none)* | 🟢 Green |
| Unreachable | `🔗 Cluster not reachable` (grey) | ⚪ Grey |
| Other error | `⚠️ <error message>` (red) | ⚪ Grey |
| Not yet checked | *(none)* | ⚪ Grey |

Closes #58