### PR TITLE
fix(macos): add toolbar with title and close button to LogsView sheet

### DIFF
--- a/apps/macos/cubelite/cubelite/Views/LogsView.swift
+++ b/apps/macos/cubelite/cubelite/Views/LogsView.swift
@@ -8,15 +8,24 @@ import SwiftUI
 struct LogsView: View {
 
     @Environment(LogStore.self) private var logStore
+    @Environment(\.dismiss) private var dismiss
     @State private var selectedEntryID: UUID?
     @State private var filter: LogFilter = .all
 
     var body: some View {
-        HSplitView {
-            logListColumn
-            logDetailColumn
+        NavigationStack {
+            HSplitView {
+                logListColumn
+                logDetailColumn
+            }
+            .frame(minWidth: 800, minHeight: 520)
+            .navigationTitle("Logs & Errors")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
         }
-        .frame(minWidth: 800, minHeight: 520)
         .task { logStore.markErrorsRead() }
     }
 


### PR DESCRIPTION
## Summary

The `LogsView` sheet had no visible title bar or close button — users could only dismiss it with the ESC key.

## Changes

- Wrapped `HSplitView` in a `NavigationStack` so the `.sheet` presentation renders a macOS title bar with the window title **"Logs & Errors"**.
- Added `@Environment(\.dismiss) private var dismiss` to `LogsView`.
- Added a `ToolbarItem(placement: .cancellationAction)` with a **"Close"** button that calls `dismiss()`.

## Testing

- `xcodebuild build` → clean (0 errors, 0 warnings)
- `.task { logStore.markErrorsRead() }` moved to `NavigationStack` level — behaviour unchanged.

Closes #75