### PR TITLE
fix(macos): replace invalid cloud.slash symbol and fix sidebar collapse constraints

### DIFF
--- a/apps/macos/cubelite/cubelite/Views/CrossClusterDashboardView.swift
+++ b/apps/macos/cubelite/cubelite/Views/CrossClusterDashboardView.swift
@@ -117,7 +117,7 @@ struct CrossClusterDashboardView: View {
 
     private var clusterEmptyState: some View {
         ContentUnavailableView {
-            Label("No Data", systemImage: "cloud.slash")
+            Label("No Data", systemImage: "icloud.slash")
         } description: {
             Text("Tap refresh to load cluster data.")
         }

--- a/apps/macos/cubelite/cubelite/Views/MainView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView.swift
@@ -87,9 +87,9 @@ struct MainView: View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             sidebar
                 .navigationSplitViewColumnWidth(
-                    min: isSidebarCollapsed ? 52 : 200,
+                    min: 52,
                     ideal: isSidebarCollapsed ? 52 : 240,
-                    max: isSidebarCollapsed ? 52 : 300
+                    max: isSidebarCollapsed ? 60 : 300
                 )
         } content: {
             resourceTypeList


### PR DESCRIPTION
## Summary

Fix two pre-existing UI bugs discovered during work on #93.

### Changes

1. **Invalid SF Symbol**: `cloud.slash` → `icloud.slash` in `CrossClusterDashboardView.swift`
2. **Constraint conflict**: `navigationSplitViewColumnWidth(min:)` kept at constant `52` instead of switching between 200/52 — prevents `width >= 200` vs `width <= 60` conflict on collapse

### Testing
- Build: `TEST BUILD SUCCEEDED`
- Tests: `TEST EXECUTE SUCCEEDED`

Closes #97