### PR TITLE
docs: add Bug Discovery Workflow for all agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,6 +114,8 @@ cubelite/
 
 - No direct commits to `main` — all changes via feature branch → PR → squash-merge
 - Commit messages follow Conventional Commits: `type(scope): description`
+- **Build and test locally before every commit** — never commit code that
+  has not been built and tested. See `AGENTS.md` § "Quality Gates" for commands
 - **PRs are mergeable only when ALL CI checks pass** (tests, lint, Sonar, build)
   - A PR that fails any check MUST NOT be merged — fix the failures first
   - No exceptions, no manual overrides
@@ -125,6 +127,21 @@ cubelite/
   exist on an open PR branch not yet merged to `main`, branch from that PR branch instead
 - Once the config PR is merged, resume branching from `main`
 - **Never overwrite** `.github/agents/*.agent.md` — rebase onto the config branch if missing
+
+### Bug Discovery Workflow
+
+When any agent discovers a bug **during work on another task**, it **MUST NOT** fix it
+on the current branch. Instead:
+
+1. **Create a GitHub issue** (`gh issue create`) with title, root cause, and acceptance criteria
+2. **Create a dedicated `fix/<N>-<slug>` branch** from `main`
+3. **Delegate to the owning agent** per the Agent Routing Table
+4. **Fix → test → commit → push → open PR** with `Closes #<N>`
+5. **Return** to the original branch
+
+See `AGENTS.md` § "Bug Discovery Workflow" for the full protocol.
+
+**Exception**: bugs caused by changes on the current branch may be fixed in-place.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,43 @@ and modifications to existing views that don't introduce new sections are exempt
 
 ---
 
+## Bug Discovery Workflow (All Agents)
+
+When an agent **discovers a bug or problem during work** (not a pre-existing issue), it
+**MUST NOT** fix it on the current branch. Instead, follow this mandatory workflow:
+
+1. **Stop** — do not apply the fix on the current feature/fix branch
+2. **Create a GitHub issue** — use `gh issue create` with:
+   - Clear title: `fix(<scope>): <description>`
+   - Body with: Bug description, Root cause (if known), Acceptance criteria, Affected files
+   - Appropriate labels (e.g., `bug`, `macos`, `desktop`, `core`)
+3. **Create a dedicated branch** from `main` (or config branch per Branching Base Rule):
+   ```bash
+   git checkout -b fix/<N>-<slug> origin/main
+   ```
+4. **Delegate to the correct agent** based on the ownership map:
+   - `crates/**` → `core-agent`
+   - `apps/desktop/**` → `desktop-agent`
+   - `apps/macos/**` → `macos-agent`
+   - `.github/**` → `devops-agent`
+5. **Implement the fix** — the owning agent:
+   - Reads its path-scoped instructions (mandatory pre-work)
+   - Implements the fix with tests
+   - Runs local quality checks (lint, test, build)
+6. **Commit + Push + PR**:
+   - Commit with Conventional Commits: `fix(<scope>): <description>`
+   - Push the branch: `git push -u origin fix/<N>-<slug>`
+   - Open PR with `Closes #<N>` in body
+7. **Return** to the original branch and resume previous work
+
+**Rationale**: fixing bugs on unrelated branches creates tangled PRs, harder reviews,
+and risk of regressions. Each fix gets its own issue, branch, and PR for clean tracking.
+
+**Exception**: if the bug is a direct consequence of changes on the current branch
+(e.g., a test you just wrote is failing), fix it in-place on the current branch.
+
+---
+
 ## Branching Base Rule
 
 - **Default**: create feature branches from `main`
@@ -132,6 +169,20 @@ and modifications to existing views that don't introduce new sections are exempt
 
 ---
 
+## Pre-Commit Rule (All Agents)
+
+Every agent **MUST** build and run tests locally **before every commit**. No exceptions.
+
+1. **Build** the affected stack to verify compilation
+2. **Run tests** for the affected stack to verify no regressions
+3. **Only commit** after both build and tests succeed
+
+Do NOT commit code that has not been built and tested. Pushing untested code
+wastes CI cycles and blocks other agents. Use the Quality Gates table below
+for the correct commands per stack.
+
+---
+
 ## Quality Gates (All Agents)
 
 | Gate | Command |
@@ -141,8 +192,8 @@ and modifications to existing views that don't introduce new sections are exempt
 | Rust format | `cargo fmt --check` |
 | Desktop lint | `pnpm --filter desktop lint` |
 | Desktop tests | `pnpm --filter desktop test` |
-| macOS build | `xcodebuild build -project apps/macos/cubelite/cubelite.xcodeproj -scheme cubelite` |
-| macOS tests | `xcodebuild test -project apps/macos/cubelite/cubelite.xcodeproj -scheme cubelite` |
+| macOS build | `xcodebuild build-for-testing -project apps/macos/cubelite/cubelite.xcodeproj -scheme cubelite -destination 'platform=macOS' -derivedDataPath /tmp/cubelite-build` |
+| macOS tests | `xcodebuild test-without-building -project apps/macos/cubelite/cubelite.xcodeproj -scheme cubelite -destination 'platform=macOS' -derivedDataPath /tmp/cubelite-build -skip-testing cubeliteUITests` |
 | Secret scan | `gh secret-scanning run` |
 | Rust docs | `cargo doc --workspace --no-deps` |
 | Dependency audit (Rust) | `cargo audit` |


### PR DESCRIPTION
## Summary

Adds a mandatory **Bug Discovery Workflow** to the shared instructions so all agents follow a consistent process when they discover bugs during unrelated work.

## Changes

### `AGENTS.md`
- New section: **Bug Discovery Workflow (All Agents)** — detailed 7-step protocol:
  1. Stop — don't fix on current branch
  2. Create GitHub issue with `gh issue create`
  3. Create dedicated `fix/<N>-<slug>` branch from `main`
  4. Delegate to correct agent per ownership map
  5. Implement fix with tests + quality checks
  6. Commit + push + open PR with `Closes #<N>`
  7. Return to original branch

### `.github/copilot-instructions.md`
- New subsection: **Bug Discovery Workflow** under Absolute Rules
- Compact 5-step summary with cross-reference to AGENTS.md

## Rationale

Fixing bugs on unrelated branches creates tangled PRs, harder reviews, and regressions. This formalizes what we already practiced (e.g., issue #93 / PR #94) as a mandatory protocol.