### PR TITLE
feat(macos): implement Preferences panel with General/Appearance/Advanced tabs

### DIFF
--- a/apps/macos/cubelite/cubelite/CubeliteApp.swift
+++ b/apps/macos/cubelite/cubelite/CubeliteApp.swift
@@ -5,6 +5,7 @@ import AppKit
 struct CubeliteApp: App {
 
     @State private var clusterState = ClusterState()
+    @State private var appSettings = AppSettings()
     private let kubeconfigService: KubeconfigService
     private let kubeAPIService: KubeAPIService
 
@@ -18,6 +19,7 @@ struct CubeliteApp: App {
         WindowGroup("CubeLite") {
             MainView(kubeconfigService: kubeconfigService, kubeAPIService: kubeAPIService)
                 .environment(clusterState)
+                .environment(appSettings)
         }
         .defaultSize(width: 1200, height: 700)
 
@@ -29,6 +31,11 @@ struct CubeliteApp: App {
                     NSApplication.shared.activate(ignoringOtherApps: true)
                 }
             )
+        }
+
+        Settings {
+            PreferencesView()
+                .environment(appSettings)
         }
     }
 }

--- a/apps/macos/cubelite/cubelite/Models/AppSettings.swift
+++ b/apps/macos/cubelite/cubelite/Models/AppSettings.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Observation
+
+/// Persistent app-wide settings backed by UserDefaults.
+///
+/// All properties are observed via the `@Observable` macro; changes are
+/// automatically persisted to `UserDefaults.standard` through `didSet`.
+/// Credentials and secrets must **never** be stored here — use `KeychainService`.
+@Observable
+@MainActor
+final class AppSettings {
+
+    // MARK: - General
+
+    /// Auto-refresh interval in seconds. `0` means disabled.
+    var autoRefreshInterval: Int = 30 {
+        didSet { UserDefaults.standard.set(autoRefreshInterval, forKey: Keys.autoRefreshInterval) }
+    }
+
+    /// Whether CubeLite should launch at login.
+    var launchAtLogin: Bool = false {
+        didSet { UserDefaults.standard.set(launchAtLogin, forKey: Keys.launchAtLogin) }
+    }
+
+    /// Whether to show system namespaces (e.g. kube-system, kube-public).
+    var showSystemNamespaces: Bool = false {
+        didSet { UserDefaults.standard.set(showSystemNamespaces, forKey: Keys.showSystemNamespaces) }
+    }
+
+    // MARK: - Appearance
+
+    /// Preferred color scheme.
+    var appearanceMode: AppearanceMode = .system {
+        didSet { UserDefaults.standard.set(appearanceMode.rawValue, forKey: Keys.appearanceMode) }
+    }
+
+    /// Menu bar icon style.
+    var menuBarIconStyle: MenuBarIconStyle = .default {
+        didSet { UserDefaults.standard.set(menuBarIconStyle.rawValue, forKey: Keys.menuBarIconStyle) }
+    }
+
+    // MARK: - Advanced
+
+    /// Custom kubeconfig file path. Empty string means the default `~/.kube/config`.
+    var kubeconfigPath: String = "" {
+        didSet { UserDefaults.standard.set(kubeconfigPath, forKey: Keys.kubeconfigPath) }
+    }
+
+    /// Kubernetes API request timeout in seconds. Clamped to 5–120.
+    var apiTimeout: Int = 30 {
+        didSet { UserDefaults.standard.set(apiTimeout, forKey: Keys.apiTimeout) }
+    }
+
+    // MARK: - Init
+
+    init() {
+        let d = UserDefaults.standard
+        // `didSet` is NOT called during initialisation, so we load manually.
+        if let v = d.object(forKey: Keys.autoRefreshInterval) as? Int { autoRefreshInterval = v }
+        launchAtLogin = d.bool(forKey: Keys.launchAtLogin)
+        showSystemNamespaces = d.bool(forKey: Keys.showSystemNamespaces)
+        if let raw = d.string(forKey: Keys.appearanceMode),
+           let mode = AppearanceMode(rawValue: raw) { appearanceMode = mode }
+        if let raw = d.string(forKey: Keys.menuBarIconStyle),
+           let style = MenuBarIconStyle(rawValue: raw) { menuBarIconStyle = style }
+        kubeconfigPath = d.string(forKey: Keys.kubeconfigPath) ?? ""
+        if let v = d.object(forKey: Keys.apiTimeout) as? Int { apiTimeout = min(120, max(5, v)) }
+    }
+
+    // MARK: - Nested Types
+
+    /// Color scheme preference.
+    enum AppearanceMode: String, CaseIterable {
+        case system, light, dark
+
+        /// Human-readable label for display in UI.
+        var label: String {
+            switch self {
+            case .system: "System"
+            case .light: "Light"
+            case .dark: "Dark"
+            }
+        }
+    }
+
+    /// Menu bar icon style.
+    enum MenuBarIconStyle: String, CaseIterable {
+        case `default`, monochrome
+
+        /// Human-readable label for display in UI.
+        var label: String {
+            switch self {
+            case .default: "Default"
+            case .monochrome: "Monochrome"
+            }
+        }
+    }
+
+    // MARK: - Keys
+
+    /// UserDefaults key constants for all persisted settings.
+    enum Keys {
+        static let autoRefreshInterval = "autoRefreshInterval"
+        static let launchAtLogin = "launchAtLogin"
+        static let showSystemNamespaces = "showSystemNamespaces"
+        static let appearanceMode = "appearanceMode"
+        static let menuBarIconStyle = "menuBarIconStyle"
+        static let kubeconfigPath = "kubeconfigPath"
+        static let apiTimeout = "apiTimeout"
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MenuBarContextView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MenuBarContextView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// Menu bar dropdown displaying the active context and a quick-switch list.
 ///
@@ -27,6 +28,13 @@ struct MenuBarContextView: View {
                 .padding(.horizontal, 4)
                 Divider()
             }
+            Button("Preferences…") {
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                NSApplication.shared.activate(ignoringOtherApps: true)
+            }
+            .keyboardShortcut(",")
+            .padding(.top, 4)
+            .padding(.horizontal, 4)
             Button("Quit CubeLite") {
                 NSApplication.shared.terminate(nil)
             }

--- a/apps/macos/cubelite/cubelite/Views/PreferencesView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PreferencesView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+/// Root preferences window for CubeLite (480 × 360).
+///
+/// Contains three tabs — General, Appearance, and Advanced — each
+/// implemented as a separate sub-view to keep individual `body`s concise.
+struct PreferencesView: View {
+
+    var body: some View {
+        TabView {
+            GeneralPreferencesTab()
+                .tabItem { Label("General", systemImage: "gearshape") }
+            AppearancePreferencesTab()
+                .tabItem { Label("Appearance", systemImage: "paintbrush") }
+            AdvancedPreferencesTab()
+                .tabItem { Label("Advanced", systemImage: "slider.horizontal.3") }
+        }
+        .frame(width: 480, height: 360)
+        .padding()
+    }
+}
+
+// MARK: - General Tab
+
+/// General preferences: auto-refresh, launch at login, system namespaces.
+private struct GeneralPreferencesTab: View {
+
+    @Environment(AppSettings.self) private var settings
+
+    private static let refreshOptions: [(label: String, value: Int)] = [
+        ("Off", 0),
+        ("15 seconds", 15),
+        ("30 seconds", 30),
+        ("1 minute", 60),
+        ("2 minutes", 120)
+    ]
+
+    var body: some View {
+        @Bindable var s = settings
+        Form {
+            Picker("Auto-refresh:", selection: $s.autoRefreshInterval) {
+                ForEach(Self.refreshOptions, id: \.value) { option in
+                    Text(option.label).tag(option.value)
+                }
+            }
+            Toggle("Launch at login", isOn: $s.launchAtLogin)
+            Toggle("Show system namespaces", isOn: $s.showSystemNamespaces)
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+}
+
+// MARK: - Appearance Tab
+
+/// Appearance preferences: theme and menu bar icon style.
+private struct AppearancePreferencesTab: View {
+
+    @Environment(AppSettings.self) private var settings
+
+    var body: some View {
+        @Bindable var s = settings
+        Form {
+            Picker("Theme:", selection: $s.appearanceMode) {
+                ForEach(AppSettings.AppearanceMode.allCases, id: \.self) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            .pickerStyle(.radioGroup)
+
+            Picker("Menu bar icon:", selection: $s.menuBarIconStyle) {
+                ForEach(AppSettings.MenuBarIconStyle.allCases, id: \.self) { style in
+                    Text(style.label).tag(style)
+                }
+            }
+            .pickerStyle(.radioGroup)
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+}
+
+// MARK: - Advanced Tab
+
+/// Advanced preferences: kubeconfig path and API timeout.
+private struct AdvancedPreferencesTab: View {
+
+    @Environment(AppSettings.self) private var settings
+
+    var body: some View {
+        @Bindable var s = settings
+        Form {
+            HStack {
+                TextField("Kubeconfig path:", text: $s.kubeconfigPath, prompt: Text("~/.kube/config"))
+                Button("Choose…") { pickKubeconfigFile(binding: $s.kubeconfigPath) }
+            }
+            Stepper("API timeout: \(s.apiTimeout) s", value: $s.apiTimeout, in: 5...120, step: 5)
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+
+    /// Opens an `NSOpenPanel` to choose a kubeconfig file.
+    private func pickKubeconfigFile(binding: Binding<String>) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.prompt = "Select"
+        panel.message = "Choose a kubeconfig file"
+        if panel.runModal() == .OK, let url = panel.url {
+            binding.wrappedValue = url.path
+        }
+    }
+}

--- a/apps/macos/cubelite/cubeliteTests/PreferencesTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/PreferencesTests.swift
@@ -7,29 +7,29 @@ final class PreferencesTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Keys used by AppSettings in UserDefaults.
-    private typealias Keys = AppSettings.Keys
-
     /// Removes all AppSettings keys from UserDefaults so each test starts clean.
-    private func resetDefaults() {
+    ///
+    /// Declared `nonisolated` so it can be called from XCTest's non-isolated
+    /// `setUp()` / `tearDown()` without triggering Swift 6 sendability errors.
+    private nonisolated func resetDefaults() {
         let d = UserDefaults.standard
-        [Keys.autoRefreshInterval,
-         Keys.launchAtLogin,
-         Keys.showSystemNamespaces,
-         Keys.appearanceMode,
-         Keys.menuBarIconStyle,
-         Keys.kubeconfigPath,
-         Keys.apiTimeout].forEach { d.removeObject(forKey: $0) }
+        [AppSettings.Keys.autoRefreshInterval,
+         AppSettings.Keys.launchAtLogin,
+         AppSettings.Keys.showSystemNamespaces,
+         AppSettings.Keys.appearanceMode,
+         AppSettings.Keys.menuBarIconStyle,
+         AppSettings.Keys.kubeconfigPath,
+         AppSettings.Keys.apiTimeout].forEach { d.removeObject(forKey: $0) }
     }
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override func setUp() {
+        super.setUp()
         resetDefaults()
     }
 
-    override func tearDown() async throws {
+    override func tearDown() {
         resetDefaults()
-        try await super.tearDown()
+        super.tearDown()
     }
 
     // MARK: - Default Values
@@ -135,14 +135,14 @@ final class PreferencesTests: XCTestCase {
     // MARK: - API Timeout Range
 
     func testApiTimeoutBelowMinimumClampsOnLoad() {
-        UserDefaults.standard.set(1, forKey: Keys.apiTimeout)
+        UserDefaults.standard.set(1, forKey: AppSettings.Keys.apiTimeout)
         let sut = AppSettings()
         XCTAssertGreaterThanOrEqual(sut.apiTimeout, 5,
                                     "Timeout below minimum should be clamped to 5 on load")
     }
 
     func testApiTimeoutAboveMaximumClampsOnLoad() {
-        UserDefaults.standard.set(999, forKey: Keys.apiTimeout)
+        UserDefaults.standard.set(999, forKey: AppSettings.Keys.apiTimeout)
         let sut = AppSettings()
         XCTAssertLessThanOrEqual(sut.apiTimeout, 120,
                                   "Timeout above maximum should be clamped to 120 on load")

--- a/apps/macos/cubelite/cubeliteTests/PreferencesTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/PreferencesTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import cubelite
+
+/// Unit tests for ``AppSettings``.
+@MainActor
+final class PreferencesTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Keys used by AppSettings in UserDefaults.
+    private typealias Keys = AppSettings.Keys
+
+    /// Removes all AppSettings keys from UserDefaults so each test starts clean.
+    private func resetDefaults() {
+        let d = UserDefaults.standard
+        [Keys.autoRefreshInterval,
+         Keys.launchAtLogin,
+         Keys.showSystemNamespaces,
+         Keys.appearanceMode,
+         Keys.menuBarIconStyle,
+         Keys.kubeconfigPath,
+         Keys.apiTimeout].forEach { d.removeObject(forKey: $0) }
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        resetDefaults()
+    }
+
+    override func tearDown() async throws {
+        resetDefaults()
+        try await super.tearDown()
+    }
+
+    // MARK: - Default Values
+
+    func testDefaultAutoRefreshInterval() {
+        let sut = AppSettings()
+        XCTAssertEqual(sut.autoRefreshInterval, 30)
+    }
+
+    func testDefaultLaunchAtLogin() {
+        let sut = AppSettings()
+        XCTAssertFalse(sut.launchAtLogin)
+    }
+
+    func testDefaultShowSystemNamespaces() {
+        let sut = AppSettings()
+        XCTAssertFalse(sut.showSystemNamespaces)
+    }
+
+    func testDefaultAppearanceMode() {
+        let sut = AppSettings()
+        XCTAssertEqual(sut.appearanceMode, .system)
+    }
+
+    func testDefaultMenuBarIconStyle() {
+        let sut = AppSettings()
+        XCTAssertEqual(sut.menuBarIconStyle, .default)
+    }
+
+    func testDefaultKubeconfigPath() {
+        let sut = AppSettings()
+        XCTAssertEqual(sut.kubeconfigPath, "")
+    }
+
+    func testDefaultApiTimeout() {
+        let sut = AppSettings()
+        XCTAssertEqual(sut.apiTimeout, 30)
+    }
+
+    // MARK: - Persistence Round-Trip
+
+    func testAutoRefreshIntervalPersists() {
+        let sut = AppSettings()
+        sut.autoRefreshInterval = 60
+        let sut2 = AppSettings()
+        XCTAssertEqual(sut2.autoRefreshInterval, 60)
+    }
+
+    func testLaunchAtLoginPersists() {
+        let sut = AppSettings()
+        sut.launchAtLogin = true
+        let sut2 = AppSettings()
+        XCTAssertTrue(sut2.launchAtLogin)
+    }
+
+    func testShowSystemNamespacesPersists() {
+        let sut = AppSettings()
+        sut.showSystemNamespaces = true
+        let sut2 = AppSettings()
+        XCTAssertTrue(sut2.showSystemNamespaces)
+    }
+
+    func testAppearanceModePersists() {
+        let sut = AppSettings()
+        sut.appearanceMode = .dark
+        let sut2 = AppSettings()
+        XCTAssertEqual(sut2.appearanceMode, .dark)
+    }
+
+    func testMenuBarIconStylePersists() {
+        let sut = AppSettings()
+        sut.menuBarIconStyle = .monochrome
+        let sut2 = AppSettings()
+        XCTAssertEqual(sut2.menuBarIconStyle, .monochrome)
+    }
+
+    func testKubeconfigPathPersists() {
+        let sut = AppSettings()
+        sut.kubeconfigPath = "/Users/test/.kube/custom-config"
+        let sut2 = AppSettings()
+        XCTAssertEqual(sut2.kubeconfigPath, "/Users/test/.kube/custom-config")
+    }
+
+    func testApiTimeoutPersists() {
+        let sut = AppSettings()
+        sut.apiTimeout = 45
+        let sut2 = AppSettings()
+        XCTAssertEqual(sut2.apiTimeout, 45)
+    }
+
+    // MARK: - Valid Refresh Intervals
+
+    func testAllRefreshIntervalOptionsAreValid() {
+        let validIntervals = [0, 15, 30, 60, 120]
+        let sut = AppSettings()
+        for interval in validIntervals {
+            sut.autoRefreshInterval = interval
+            XCTAssertEqual(sut.autoRefreshInterval, interval,
+                           "Interval \(interval) should be stored as-is")
+        }
+    }
+
+    // MARK: - API Timeout Range
+
+    func testApiTimeoutBelowMinimumClampsOnLoad() {
+        UserDefaults.standard.set(1, forKey: Keys.apiTimeout)
+        let sut = AppSettings()
+        XCTAssertGreaterThanOrEqual(sut.apiTimeout, 5,
+                                    "Timeout below minimum should be clamped to 5 on load")
+    }
+
+    func testApiTimeoutAboveMaximumClampsOnLoad() {
+        UserDefaults.standard.set(999, forKey: Keys.apiTimeout)
+        let sut = AppSettings()
+        XCTAssertLessThanOrEqual(sut.apiTimeout, 120,
+                                  "Timeout above maximum should be clamped to 120 on load")
+    }
+
+    func testApiTimeoutAtBoundaries() {
+        let sut = AppSettings()
+        sut.apiTimeout = 5
+        XCTAssertEqual(sut.apiTimeout, 5)
+        sut.apiTimeout = 120
+        XCTAssertEqual(sut.apiTimeout, 120)
+    }
+
+    // MARK: - Appearance Mode Cases
+
+    func testAllAppearanceModesCoveredByLabel() {
+        for mode in AppSettings.AppearanceMode.allCases {
+            XCTAssertFalse(mode.label.isEmpty,
+                           "AppearanceMode.\(mode.rawValue) must have a non-empty label")
+        }
+    }
+
+    // MARK: - Menu Bar Icon Style Cases
+
+    func testAllMenuBarIconStylesCoveredByLabel() {
+        for style in AppSettings.MenuBarIconStyle.allCases {
+            XCTAssertFalse(style.label.isEmpty,
+                           "MenuBarIconStyle.\(style.rawValue) must have a non-empty label")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a native macOS Preferences panel with three tabs (General, Appearance, Advanced), matching the Penpot design.

## Changes

### Model
- **AppSettings** (new): `@Observable @MainActor` class with 7 persisted settings via UserDefaults. Includes `AppearanceMode` and `MenuBarIconStyle` enums.

### Views
- **PreferencesView** (new): 480×360 `TabView` with:
  - **General**: Auto-refresh interval picker, launch at login toggle, show system namespaces toggle
  - **Appearance**: Theme picker (System/Light/Dark), menu bar icon style picker
  - **Advanced**: Kubeconfig path with file picker (NSOpenPanel), API timeout stepper
- **CubeliteApp**: Added `Settings` scene for standard macOS preferences window
- **MenuBarContextView**: Added "Preferences…" (⌘,) menu item

### Tests
- 20 new XCTest cases covering defaults, persistence, value ranges, enum labels
- All 46 tests pass (20 new + 26 existing)

## Penpot Reference
- Page: macOS Native → Preferences board

Closes #66