### PR TITLE
fix(design): P2-11 — document Resource Browser sidebar icon → Apple color map

### DIFF
--- a/docs/cubelite-macos-design-instructions.md
+++ b/docs/cubelite-macos-design-instructions.md
@@ -94,6 +94,21 @@ Riferimento per i mockup Penpot e l'allineamento con i kit `kit-titlebar-*`. mac
 - **Desktop tinting**: aggiungere trasparenza ai background custom di componenti neutrali, così si armonizzano con lo sfondo del desktop
 - Non aggiungere trasparenza quando il componente usa colore (evita fluttuazioni)
 
+### Mappatura Icone Sidebar Resource Browser
+
+Le icone sidebar della **Resource Browser** usano colori semantici Apple system con varianti light/dark coerenti. Il raggruppamento riflette i domini Kubernetes:
+
+| Gruppo | Risorse | Light | Dark | Apple |
+|---|---|---|---|---|
+| Workloads | pods, deployments, jobs, cronjobs | `#007AFF` | `#0A84FF` | `systemBlue` |
+| Networking | services, ingress | `#AF52DE` | `#BF5AF2` | `systemPurple` |
+| Config | configmaps, secrets | `#FF9500` | `#FF9F0A` | `systemOrange` |
+| Storage | pvc | `#34C759` | `#30D158` | `systemGreen` |
+| Cluster | nodes | `#FF9500` | `#FF9F0A` | `systemOrange` |
+| Helm | helm-releases, helm-charts | `#007AFF` | `#0A84FF` | `systemBlue` |
+
+> Nota HIG: Apple raccomanda generalmente di rispettare l'`accentColor` utente per le icone sidebar. Per le **icone "categoria"** di una resource browser è ammesso fissare colori semantici purché provengano dalla palette system, in modo che il cambio di tema light/dark sia automatico e il contrasto resti garantito.
+
 ---
 
 ## 3. Dimensioni e Spaziatura

--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -459,7 +459,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 | P2-08 | macOS – Namespace View / Deployment Detail (Light) | Titlebar bg #e0e0e0 invece di standard #e8e8e8; traffic light colors diversi | Uniformare al kit standard — ✅ Risolto (#167) — verificato via MCP: entrambe le board hanno già `titlebar-bg #e8e8e8` e traffic lights `#ff5f57 / #febc2e / #28c840` (allineati al kit). Rilevato in PR precedenti (#143, #151); doc aggiornata per tracciamento |
 | P2-09 | Altezza titlebar | 28pt in Namespace/Preferences/Deployment vs 32pt in MainView | Definire altezza standard per ogni tipo di finestra e documentarla |
 | P2-10 | Preferences Advanced (TLS) | Input height 24pt invece di 28pt standard | Portare a 28pt |
-| P2-11 | Resource Browser | Icon colors sidebar non standard (#5856d6/#5e5ce6 purple, #ff6b00 orange, #0070c9/#0096ff blue) | Sostituire con Apple system colors |
+| P2-11 | Resource Browser | Icon colors sidebar non standard (#5856d6/#5e5ce6 purple, #ff6b00 orange, #0070c9/#0096ff blue) | Sostituire con Apple system colors — ✅ Risolto (#168) — verificato via MCP: tutte le 12 icone sidebar `icon-*` (Light + Dark) usano già colori Apple system (`systemBlue/Purple/Orange/Green` con varianti light/dark). Mappatura icona→colore documentata in `docs/cubelite-macos-design-instructions.md` § "Mappatura Icone Sidebar Resource Browser" |
 | P2-12 | cubelite-icon board | `icon-image` rect ha fill `undefined` | Collegare risorsa immagine |
 
 ---


### PR DESCRIPTION
## Summary
Resolves P2-11.

**MCP probe**: every `icon-*` ellipse in both `Resource Browser – Light` and `– Dark` already uses an Apple system color with the appropriate light/dark variant. The audit row referenced legacy colors (`#5856d6`, `#ff6b00`, `#0070c9` / `#0096ff`) that no longer appear in either board — likely fixed by a prior board cleanup PR.

**Action**: documentation only. Added the canonical icon → color mapping to `docs/cubelite-macos-design-instructions.md` so future contributions stay within the HIG-approved palette.

| Gruppo | Risorse | Light | Dark | Apple |
|---|---|---|---|---|
| Workloads | pods, deployments, jobs, cronjobs | `#007AFF` | `#0A84FF` | `systemBlue` |
| Networking | services, ingress | `#AF52DE` | `#BF5AF2` | `systemPurple` |
| Config | configmaps, secrets | `#FF9500` | `#FF9F0A` | `systemOrange` |
| Storage | pvc | `#34C759` | `#30D158` | `systemGreen` |
| Cluster | nodes | `#FF9500` | `#FF9F0A` | `systemOrange` |
| Helm | helm-releases, helm-charts | `#007AFF` | `#0A84FF` | `systemBlue` |

## Acceptance
- [x] All Resource Browser sidebar icons use Apple system colors (Light & Dark)
- [x] Icon → color mapping documented in `docs/cubelite-macos-design-instructions.md`
- [x] `docs/hig-review-report.md` § P2-11 marked ✅ Risolto with PR link

## Note for reviewer
This PR and #171 (P2-03) both touch `docs/cubelite-macos-design-instructions.md`, but in disjoint sections (#171 inserts after `### Colore Accent`, this PR inserts after `### Dark Mode`) so they should not conflict. If GitHub still flags a conflict, retarget the second-merged PR to the merged-main snapshot before merging.

Closes #168