### PR TITLE
fix(design): P2-08 — verify Namespace/Deployment Light titlebar already aligned

### DIFF
--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -456,7 +456,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 | P2-05 | Logs & Errors Panel – Light | Elementi titlebar duplicati | Rimuovere duplicati |
 | P2-06 | macOS – Namespace View Light/Dark | Ordine colonne tabella diverso tra Light e Dark | Allineare schema colonne tra varianti |
 | P2-07 | macOS – Namespace View Light/Dark | Badge radius r:9 (Light) vs r:4 (Dark) | Uniformare — ✅ Risolto (#166) — `all-ns-badge-bg` portato a `r:9` su entrambe le varianti (pill style su altezza 18pt). Probe MCP ha mostrato che entrambi erano in realtà `r:4`; ora entrambi `r:9` |
-| P2-08 | macOS – Namespace View / Deployment Detail (Light) | Titlebar bg #e0e0e0 invece di standard #e8e8e8; traffic light colors diversi | Uniformare al kit standard |
+| P2-08 | macOS – Namespace View / Deployment Detail (Light) | Titlebar bg #e0e0e0 invece di standard #e8e8e8; traffic light colors diversi | Uniformare al kit standard — ✅ Risolto (#167) — verificato via MCP: entrambe le board hanno già `titlebar-bg #e8e8e8` e traffic lights `#ff5f57 / #febc2e / #28c840` (allineati al kit). Rilevato in PR precedenti (#143, #151); doc aggiornata per tracciamento |
 | P2-09 | Altezza titlebar | 28pt in Namespace/Preferences/Deployment vs 32pt in MainView | Definire altezza standard per ogni tipo di finestra e documentarla |
 | P2-10 | Preferences Advanced (TLS) | Input height 24pt invece di 28pt standard | Portare a 28pt |
 | P2-11 | Resource Browser | Icon colors sidebar non standard (#5856d6/#5e5ce6 purple, #ff6b00 orange, #0070c9/#0096ff blue) | Sostituire con Apple system colors |


### PR DESCRIPTION
## Summary
Resolves P2-08.

**Finding** (MCP probe): both `macOS - Namespace View – Light` and `macOS - Deployment Detail – Light` already match the kit-standard window chrome:

| Element | Expected | Actual |
|---|---|---|
| `titlebar-bg` | `#e8e8e8` | `#e8e8e8` ✅ |
| `tl-close` / `tl-c` | `#ff5f57` | `#ff5f57` ✅ |
| `tl-min` / `tl-m` | `#febc2e` | `#febc2e` ✅ |
| `tl-max` / `tl-x` | `#28c840` | `#28c840` ✅ |

Likely already corrected by prior PRs #143 (Deployment Detail Light HIG normalization) and #151. Documentation-only update marking the row ✅ Risolto with verification evidence.

## Acceptance
- [x] Namespace Light + Deployment Detail Light use titlebar `#e8e8e8`
- [x] Traffic lights aligned to kit standard (`#ff5f57`/`#febc2e`/`#28c840`)
- [x] `docs/hig-review-report.md` § P2-08 marked ✅ Risolto with PR link

Closes #167