### PR TITLE
feat(macos): auto-reload kubeconfig via FSEvents

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/KubeconfigWatcher.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeconfigWatcher.swift
@@ -1,0 +1,300 @@
+import CoreServices
+import Foundation
+import os
+
+/// Watches kubeconfig file paths on disk via FSEvents and fires a callback
+/// when any change is detected.
+///
+/// Behavior:
+/// - Resolves watched paths from `$KUBECONFIG` (colon-separated), expanding
+///   tildes, falling back to `~/.kube/config`. Paths are de-duplicated.
+/// - Files that don't exist yet are still observed by watching their parent
+///   directory, so they get picked up on creation (e.g. `aws eks
+///   update-kubeconfig` creating `~/.kube/config` for the first time).
+/// - Coalesces rapid bursts of FSEvents through a 250 ms debounce so atomic
+///   editor writes / multi-step CLI updates trigger exactly one callback.
+/// - The FSEventStream callback is invoked from a private dispatch queue
+///   (FSEvents is C-threaded). The watcher hops onto the main actor before
+///   firing the user-supplied `onChange` closure so call sites can mutate
+///   `@MainActor` state safely.
+///
+/// Usage:
+/// ```swift
+/// let watcher = KubeconfigWatcher { [weak self] in
+///     await self?.reloadKubeconfig()
+/// }
+/// watcher.start(paths: KubeconfigWatcher.resolveWatchedPaths())
+/// // … later
+/// watcher.stop()
+/// ```
+final class KubeconfigWatcher: @unchecked Sendable {
+
+    // MARK: - Types
+
+    /// Async closure invoked on the main actor when a kubeconfig change is
+    /// detected (after debounce).
+    typealias ChangeHandler = @Sendable @MainActor () async -> Void
+
+    // MARK: - Constants
+
+    /// Quiescence window in seconds. Multiple FSEvents arriving within this
+    /// window collapse into a single `onChange` invocation.
+    static let debounceInterval: TimeInterval = 0.25
+
+    // MARK: - State
+
+    /// Lock guarding `stream` and `currentPaths`.
+    private let lock = NSLock()
+    private var stream: FSEventStreamRef?
+    private var currentPaths: [URL] = []
+    private let queue = DispatchQueue(label: "com.cubelite.kubeconfig-watcher", qos: .utility)
+    private let logger = Logger(subsystem: "com.cubelite", category: "KubeconfigWatcher")
+    private let onChange: ChangeHandler
+    private let debouncer: Debouncer
+
+    // MARK: - Init
+
+    /// Creates a watcher that calls `onChange` (on the main actor) whenever a
+    /// watched path or its parent directory reports a relevant FSEvent, after
+    /// debouncing.
+    init(
+        debounceInterval: TimeInterval = KubeconfigWatcher.debounceInterval,
+        onChange: @escaping ChangeHandler
+    ) {
+        self.onChange = onChange
+        self.debouncer = Debouncer(interval: debounceInterval)
+    }
+
+    deinit {
+        stopInternal()
+    }
+
+    // MARK: - Public API
+
+    /// Starts watching the supplied paths. Calling `start` while already
+    /// running stops the existing stream and replaces it with a new one
+    /// configured for the new paths. Passing an empty array stops the watcher
+    /// without starting a new stream.
+    func start(paths: [URL]) {
+        lock.lock()
+        defer { lock.unlock() }
+        stopInternal()
+        guard !paths.isEmpty else {
+            logger.debug("start(paths:) called with empty paths — watcher idle")
+            return
+        }
+        currentPaths = paths
+        let watchTargets = Self.expandToWatchTargets(paths)
+        guard !watchTargets.isEmpty else {
+            logger.warning("No usable watch targets resolved from paths: \(paths.map(\.path), privacy: .public)")
+            return
+        }
+        stream = Self.makeStream(
+            paths: watchTargets,
+            queue: queue,
+            owner: Unmanaged.passUnretained(self).toOpaque()
+        )
+        if let stream {
+            FSEventStreamStart(stream)
+            logger.info("Started watching \(watchTargets.count, privacy: .public) target(s) for \(paths.count, privacy: .public) kubeconfig path(s)")
+        } else {
+            logger.error("FSEventStreamCreate returned nil for paths: \(watchTargets, privacy: .public)")
+        }
+    }
+
+    /// Stops watching and cancels any pending debounced callback.
+    func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+        stopInternal()
+    }
+
+    /// Currently watched kubeconfig paths (the user-facing list, not the
+    /// expanded directory targets passed to FSEvents).
+    var watchedPaths: [URL] {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentPaths
+    }
+
+    // MARK: - Path Resolution
+
+    /// Resolves the set of kubeconfig paths to watch from the environment.
+    ///
+    /// Mirrors `kubectl` semantics:
+    /// 1. If `$KUBECONFIG` is set and non-empty, split on `:` and expand
+    ///    tildes. Empty entries are dropped.
+    /// 2. Otherwise fall back to `~/.kube/config`.
+    ///
+    /// Paths that resolve to the same standardized URL are de-duplicated
+    /// while preserving first-occurrence order.
+    static func resolveWatchedPaths(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = realHomeDirectory()
+    ) -> [URL] {
+        var raw: [String] = []
+        if let envValue = environment["KUBECONFIG"], !envValue.isEmpty {
+            raw = envValue.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
+        } else {
+            raw = [homeDirectory.appendingPathComponent(".kube/config").path]
+        }
+        var seen = Set<String>()
+        var result: [URL] = []
+        for entry in raw {
+            let trimmed = entry.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            let expanded = expandTilde(trimmed, home: homeDirectory)
+            let url = URL(fileURLWithPath: expanded).standardizedFileURL
+            if seen.insert(url.path).inserted {
+                result.append(url)
+            }
+        }
+        return result
+    }
+
+    /// Returns the user's real home directory, bypassing sandbox container
+    /// redirection. Mirrors the helper in `KubeconfigService`.
+    static func realHomeDirectory() -> URL {
+        if let pw = getpwuid(getuid()), let dir = pw.pointee.pw_dir {
+            return URL(fileURLWithPath: String(cString: dir))
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+    }
+
+    /// For each requested kubeconfig path, returns either the file itself
+    /// (when it exists) or its parent directory (so a not-yet-created file is
+    /// still picked up). Duplicates are removed.
+    static func expandToWatchTargets(_ paths: [URL]) -> [String] {
+        let fm = FileManager.default
+        var seen = Set<String>()
+        var targets: [String] = []
+        for url in paths {
+            let standardized = url.standardizedFileURL
+            let target: String
+            if fm.fileExists(atPath: standardized.path) {
+                target = standardized.path
+            } else {
+                target = standardized.deletingLastPathComponent().path
+            }
+            // FSEvents requires the path to exist; skip targets whose parent
+            // directory is also missing rather than silently failing.
+            guard fm.fileExists(atPath: target) else { continue }
+            if seen.insert(target).inserted {
+                targets.append(target)
+            }
+        }
+        return targets
+    }
+
+    // MARK: - Private
+
+    private static func expandTilde(_ path: String, home: URL) -> String {
+        guard path.hasPrefix("~") else { return path }
+        if path == "~" { return home.path }
+        if path.hasPrefix("~/") {
+            return home.appendingPathComponent(String(path.dropFirst(2))).path
+        }
+        // Other forms like ~user are not supported; return unchanged.
+        return path
+    }
+
+    /// Caller MUST hold `lock`.
+    private func stopInternal() {
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            self.stream = nil
+        }
+        debouncer.cancel()
+        currentPaths = []
+    }
+
+    private static func makeStream(
+        paths: [String],
+        queue: DispatchQueue,
+        owner: UnsafeMutableRawPointer
+    ) -> FSEventStreamRef? {
+        var context = FSEventStreamContext(
+            version: 0,
+            info: owner,
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+        let flags: FSEventStreamCreateFlags = UInt32(
+            kFSEventStreamCreateFlagFileEvents
+                | kFSEventStreamCreateFlagNoDefer
+                | kFSEventStreamCreateFlagUseCFTypes
+        )
+        let callback: FSEventStreamCallback = { _, info, numEvents, _, _, _ in
+            guard let info, numEvents > 0 else { return }
+            let watcher = Unmanaged<KubeconfigWatcher>.fromOpaque(info).takeUnretainedValue()
+            watcher.scheduleDebouncedFire()
+        }
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            callback,
+            &context,
+            paths as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.05,
+            flags
+        ) else {
+            return nil
+        }
+        FSEventStreamSetDispatchQueue(stream, queue)
+        return stream
+    }
+
+    /// Schedules a debounced fire. Called from the FSEvents dispatch queue.
+    private func scheduleDebouncedFire() {
+        let handler = self.onChange
+        let logger = self.logger
+        debouncer.schedule {
+            logger.debug("Debounce window elapsed; firing onChange")
+            Task { @MainActor in
+                await handler()
+            }
+        }
+    }
+}
+
+// MARK: - Debouncer
+
+/// Coalesces rapid bursts of events into a single fire after `interval`
+/// seconds of quiescence. Thread-safe.
+final class Debouncer: @unchecked Sendable {
+    private let interval: TimeInterval
+    private let queue: DispatchQueue
+    private let lock = NSLock()
+    private var pending: DispatchWorkItem?
+
+    init(
+        interval: TimeInterval,
+        queue: DispatchQueue = DispatchQueue(label: "com.cubelite.debouncer", qos: .utility)
+    ) {
+        self.interval = interval
+        self.queue = queue
+    }
+
+    /// Schedules `action` to run after `interval` seconds. Subsequent calls
+    /// before the deadline cancel the previous schedule and start a new one,
+    /// so only the most recent action fires.
+    func schedule(_ action: @escaping @Sendable () -> Void) {
+        lock.lock()
+        pending?.cancel()
+        let work = DispatchWorkItem(block: action)
+        pending = work
+        lock.unlock()
+        queue.asyncAfter(deadline: .now() + interval, execute: work)
+    }
+
+    /// Cancels any pending action.
+    func cancel() {
+        lock.lock()
+        pending?.cancel()
+        pending = nil
+        lock.unlock()
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MainView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView.swift
@@ -30,6 +30,7 @@ struct MainView: View {
 
     @Environment(ClusterState.self) private var clusterState
     @Environment(LogStore.self) private var logStore
+    @Environment(AppSettings.self) private var appSettings
 
     // MARK: - Navigation State
 
@@ -81,6 +82,13 @@ struct MainView: View {
     /// Row ID of the selected Helm release.
     @State private var selectedHelmReleaseID: HelmReleaseInfo.ID?
 
+    // MARK: - Auto-Reload
+
+    /// Box holding the FSEvents-based kubeconfig watcher. Wrapped in a class
+    /// so the `@State` value is stable across view re-evaluations and the
+    /// watcher's `start`/`stop` lifecycle ties to view appearance.
+    @State private var watcherBox = WatcherBox()
+
     // MARK: - Body
 
     var body: some View {
@@ -108,6 +116,8 @@ struct MainView: View {
                 .environment(logStore)
         }
         .task { await loadKubeconfig() }
+        .task(id: appSettings.kubeconfigPaths) { startKubeconfigWatcher() }
+        .onDisappear { watcherBox.watcher?.stop() }
         .onChange(of: selectedContext) { _, newValue in
             // Only exit All Clusters mode when selecting a specific context.
             // When All Clusters sets selectedContext = nil, preserve showAllClusters.
@@ -821,6 +831,58 @@ struct MainView: View {
         }
     }
 
+    // MARK: - Auto-Reload Wiring
+
+    /// Starts (or restarts) the kubeconfig file watcher. Called from a
+    /// `.task(id:)` so it re-runs whenever the user-configured kubeconfig
+    /// path list changes.
+    ///
+    /// On any debounced change event the watcher reloads the kubeconfig and
+    /// records an info-severity log entry so the change surfaces in the
+    /// existing logs view without introducing a new toast subsystem.
+    @MainActor
+    private func startKubeconfigWatcher() {
+        watcherBox.watcher?.stop()
+        let watcher = KubeconfigWatcher { [logStore] in
+            await reloadAfterFileChange(logStore: logStore)
+        }
+        watcherBox.watcher = watcher
+        let resolved = resolvePathsToWatch()
+        watcher.start(paths: resolved)
+    }
+
+    /// Resolves the set of paths to watch. Custom paths from `AppSettings`
+    /// take precedence over `$KUBECONFIG` / `~/.kube/config` discovery, to
+    /// stay in sync with `KubeconfigService.configure(paths:)`.
+    @MainActor
+    private func resolvePathsToWatch() -> [URL] {
+        let custom = appSettings.kubeconfigPaths
+        if !custom.isEmpty {
+            return custom.map { URL(fileURLWithPath: $0).standardizedFileURL }
+        }
+        return KubeconfigWatcher.resolveWatchedPaths()
+    }
+
+    /// Reloads the kubeconfig and the active context's resources after the
+    /// watcher detects an on-disk change. Logs the event to `LogStore`.
+    @MainActor
+    private func reloadAfterFileChange(logStore: LogStore) async {
+        logStore.append(
+            LogEntry(
+                severity: .info,
+                source: "Config",
+                message: "Kubeconfig updated on disk — reloading"
+            )
+        )
+        await loadKubeconfig()
+        if let context = selectedContext {
+            await loadNamespaces(for: context)
+        }
+        if let sel = sidebarSelection {
+            await loadResources(context: sel.context, namespace: sel.namespace)
+        }
+    }
+
     /// Looks up the default namespace for a context from the kubeconfig.
     ///
     /// Returns `nil` if the context has no namespace set, allowing cluster-scope queries.
@@ -1113,6 +1175,7 @@ struct MainView: View {
     return MainView(kubeconfigService: ks, kubeAPIService: KubeAPIService(kubeconfigService: ks))
         .environment(state)
         .environment(LogStore())
+        .environment(AppSettings())
 }
 
 #Preview("No kubeconfig") {
@@ -1122,4 +1185,15 @@ struct MainView: View {
     return MainView(kubeconfigService: ks, kubeAPIService: KubeAPIService(kubeconfigService: ks))
         .environment(state)
         .environment(LogStore())
+        .environment(AppSettings())
+}
+
+// MARK: - Watcher Box
+
+/// Reference-typed wrapper around `KubeconfigWatcher` so it can be stored in
+/// `@State` without being copied. Holding the watcher in a class also lets the
+/// FSEvents stream live across SwiftUI body re-evaluations.
+@MainActor
+final class WatcherBox {
+    var watcher: KubeconfigWatcher?
 }

--- a/apps/macos/cubelite/cubeliteTests/KubeconfigWatcherTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/KubeconfigWatcherTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+
+@testable import cubelite
+
+// MARK: - Kubeconfig Watcher Tests
+//
+// Covers:
+// - Path resolver: tilde expansion, $KUBECONFIG parsing, deduplication
+// - Debouncer: bursts collapse into a single fire after the quiescence window
+// - Integration: writing to a temp file fires the reload callback within 2 s
+
+final class KubeconfigWatcherTests: XCTestCase {
+
+    // MARK: - Path Resolver
+
+    func testResolveWatchedPaths_defaultsToHomeKubeConfig_whenEnvUnset() {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let paths = KubeconfigWatcher.resolveWatchedPaths(
+            environment: [:],
+            homeDirectory: home
+        )
+        XCTAssertEqual(paths.map(\.path), ["/Users/test/.kube/config"])
+    }
+
+    func testResolveWatchedPaths_parsesColonSeparatedKUBECONFIG() {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let paths = KubeconfigWatcher.resolveWatchedPaths(
+            environment: ["KUBECONFIG": "/etc/kube/a:/etc/kube/b:/etc/kube/c"],
+            homeDirectory: home
+        )
+        XCTAssertEqual(paths.map(\.path), [
+            "/etc/kube/a",
+            "/etc/kube/b",
+            "/etc/kube/c",
+        ])
+    }
+
+    func testResolveWatchedPaths_expandsTilde() {
+        let home = URL(fileURLWithPath: "/Users/alice")
+        let paths = KubeconfigWatcher.resolveWatchedPaths(
+            environment: ["KUBECONFIG": "~/.kube/config:~/work/k8s.yaml"],
+            homeDirectory: home
+        )
+        XCTAssertEqual(paths.map(\.path), [
+            "/Users/alice/.kube/config",
+            "/Users/alice/work/k8s.yaml",
+        ])
+    }
+
+    func testResolveWatchedPaths_dropsEmptyEntriesAndDuplicates() {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let paths = KubeconfigWatcher.resolveWatchedPaths(
+            environment: ["KUBECONFIG": "/a::/a:/b:"],
+            homeDirectory: home
+        )
+        XCTAssertEqual(paths.map(\.path), ["/a", "/b"])
+    }
+
+    func testExpandToWatchTargets_filtersMissingFilesUpToParentDirectory() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(
+            "watcher-targets-\(UUID().uuidString)"
+        )
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+
+        let existing = tempDir.appendingPathComponent("config")
+        try Data("apiVersion: v1\nkind: Config\n".utf8).write(to: existing)
+
+        let missing = tempDir.appendingPathComponent("future-config")
+        let parentMissing = URL(fileURLWithPath: "/no/such/dir/at/all/cfg")
+
+        let targets = KubeconfigWatcher.expandToWatchTargets([existing, missing, parentMissing])
+
+        XCTAssertTrue(targets.contains(existing.path))
+        XCTAssertTrue(targets.contains(tempDir.path))
+        XCTAssertFalse(targets.contains(parentMissing.path))
+        XCTAssertFalse(targets.contains(parentMissing.deletingLastPathComponent().path))
+    }
+
+    // MARK: - Debouncer
+
+    func testDebouncer_collapsesFiveRapidEventsIntoOneFire() {
+        let debouncer = Debouncer(interval: 0.25)
+        let expectation = expectation(description: "debounced fire")
+        let counter = AtomicCounter()
+
+        for _ in 0..<5 {
+            debouncer.schedule {
+                counter.increment()
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+        // Wait a little more to ensure no extra fires arrive after the first.
+        let extra = XCTestExpectation(description: "no extra fires")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) { extra.fulfill() }
+        wait(for: [extra], timeout: 1.0)
+
+        XCTAssertEqual(counter.value, 1, "Debouncer must collapse rapid events into a single fire")
+    }
+
+    func testDebouncer_cancelPreventsFire() {
+        let debouncer = Debouncer(interval: 0.10)
+        let counter = AtomicCounter()
+        debouncer.schedule { counter.increment() }
+        debouncer.cancel()
+
+        let waited = XCTestExpectation(description: "cancel window")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) { waited.fulfill() }
+        wait(for: [waited], timeout: 1.0)
+
+        XCTAssertEqual(counter.value, 0)
+    }
+
+    // MARK: - Integration: FSEvents fires on file write
+
+    @MainActor
+    func testWatcher_firesCallbackWhenWatchedFileIsWritten() async throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent(
+            "watcher-int-\(UUID().uuidString)"
+        )
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+
+        let configPath = tempDir.appendingPathComponent("config")
+        try Data("apiVersion: v1\nkind: Config\ncontexts: []\n".utf8).write(to: configPath)
+
+        let expectation = expectation(description: "watcher reload callback fires")
+        expectation.assertForOverFulfill = false
+
+        let watcher = KubeconfigWatcher(debounceInterval: 0.20) {
+            expectation.fulfill()
+        }
+        watcher.start(paths: [configPath])
+        defer { watcher.stop() }
+
+        // Give FSEvents a moment to attach before the first write.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Atomic write — mimics editors and `kubectl config use-context`.
+        try Data("apiVersion: v1\nkind: Config\ncontexts: []\n# updated\n".utf8)
+            .write(to: configPath, options: .atomic)
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+}
+
+// MARK: - Helpers
+
+/// Tiny lock-protected counter so multiple debouncer fires (if any) are seen.
+private final class AtomicCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+    func increment() {
+        lock.lock(); defer { lock.unlock() }
+        _value += 1
+    }
+}


### PR DESCRIPTION
Closes #119

## Summary

Adds **`KubeconfigWatcher`**, an FSEvents-based service that observes the user's kubeconfig file(s) on disk and triggers an in-app reload when the contents change — no more manual reload after `kubectl config use-context`, manual edits, `aws eks update-kubeconfig`, or `gcloud container clusters get-credentials`.

## How FSEvents is wired

- Uses `FSEventStreamCreate` (not `DispatchSource.makeFileSystemObjectSource`) so atomic-write/rename patterns from editors and CLI tools are caught reliably.
- Stream flags: `kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagUseCFTypes`.
- Stream is dispatched onto a private utility queue.
- The C-threaded callback bridges to `@MainActor` via `Task { @MainActor in await handler() }` so call sites can mutate `@Observable @MainActor` state safely.
- Lifecycle: started from a SwiftUI `.task(id: appSettings.kubeconfigPaths)` in `MainView` (re-runs whenever the user-configured path list changes), stopped on `.onDisappear` and in the watcher's `deinit`. The stream is also stopped + invalidated + released on every `start(paths:)` call so reconfigurations don't leak.

## How `$KUBECONFIG` is parsed

`KubeconfigWatcher.resolveWatchedPaths(environment:homeDirectory:)`:

1. If `$KUBECONFIG` is set and non-empty, splits on `:`, drops empty entries, expands leading `~` against the real home directory.
2. Otherwise falls back to `~/.kube/config`.
3. De-duplicates by standardized path while preserving first-occurrence order.

`MainView` prefers the user-configured paths from `AppSettings.kubeconfigPaths` when non-empty (matching the precedence rule already used by `KubeconfigService.configure(paths:)`), and falls back to the resolver otherwise.

For paths that don't exist yet, `expandToWatchTargets` substitutes the parent directory so the file is picked up on creation (e.g. first-time `aws eks update-kubeconfig`).

## How debouncing works

Extracted into a small standalone `Debouncer` type for testability:

- Each `schedule(_:)` call cancels any previously pending `DispatchWorkItem` and posts a new one with a `now() + interval` deadline (default `0.25 s`).
- Therefore N rapid events within the quiescence window collapse into exactly **one** fire, after the last event + 250 ms.
- `cancel()` discards any pending work item; called from `stop()` and `deinit`.

## Test approach

`KubeconfigWatcherTests` — 8 new XCTests:

| Test | Coverage |
|---|---|
| `testResolveWatchedPaths_defaultsToHomeKubeConfig_whenEnvUnset` | fallback path |
| `testResolveWatchedPaths_parsesColonSeparatedKUBECONFIG` | env parse |
| `testResolveWatchedPaths_expandsTilde` | `~/` expansion |
| `testResolveWatchedPaths_dropsEmptyEntriesAndDuplicates` | hygiene |
| `testExpandToWatchTargets_filtersMissingFilesUpToParentDirectory` | parent-dir fallback + missing-parent skip |
| `testDebouncer_collapsesFiveRapidEventsIntoOneFire` | 5 events → 1 fire after 250 ms |
| `testDebouncer_cancelPreventsFire` | `cancel()` semantics |
| `testWatcher_firesCallbackWhenWatchedFileIsWritten` (`@MainActor`) | end-to-end FSEvents → callback within 2 s |

No new UITests — issue's UI surface is minimal (it reuses the existing `LogStore`-backed log view to surface the reload notification).

## UI surface

Per the issue: no new toast/banner subsystem in this PR. Reloads are appended to the existing `LogStore` as an info entry (`source: "Config"`, message: *"Kubeconfig updated on disk — reloading"*) and additionally logged via `os.Logger` (`subsystem: "com.cubelite", category: "KubeconfigWatcher"`). A dedicated banner can be added in a follow-up if desired.

## Quality gates (local)

```
xcodebuild build-for-testing … cubelite … → ** TEST BUILD SUCCEEDED **
xcodebuild test-without-building … -skip-testing cubeliteUITests
  → 351 passed, 0 failed (exit 0); +8 tests vs main
```
