### PR TITLE
fix(macos): handle errSecCertificateValidityPeriodTooLong in TLS trust evaluation

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -571,9 +571,25 @@ private final class KubeURLSessionDelegate: NSObject, URLSessionDelegate, @unche
                 var error: CFError?
                 if SecTrustEvaluateWithError(trust, &error) {
                     return (.useCredential, URLCredential(trust: trust))
-                } else {
-                    return (.cancelAuthenticationChallenge, nil)
                 }
+
+                // macOS rejects server certificates whose validity period exceeds
+                // 398 days (errSecCertificateValidityPeriodTooLong, OSStatus -67901).
+                // Local/dev clusters (minikube, k3s, kind) commonly generate long-lived
+                // certificates signed by a private CA. Since we already pinned that CA
+                // as the sole trust anchor, fall back to a basic X.509 chain-only
+                // evaluation which verifies the signature chain without enforcing
+                // Apple's temporal-compliance policy.
+                if (error.map { ($0 as Error as NSError).code }) == -67901 {
+                    let chainOnlyPolicy = SecPolicyCreateBasicX509()
+                    SecTrustSetPolicies(trust, chainOnlyPolicy)
+                    var chainError: CFError?
+                    if SecTrustEvaluateWithError(trust, &chainError) {
+                        return (.useCredential, URLCredential(trust: trust))
+                    }
+                }
+
+                return (.cancelAuthenticationChallenge, nil)
             }
         }
 


### PR DESCRIPTION
## Problem

macOS rejects server certificates whose validity period exceeds 398 days (`errSecCertificateValidityPeriodTooLong`, OSStatus -67901). Local/dev clusters like minikube, k3s, and kind commonly generate long-lived certificates signed by a private CA.

This caused `SecTrustEvaluateWithError` to fail → the URLSession delegate to cancel the auth challenge → `URLError.cancelled` → **"Kubernetes API error: Network request failed: cancelled"** in the sidebar.

## Root Cause

The `KubeURLSessionDelegate` cancelled the authentication challenge when `SecTrustEvaluateWithError` returned `false`, without checking the specific error code. The error was:

```
Certificate 0 "minikube" has errors: Certificate exceeds maximum temporal validity period
```

## Fix

When the standard SSL trust evaluation fails with error code -67901 specifically, fall back to a **basic X.509 chain-only evaluation** (`SecPolicyCreateBasicX509`) that:
- Verifies the certificate signature chain against the pinned custom CA
- Checks certificate expiration (notBefore/notAfter)
- Does **not** enforce Apple's temporal-compliance policy (398-day maximum)

This is safe because we already pin the custom CA as the sole trust anchor via `SecTrustSetAnchorCertificatesOnly`.

## Testing

- [x] Build succeeds
- [x] App connects to minikube without errors (was failing before)
- [x] All 145 unit tests pass
- [x] No regressions