### PR TITLE
fix(design): P2-01 — add visible border to kit-checkbox-unchecked-dark

### DIFF
--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -449,7 +449,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 
 | ID | Board/Componente | Problema | Azione |
 |---|---|---|---|
-| P2-01 | kit-checkbox-unchecked-dark | Manca border element (presente in light) | Aggiungere `box-border` rect 1pt stroke |
+| P2-01 | kit-checkbox-unchecked-dark | Manca border element (presente in light) | Aggiungere `box-border` rect 1pt stroke — ✅ Risolto (#163) — `kit-cb-border-d` convertito da rect filled a 1pt inner stroke `#48484A` (Apple separator dark), border-radius 4pt |
 | P2-02 | MainView – Empty/Error/No Config/Select NS (Dark) | Titlebar bg #242424 (non standard vs kit #2c2c2e) | Uniformare a #2c2c2e |
 | P2-03 | MainView – Empty/Error/No Config/Select NS (Dark) | Toolbar bg #2d2d2d (non documentato nel kit) | Definire valore standard e uniformare |
 | P2-04 | Logs & Errors Panel – Light | `r6-sb` con ry=6008 — bug posizionamento | Correggere coordinata y |


### PR DESCRIPTION
## Summary
Resolves P2-01 from the macOS HIG audit.

Converted `kit-cb-border-d` (in States & Components > `kit-checkbox-unchecked-dark`) from a filled rectangle (which fully overlaid the bg and was therefore invisible) into a 1pt **inner stroke** using Apple separator dark `#48484A`, with border-radius 4pt.

Light variant already had a working border element — this restores parity.

## Acceptance
- [x] Penpot board `kit-checkbox-unchecked-dark` contains `box-border` element with visible stroke
- [x] `docs/hig-review-report.md` § P2-01 marked ✅ Risolto with PR link

Closes #163