### PR TITLE
fix(macos): persist Skip TLS setting and invalidate session on toggle

### DIFF
--- a/apps/macos/cubelite/cubelite/CubeliteApp.swift
+++ b/apps/macos/cubelite/cubelite/CubeliteApp.swift
@@ -37,6 +37,12 @@ struct CubeliteApp: App {
                             await kubeAPIService.invalidateSession()
                         }
                     }
+                    .onChange(of: appSettings.skipTLSVerification) { _, newValue in
+                        // Defensive: persist explicitly in case @Observable didSet
+                        // does not fire for all binding paths.
+                        UserDefaults.standard.set(newValue, forKey: AppSettings.Keys.skipTLSVerification)
+                        Task { await kubeAPIService.invalidateSession() }
+                    }
                     .task {
                         applyNSAppearance(appSettings.appearanceMode)
                         let urls = appSettings.kubeconfigPaths.map { URL(fileURLWithPath: $0) }

--- a/apps/macos/cubelite/cubeliteTests/RBACResilienceTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/RBACResilienceTests.swift
@@ -240,3 +240,49 @@ final class AppSettingsContextNamespacesTests: XCTestCase {
         XCTAssertNil(reloaded.contextNamespaces["prod"])
     }
 }
+
+// MARK: - AppSettings Skip TLS Verification Persistence
+
+@MainActor
+final class AppSettingsSkipTLSTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: AppSettings.Keys.skipTLSVerification)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: AppSettings.Keys.skipTLSVerification)
+        super.tearDown()
+    }
+
+    func testSkipTLS_defaultIsFalse() {
+        let sut = AppSettings()
+        XCTAssertFalse(sut.skipTLSVerification)
+    }
+
+    func testSkipTLS_enablePersistsAcrossInstances() {
+        let sut = AppSettings()
+        sut.skipTLSVerification = true
+
+        let reloaded = AppSettings()
+        XCTAssertTrue(reloaded.skipTLSVerification, "skipTLSVerification must survive a fresh AppSettings init")
+    }
+
+    func testSkipTLS_disablePersistsAcrossInstances() {
+        let sut = AppSettings()
+        sut.skipTLSVerification = true
+        sut.skipTLSVerification = false
+
+        let reloaded = AppSettings()
+        XCTAssertFalse(reloaded.skipTLSVerification)
+    }
+
+    func testSkipTLS_userDefaultsRawValue_matchesProperty() {
+        let sut = AppSettings()
+        sut.skipTLSVerification = true
+
+        let raw = UserDefaults.standard.bool(forKey: AppSettings.Keys.skipTLSVerification)
+        XCTAssertTrue(raw, "UserDefaults must contain the updated value")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the **Skip TLS Verification** setting not surviving app restarts and not taking effect until a context switch.

## Changes

### `CubeliteApp.swift`
- Added `.onChange(of: appSettings.skipTLSVerification)` that:
  - Explicitly saves to `UserDefaults` (defensive, in case `@Observable` `didSet` does not fire for all binding paths)
  - Invalidates the cached `URLSession` so the new TLS delegate takes effect immediately

### `RBACResilienceTests.swift`
- Added `AppSettingsSkipTLSTests` (4 tests):
  - Default is `false`
  - Enable persists across `AppSettings` instances
  - Disable persists across instances
  - `UserDefaults` raw value matches property

## Testing

- All 4 new tests pass locally
- Full test suite passes (only pre-existing flaky keychain test fails intermittently)

Closes #93