### PR TITLE
fix(macos): apply dark mode toggle from Preferences to app chrome

### DIFF
--- a/apps/macos/cubelite/cubelite/CubeliteApp.swift
+++ b/apps/macos/cubelite/cubelite/CubeliteApp.swift
@@ -26,6 +26,13 @@ struct CubeliteApp: App {
                     .environment(clusterState)
                     .environment(appSettings)
                     .environment(logStore)
+                    .preferredColorScheme(appSettings.colorScheme)
+                    .onChange(of: appSettings.appearanceMode) { _, newMode in
+                        applyNSAppearance(newMode)
+                    }
+                    .task {
+                        applyNSAppearance(appSettings.appearanceMode)
+                    }
             } else {
                 FirstLaunchView(
                     kubeconfigService: kubeconfigService,
@@ -51,6 +58,22 @@ struct CubeliteApp: App {
         Settings {
             PreferencesView()
                 .environment(appSettings)
+        }
+    }
+
+    /// Applies `NSAppearance` to the whole application so that window chrome,
+    /// menus, and AppKit elements match the user's selected theme.
+    ///
+    /// - Parameter mode: The `AppearanceMode` selected in Preferences.
+    @MainActor
+    private func applyNSAppearance(_ mode: AppSettings.AppearanceMode) {
+        switch mode {
+        case .system:
+            NSApp.appearance = nil
+        case .light:
+            NSApp.appearance = NSAppearance(named: .aqua)
+        case .dark:
+            NSApp.appearance = NSAppearance(named: .darkAqua)
         }
     }
 }

--- a/apps/macos/cubelite/cubelite/Models/AppSettings.swift
+++ b/apps/macos/cubelite/cubelite/Models/AppSettings.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftUI
 
 /// Persistent app-wide settings backed by UserDefaults.
 ///
@@ -32,6 +33,18 @@ final class AppSettings {
     /// Preferred color scheme.
     var appearanceMode: AppearanceMode = .system {
         didSet { UserDefaults.standard.set(appearanceMode.rawValue, forKey: Keys.appearanceMode) }
+    }
+
+    /// The SwiftUI `ColorScheme` corresponding to the current `appearanceMode`.
+    ///
+    /// Returns `nil` when the mode is `.system`, which defers colour scheme
+    /// selection to the operating system.
+    var colorScheme: ColorScheme? {
+        switch appearanceMode {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
     }
 
     /// Menu bar icon style.

--- a/apps/macos/cubelite/cubeliteTests/AppSettingsAppearanceTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/AppSettingsAppearanceTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import SwiftUI
+@testable import cubelite
+
+// MARK: - AppSettingsAppearanceTests
+
+/// Tests that `AppSettings.colorScheme` maps each `AppearanceMode` correctly
+/// and that the setting round-trips through `UserDefaults`.
+@MainActor
+final class AppSettingsAppearanceTests: XCTestCase {
+
+    private let appearanceKey = "appearanceMode"
+
+    override func tearDown() {
+        super.tearDown()
+        // Clean up UserDefaults after each test to avoid cross-test contamination.
+        UserDefaults.standard.removeObject(forKey: appearanceKey)
+    }
+
+    // MARK: - colorScheme mapping
+
+    func testColorScheme_system_returnsNil() {
+        let sut = AppSettings()
+        sut.appearanceMode = .system
+
+        XCTAssertNil(sut.colorScheme)
+    }
+
+    func testColorScheme_light_returnsLight() {
+        let sut = AppSettings()
+        sut.appearanceMode = .light
+
+        XCTAssertEqual(sut.colorScheme, .light)
+    }
+
+    func testColorScheme_dark_returnsDark() {
+        let sut = AppSettings()
+        sut.appearanceMode = .dark
+
+        XCTAssertEqual(sut.colorScheme, .dark)
+    }
+
+    // MARK: - UserDefaults persistence
+
+    func testAppearanceMode_persists_throughUserDefaults() {
+        let sut = AppSettings()
+        sut.appearanceMode = .dark
+
+        // Re-create to simulate app restart reading saved value.
+        let sut2 = AppSettings()
+
+        XCTAssertEqual(sut2.appearanceMode, .dark)
+        XCTAssertEqual(sut2.colorScheme, .dark)
+    }
+
+    func testAppearanceMode_light_persists_throughUserDefaults() {
+        let sut = AppSettings()
+        sut.appearanceMode = .light
+
+        let sut2 = AppSettings()
+
+        XCTAssertEqual(sut2.appearanceMode, .light)
+        XCTAssertEqual(sut2.colorScheme, .light)
+    }
+
+    func testAppearanceMode_defaultsToSystem_whenNoSavedValue() {
+        // Ensure no prior value exists.
+        UserDefaults.standard.removeObject(forKey: appearanceKey)
+
+        let sut = AppSettings()
+
+        XCTAssertEqual(sut.appearanceMode, .system)
+        XCTAssertNil(sut.colorScheme)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the dark mode toggle in Preferences — previously the toggle saved the setting but did not actually apply the theme to the app.

## Changes

### AppSettings
- Added `colorScheme` computed property that maps `AppearanceMode` → SwiftUI `ColorScheme?`

### CubeliteApp
- Applied `.preferredColorScheme(appSettings.colorScheme)` for SwiftUI views
- Added `applyNSAppearance()` to set `NSApp.appearance` so window chrome, menus, and AppKit elements also follow the theme
- Reacts to `appearanceMode` changes via `.onChange` and applies on launch via `.task`

### Tests
- 6 new XCTests in `AppSettingsAppearanceTests.swift`
  - colorScheme mapping: system→nil, light→.light, dark→.dark
  - UserDefaults persistence: dark, light, and default (system) round-trips

Closes #74