### PR TITLE
fix(macos): make 'All Namespaces' visually distinct in sidebar

### DIFF
--- a/apps/macos/cubelite/cubelite/Views/NamespaceListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/NamespaceListView.swift
@@ -36,6 +36,10 @@ struct NamespaceListView: View {
                 errorRow(error)
             } else {
                 allNamespacesRow
+                if !namespaces.isEmpty {
+                    Divider()
+                        .padding(.leading, 4)
+                }
                 ForEach(namespaces) { ns in
                     namespaceRow(ns.name)
                 }
@@ -70,9 +74,10 @@ struct NamespaceListView: View {
         namespaceRowView(
             namespace: nil,
             label: "All Namespaces",
-            icon: "tray.2",
+            icon: "square.grid.2x2",
             count: namespacePodCounts.values.reduce(0, +)
         )
+        .fontWeight(.semibold)
     }
 
     private func namespaceRow(_ name: String) -> some View {


### PR DESCRIPTION
## Summary

The **"All Namespaces"** row appeared at the same indentation and style as individual namespace rows, making it visually ambiguous.

## Changes

- **Icon**: changed from `tray.2` → `square.grid.2x2` to differentiate from individual namespace rows (`square.dashed`)
- **Font weight**: applied `.fontWeight(.semibold)` to the All Namespaces row so it reads as a special aggregate option
- **Divider**: added `Divider()` below the All Namespaces row (only rendered when there are individual namespaces to separate)

### Before
```
▾ minikube
    All Namespaces      ← same look as below
    default
    kube-system
```

### After
```
▾ minikube
    ⊞ All Namespaces    ← semibold, different icon
    ──────────────────
    ⬚ default
    ⬚ kube-system
```

## Testing

- `xcodebuild build` → Exit 0 (0 errors, 0 warnings)
- `xcodebuild test` → all tests passed

Closes #76