### PR TITLE
fix(design): P2-03 — standardize MainView Dark toolbar to #2C2C2E

### DIFF
--- a/docs/cubelite-macos-design-instructions.md
+++ b/docs/cubelite-macos-design-instructions.md
@@ -72,6 +72,20 @@ delle Apple Human Interface Guidelines (Foundations, Components, Patterns, Input
 - **Non fissare** il colore delle icone sidebar — usare il colore accent dell'utente
 - Azione distruttiva: stile **destructive** (rosso), ma solo per azioni non intenzionali
 
+### Cromia Window Chrome (CubeLite)
+
+Riferimento per i mockup Penpot e l'allineamento con i kit `kit-titlebar-*`. macOS Sonoma adotta una **toolbar unificata** con titlebar dello stesso colore (no separazione visiva).
+
+| Elemento | Light | Dark | Note |
+|---|---|---|---|
+| Titlebar bg | `#E8E8E8` | `#2C2C2E` | `kit-titlebar-light` / `kit-titlebar-dark` |
+| Toolbar bg | `#E8E8E8` | `#2C2C2E` | **Parità con titlebar** (unified toolbar HIG) — applicato a tutte le `MainView – */Dark` board |
+| Window bg | `#FFFFFF` | `#1C1C1E` | Contenuto principale |
+| Sidebar bg (Dark) | — | `#252528` | `kit-statusbar-dark` |
+| Traffic light close | `#FF5F57` | `#FF5F57` | |
+| Traffic light min | `#FEBC2E` | `#FEBC2E` | |
+| Traffic light max | `#28C840` | `#28C840` | |
+
 ### Dark Mode
 
 - Rispettare la scelta di sistema — **mai offrire impostazione app-specifica** per aspetto

--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -451,7 +451,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 |---|---|---|---|
 | P2-01 | kit-checkbox-unchecked-dark | Manca border element (presente in light) | Aggiungere `box-border` rect 1pt stroke — ✅ Risolto (#163) — `kit-cb-border-d` convertito da rect filled a 1pt inner stroke `#48484A` (Apple separator dark), border-radius 4pt |
 | P2-02 | MainView – Empty/Error/No Config/Select NS (Dark) | Titlebar bg #242424 (non standard vs kit #2c2c2e) | Uniformare a #2c2c2e — ✅ Risolto (#164) — verificato che `titlebar-bg` di tutte e 4 le board MainView Dark è già `#2c2c2e` (allineato a `kit-titlebar-dark`); nessuna modifica Penpot necessaria, doc aggiornata per tracciamento |
-| P2-03 | MainView – Empty/Error/No Config/Select NS (Dark) | Toolbar bg #2d2d2d (non documentato nel kit) | Definire valore standard e uniformare |
+| P2-03 | MainView – Empty/Error/No Config/Select NS (Dark) | Toolbar bg #2d2d2d (non documentato nel kit) | Definire valore standard e uniformare — ✅ Risolto (#165) — `toolbar-bg` di tutte e 4 le board MainView Dark portato a `#2C2C2E` (parità titlebar, unified toolbar Sonoma); valore documentato in `docs/cubelite-macos-design-instructions.md` § "Cromia Window Chrome" |
 | P2-04 | Logs & Errors Panel – Light | `r6-sb` con ry=6008 — bug posizionamento | Correggere coordinata y |
 | P2-05 | Logs & Errors Panel – Light | Elementi titlebar duplicati | Rimuovere duplicati |
 | P2-06 | macOS – Namespace View Light/Dark | Ordine colonne tabella diverso tra Light e Dark | Allineare schema colonne tra varianti |


### PR DESCRIPTION
## Summary
Resolves P2-03 from the macOS HIG audit.

**Decision**: Adopted **unified toolbar** color (titlebar parity) per macOS Sonoma HIG. All four MainView Dark boards now use `toolbar-bg = #2C2C2E`, matching `titlebar-bg` (= `kit-titlebar-dark`).

**Rationale**: macOS Sonoma window chrome merges titlebar + toolbar visually with the same color. The previous `#323232` was undocumented and ~3pt lighter than the titlebar, creating an unintended seam. Choosing `#1C1C1E` (window-bg parity, "depth" effect) was rejected because it would push the toolbar too dark and increase contrast with the titlebar instead of unifying.

**Audit reading correction**: The audit report listed the previous color as `#2d2d2d`; MCP probe showed it was actually `#323232`. Either way, non-standard.

**Reviewer note**: This is the design decision flagged in the M5.1 dispatch — happy to switch to `#1C1C1E` if you prefer the explicit titlebar/toolbar separation.

## Acceptance
- [x] All 4 MainView Dark boards use the same `toolbar-bg` standard (`#2C2C2E`)
- [x] Value documented in `docs/cubelite-macos-design-instructions.md` (table § "Cromia Window Chrome")
- [x] `docs/hig-review-report.md` § P2-03 marked ✅ Risolto with PR link

Closes #165