### PR TITLE
fix(design): P2-07 — uniform Namespace badge corner radius (r:9 pill)

### DIFF
--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -455,7 +455,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 | P2-04 | Logs & Errors Panel – Light | `r6-sb` con ry=6008 — bug posizionamento | Correggere coordinata y |
 | P2-05 | Logs & Errors Panel – Light | Elementi titlebar duplicati | Rimuovere duplicati |
 | P2-06 | macOS – Namespace View Light/Dark | Ordine colonne tabella diverso tra Light e Dark | Allineare schema colonne tra varianti |
-| P2-07 | macOS – Namespace View Light/Dark | Badge radius r:9 (Light) vs r:4 (Dark) | Uniformare |
+| P2-07 | macOS – Namespace View Light/Dark | Badge radius r:9 (Light) vs r:4 (Dark) | Uniformare — ✅ Risolto (#166) — `all-ns-badge-bg` portato a `r:9` su entrambe le varianti (pill style su altezza 18pt). Probe MCP ha mostrato che entrambi erano in realtà `r:4`; ora entrambi `r:9` |
 | P2-08 | macOS – Namespace View / Deployment Detail (Light) | Titlebar bg #e0e0e0 invece di standard #e8e8e8; traffic light colors diversi | Uniformare al kit standard |
 | P2-09 | Altezza titlebar | 28pt in Namespace/Preferences/Deployment vs 32pt in MainView | Definire altezza standard per ogni tipo di finestra e documentarla |
 | P2-10 | Preferences Advanced (TLS) | Input height 24pt invece di 28pt standard | Portare a 28pt |


### PR DESCRIPTION
## Summary
Resolves P2-07.

Set `borderRadius = 9` on `all-ns-badge-bg` in both `macOS - Namespace View – Light` and `– Dark`. With badge height 18pt, r:9 produces the canonical macOS pill badge.

**Audit reading correction**: Both variants were `r:4` (not r:9 vs r:4 as the audit suggested). Either way the goal — matching pill radius — is now satisfied.

## Acceptance
- [x] `all-ns-badge-bg` with `r:9` in Light and Dark
- [x] `docs/hig-review-report.md` § P2-07 marked ✅ Risolto with PR link

Closes #166