### PR TITLE
feat(macos): auto-discover kubeconfig files in ~/.kube/ directory

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/KubeconfigService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeconfigService.swift
@@ -10,15 +10,67 @@ actor KubeconfigService {
     // MARK: - Path Resolution
 
     /// Resolves kubeconfig file paths from the `KUBECONFIG` environment variable,
-    /// falling back to `~/.kube/config`.
+    /// falling back to `~/.kube/config` plus any additional kubeconfig files
+    /// discovered in the `~/.kube/` directory.
+    ///
+    /// Auto-discovery scans `~/.kube/` for regular files whose first bytes
+    /// contain a YAML `kind: Config` marker, which is present in all valid
+    /// kubeconfig files. The default `config` file always comes first so its
+    /// `current-context` takes precedence during merge.
     static func resolveKubeconfigPaths() -> [URL] {
         if let envValue = ProcessInfo.processInfo.environment["KUBECONFIG"],
-           !envValue.isEmpty {
-            return envValue
+            !envValue.isEmpty
+        {
+            return
+                envValue
                 .split(separator: ":")
                 .map { URL(fileURLWithPath: String($0)) }
         }
-        return [realHomeDirectory().appendingPathComponent(".kube/config")]
+        let kubeDir = realHomeDirectory().appendingPathComponent(".kube")
+        let defaultConfig = kubeDir.appendingPathComponent("config")
+        var paths = [defaultConfig]
+        // Auto-discover additional kubeconfig files in ~/.kube/
+        paths.append(contentsOf: discoverKubeconfigFiles(in: kubeDir, excluding: defaultConfig))
+        return paths
+    }
+
+    /// Scans a directory for files that look like valid kubeconfig YAML.
+    ///
+    /// A file qualifies when it is a regular file (not a directory or symlink
+    /// to a directory) and its first 512 bytes contain `kind: Config` or
+    /// `kind: "Config"`. Hidden files (starting with `.`) and the `cache`
+    /// directory are skipped.
+    private static func discoverKubeconfigFiles(
+        in directory: URL,
+        excluding excluded: URL
+    ) -> [URL] {
+        let fm = FileManager.default
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else { return [] }
+
+        return entries
+            .filter { url in
+                // Skip the already-included default config
+                guard url.standardizedFileURL != excluded.standardizedFileURL else {
+                    return false
+                }
+                // Skip directories (e.g. cache/, kubens/)
+                let isDir =
+                    (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+                guard !isDir else { return false }
+                // Quick heuristic: read first 512 bytes and check for kubeconfig marker
+                guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+                defer { handle.closeFile() }
+                guard let header = try? handle.read(upToCount: 512) else { return false }
+                guard let text = String(data: header, encoding: .utf8) else { return false }
+                return text.contains("kind: Config") || text.contains("kind: \"Config\"")
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
     }
 
     /// Returns the user's real home directory, bypassing sandbox container redirection.
@@ -35,11 +87,28 @@ actor KubeconfigService {
         return FileManager.default.homeDirectoryForCurrentUser
     }
 
+    // MARK: - Custom Paths
+
+    /// User-specified kubeconfig paths. When non-empty, overrides `KUBECONFIG` env-var
+    /// and default `~/.kube/config` resolution.
+    private var customPaths: [URL] = []
+
+    /// Updates the custom kubeconfig paths used by this service.
+    ///
+    /// Call this whenever `AppSettings.kubeconfigPaths` changes.
+    /// Pass an empty array to revert to default path resolution.
+    func configure(paths: [URL]) {
+        customPaths = paths
+    }
+
     // MARK: - Load
 
     /// Loads and merges kubeconfig from the resolved paths.
+    ///
+    /// Uses `customPaths` when non-empty; otherwise falls back to `KUBECONFIG`
+    /// env-var resolution and `~/.kube/config`.
     func load() throws -> KubeConfig {
-        let paths = Self.resolveKubeconfigPaths()
+        let paths = customPaths.isEmpty ? Self.resolveKubeconfigPaths() : customPaths
         return try loadFromPaths(paths)
     }
 

--- a/apps/macos/cubelite/cubeliteTests/KubeconfigAutoDiscoveryTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/KubeconfigAutoDiscoveryTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+
+@testable import cubelite
+
+// MARK: - Kubeconfig Auto-Discovery Tests
+//
+// Tests for automatic discovery of kubeconfig files in ~/.kube/.
+// Uses temporary directories with synthetic kubeconfig files.
+
+final class KubeconfigAutoDiscoveryTests: XCTestCase {
+
+    private let fm = FileManager.default
+    private let sut = KubeconfigService()
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = fm.temporaryDirectory.appendingPathComponent(
+            "cubelite-discovery-\(UUID().uuidString)"
+        )
+        try? fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? fm.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func writeFile(_ name: String, contents: String) throws -> URL {
+        let url = tempDir.appendingPathComponent(name)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func minimalKubeconfig(context: String, server: String) -> String {
+        """
+        apiVersion: v1
+        kind: Config
+        current-context: \(context)
+        contexts:
+        - name: \(context)
+          context:
+            cluster: \(context)
+            user: user-\(context)
+        clusters:
+        - name: \(context)
+          cluster:
+            server: \(server)
+        users:
+        - name: user-\(context)
+          user:
+            token: test-token-\(context)
+        """
+    }
+
+    // MARK: - loadFromPaths merges discovered files
+
+    func testLoadFromPaths_mergesMultipleKubeconfigs() async throws {
+        let config1 = try writeFile("config", contents: minimalKubeconfig(
+            context: "default-ctx", server: "https://k8s-default.example"
+        ))
+        let config2 = try writeFile("kub3-dev", contents: minimalKubeconfig(
+            context: "kub3-dev", server: "https://kub3.example/k8s/clusters/local"
+        ))
+
+        let config = try await sut.loadFromPaths([config1, config2])
+
+        XCTAssertEqual(config.contexts.count, 2)
+        XCTAssertTrue(config.contexts.contains("default-ctx"))
+        XCTAssertTrue(config.contexts.contains("kub3-dev"))
+        // First file's current-context wins
+        XCTAssertEqual(config.currentContext, "default-ctx")
+    }
+
+    func testLoadFromPaths_duplicateContextNames_firstWins() async throws {
+        let config1 = try writeFile("config", contents: minimalKubeconfig(
+            context: "shared", server: "https://server-a.example"
+        ))
+        let config2 = try writeFile("extra", contents: minimalKubeconfig(
+            context: "shared", server: "https://server-b.example"
+        ))
+
+        let config = try await sut.loadFromPaths([config1, config2])
+
+        XCTAssertEqual(config.contexts.count, 1)
+        XCTAssertEqual(
+            config.raw.clusters?.first?.cluster?.server,
+            "https://server-a.example"
+        )
+    }
+
+    // MARK: - Rancher-style kubeconfig without namespace
+
+    func testLoadFromPaths_rancherKubeconfig_noNamespace_loadsSuccessfully() async throws {
+        let rancherYAML = """
+            apiVersion: v1
+            kind: Config
+            current-context: kub3-dev
+            contexts:
+            - name: kub3-dev
+              context:
+                cluster: kub3-dev
+                user: kub3-dev
+            clusters:
+            - name: kub3-dev
+              cluster:
+                server: "https://kub3.ors.it/k8s/clusters/local"
+                certificate-authority-data: "dGVzdA=="
+            users:
+            - name: kub3-dev
+              user:
+                token: test-token
+            """
+        let url = try writeFile("kub3-dev", contents: rancherYAML)
+
+        let config = try await sut.loadFromPaths([url])
+
+        XCTAssertEqual(config.contexts, ["kub3-dev"])
+    }
+
+    func testLoadFromPaths_rancherPlusDefault_mergesContexts() async throws {
+        let defaultConfig = try writeFile("config", contents: minimalKubeconfig(
+            context: "minikube", server: "https://127.0.0.1:8443"
+        ))
+        let rancherConfig = try writeFile("kub3-dev", contents: minimalKubeconfig(
+            context: "kub3-dev", server: "https://kub3.ors.it/k8s/clusters/local"
+        ))
+
+        let config = try await sut.loadFromPaths([defaultConfig, rancherConfig])
+
+        XCTAssertEqual(config.contexts.sorted(), ["kub3-dev", "minikube"])
+        XCTAssertEqual(config.currentContext, "minikube")
+    }
+
+    // MARK: - discoverKubeconfigFiles via resolveKubeconfigPaths behavior
+
+    func testDiscoverKubeconfigFiles_skipsDirectories() throws {
+        _ = try writeFile("config", contents: minimalKubeconfig(
+            context: "main", server: "https://main.example"
+        ))
+        // Create a subdirectory that should be skipped
+        let subDir = tempDir.appendingPathComponent("cache")
+        try fm.createDirectory(at: subDir, withIntermediateDirectories: true)
+        try "not a kubeconfig".write(
+            to: subDir.appendingPathComponent("somefile"),
+            atomically: true, encoding: .utf8
+        )
+
+        // Verify the directory's contents don't include subdirectory entries
+        let entries = try fm.contentsOfDirectory(
+            at: tempDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let nonDirs = entries.filter {
+            let isDir = (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            return !isDir
+        }
+        XCTAssertEqual(nonDirs.count, 1)
+        XCTAssertEqual(nonDirs.first?.lastPathComponent, "config")
+    }
+
+    func testDiscoverKubeconfigFiles_skipsNonKubeconfigs() throws {
+        _ = try writeFile("config", contents: minimalKubeconfig(
+            context: "main", server: "https://main.example"
+        ))
+        // Write a file that is NOT a kubeconfig
+        _ = try writeFile("notes.txt", contents: "this is not a kubeconfig")
+        // Write a file that looks like YAML but isn't kubeconfig
+        _ = try writeFile("other.yaml", contents: """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: test
+            """)
+
+        // Load only from the config file — the other files should not parse as kubeconfigs
+        let config = try fm.contentsOfDirectory(
+            at: tempDir,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ).filter { url in
+            guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+            defer { handle.closeFile() }
+            guard let header = try? handle.read(upToCount: 512),
+                let text = String(data: header, encoding: .utf8)
+            else { return false }
+            return text.contains("kind: Config")
+        }
+
+        XCTAssertEqual(config.count, 1)
+        XCTAssertEqual(config.first?.lastPathComponent, "config")
+    }
+
+    func testDiscoverKubeconfigFiles_findsExtraKubeconfigs() throws {
+        _ = try writeFile("config", contents: minimalKubeconfig(
+            context: "main", server: "https://main.example"
+        ))
+        _ = try writeFile("kub3-dev", contents: minimalKubeconfig(
+            context: "kub3-dev", server: "https://kub3.example"
+        ))
+        _ = try writeFile("staging-cluster", contents: minimalKubeconfig(
+            context: "staging", server: "https://staging.example"
+        ))
+        _ = try writeFile("notes.txt", contents: "not a kubeconfig at all")
+
+        // Simulate the discovery logic
+        let excluded = tempDir.appendingPathComponent("config")
+        let entries = try fm.contentsOfDirectory(
+            at: tempDir,
+            includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let discovered = entries
+            .filter { url in
+                guard url.standardizedFileURL != excluded.standardizedFileURL else { return false }
+                let isDir =
+                    (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+                guard !isDir else { return false }
+                guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+                defer { handle.closeFile() }
+                guard let header = try? handle.read(upToCount: 512),
+                    let text = String(data: header, encoding: .utf8)
+                else { return false }
+                return text.contains("kind: Config") || text.contains("kind: \"Config\"")
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        XCTAssertEqual(discovered.count, 2)
+        XCTAssertEqual(discovered[0].lastPathComponent, "kub3-dev")
+        XCTAssertEqual(discovered[1].lastPathComponent, "staging-cluster")
+    }
+}

--- a/apps/macos/cubelite/cubeliteTests/KubeconfigServiceSaveTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/KubeconfigServiceSaveTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+
+@testable import cubelite
+
+// MARK: - KubeconfigServiceSaveTests
+
+/// Tests for ``KubeconfigService/save(_:)`` and the full load → mutate → save → reload cycle.
+final class KubeconfigServiceSaveTests: XCTestCase {
+
+    private let sut = KubeconfigService()
+
+    // MARK: - save: basic round-trip
+
+    /// Verifies that saving a config and reloading it from the same file returns the same data.
+    func testSave_loadRoundTrip_preservesContexts() async throws {
+        let yaml = minimalYAML(
+            context: "round-trip-ctx", cluster: "cluster-rt", server: "https://rt.example.com")
+        let url = try temporaryFile(contents: yaml)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let config = try await sut.loadFromPaths([url])
+        try await sut.save(config)
+
+        let reloaded = try await sut.loadFromPaths([url])
+        XCTAssertEqual(reloaded.contexts, config.contexts)
+        XCTAssertEqual(reloaded.currentContext, config.currentContext)
+    }
+
+    /// Verifies that saving after `setActiveContext` persists the new active context.
+    func testSave_afterSetActiveContext_persistsNewContext() async throws {
+        let yaml = twoContextYAML()
+        let url = try temporaryFile(contents: yaml)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var config = try await sut.loadFromPaths([url])
+        XCTAssertEqual(config.currentContext, "ctx-a")
+
+        try await sut.setActiveContext("ctx-b", in: &config)
+        try await sut.save(config)
+
+        let reloaded = try await sut.loadFromPaths([url])
+        XCTAssertEqual(
+            reloaded.currentContext, "ctx-b",
+            "Reloaded config should reflect the saved context switch")
+    }
+
+    /// Verifies that all context names survive a save/reload round-trip.
+    func testSave_twoContexts_bothPresentAfterReload() async throws {
+        let yaml = twoContextYAML()
+        let url = try temporaryFile(contents: yaml)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let config = try await sut.loadFromPaths([url])
+        try await sut.save(config)
+
+        let reloaded = try await sut.loadFromPaths([url])
+        XCTAssertTrue(reloaded.contexts.contains("ctx-a"))
+        XCTAssertTrue(reloaded.contexts.contains("ctx-b"))
+        XCTAssertEqual(reloaded.contexts.count, 2)
+    }
+
+    // MARK: - save: writes to first path only
+
+    /// Verifies that when a merged config has multiple paths, save writes to the first file.
+    func testSave_multipleSourcePaths_writesToFirstFile() async throws {
+        let yaml1 = minimalYAML(
+            context: "ctx-a", cluster: "cluster-a", server: "https://a.example.com")
+        let yaml2 = minimalYAML(
+            context: "ctx-b", cluster: "cluster-b", server: "https://b.example.com")
+        let url1 = try temporaryFile(contents: yaml1)
+        let url2 = try temporaryFile(contents: yaml2)
+        defer {
+            try? FileManager.default.removeItem(at: url1)
+            try? FileManager.default.removeItem(at: url2)
+        }
+
+        var config = try await sut.loadFromPaths([url1, url2])
+        try await sut.setActiveContext("ctx-b", in: &config)
+        try await sut.save(config)
+
+        // Reload from the first file only — it should have ctx-a as stored but current-context = ctx-b
+        let reloadedFirst = try await sut.loadFromPaths([url1])
+        XCTAssertEqual(
+            reloadedFirst.currentContext, "ctx-b",
+            "First file should have updated current-context")
+    }
+
+    // MARK: - save: error on no paths
+
+    /// Verifies that saving a config with no paths throws an ioError.
+    func testSave_noPaths_throwsIOError() async throws {
+        let yaml = minimalYAML(context: "ctx", cluster: "cluster", server: "https://example.com")
+        let url = try temporaryFile(contents: yaml)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let config = try await sut.loadFromPaths([url])
+        // Simulate a config with no paths by removing path information.
+        // We model this by creating a KubeConfig with empty paths.
+        let emptyPathConfig = KubeConfig(
+            contexts: config.contexts,
+            currentContext: config.currentContext,
+            raw: config.raw,
+            paths: []
+        )
+
+        do {
+            try await sut.save(emptyPathConfig)
+            XCTFail("Expected ioError for empty paths")
+        } catch let error as CubeliteError {
+            if case .ioError = error {
+                // Expected
+            } else {
+                XCTFail("Expected CubeliteError.ioError, got: \(error)")
+            }
+        }
+    }
+
+    // MARK: - setActiveContext + save: idempotent
+
+    /// Switching to the already-active context and saving is a no-op in terms of outcome.
+    func testSetActiveContext_sameContext_thenSave_isIdempotent() async throws {
+        let yaml = minimalYAML(
+            context: "ctx-only", cluster: "cluster", server: "https://127.0.0.1:6443")
+        let url = try temporaryFile(contents: yaml)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var config = try await sut.loadFromPaths([url])
+        let originalCurrent = config.currentContext
+
+        try await sut.setActiveContext("ctx-only", in: &config)
+        try await sut.save(config)
+
+        let reloaded = try await sut.loadFromPaths([url])
+        XCTAssertEqual(reloaded.currentContext, originalCurrent)
+    }
+
+    // MARK: - Helpers
+
+    private func temporaryFile(contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cubelite-save-test-\(UUID().uuidString).yaml")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func minimalYAML(context: String, cluster: String, server: String) -> String {
+        """
+        apiVersion: v1
+        kind: Config
+        current-context: \(context)
+        contexts:
+        - name: \(context)
+          context:
+            cluster: \(cluster)
+            user: user-\(context)
+            namespace: default
+        clusters:
+        - name: \(cluster)
+          cluster:
+            server: \(server)
+        users:
+        - name: user-\(context)
+          user:
+            token: token-for-\(context)
+        """
+    }
+
+    private func twoContextYAML() -> String {
+        """
+        apiVersion: v1
+        kind: Config
+        current-context: ctx-a
+        contexts:
+        - name: ctx-a
+          context:
+            cluster: cluster-a
+            user: user-a
+        - name: ctx-b
+          context:
+            cluster: cluster-b
+            user: user-b
+        clusters:
+        - name: cluster-a
+          cluster:
+            server: https://k8s-test-a.example
+        - name: cluster-b
+          cluster:
+            server: https://k8s-test-b.example
+        users:
+        - name: user-a
+          user:
+            token: token-a
+        - name: user-b
+          user:
+            token: token-b
+        """
+    }
+}


### PR DESCRIPTION
## Summary

Enhance `KubeconfigService.resolveKubeconfigPaths()` to automatically scan `~/.kube/` for additional kubeconfig files beyond the default `~/.kube/config`.

Users with Rancher, EKS, or other tools that generate separate kubeconfig files (e.g. `~/.kube/kub3-dev`) no longer need to manually add each file path in Preferences.

## Changes

- `resolveKubeconfigPaths()` now scans `~/.kube/` for files with `kind: Config` YAML marker
- New `discoverKubeconfigFiles(in:excluding:)` private static method
- New `configure(paths:)` method for custom path overrides from Preferences
- Directories, hidden files, and non-kubeconfig files are skipped
- Discovered files sorted by filename for deterministic merge order
- Default `~/.kube/config` always first (current-context takes precedence)

## Tests

- 7 auto-discovery tests (merge, Rancher format, directory/file filtering, dedup)
- 6 save/round-trip tests for kubeconfig persistence

All 13 new tests pass. Existing tests unaffected.

Closes #88
