### PR TITLE
fix(design): P2-09 — uniform MainView titlebar height to 28pt

### DIFF
--- a/docs/cubelite-macos-design-instructions.md
+++ b/docs/cubelite-macos-design-instructions.md
@@ -86,6 +86,29 @@ Riferimento per i mockup Penpot e l'allineamento con i kit `kit-titlebar-*`. mac
 | Traffic light min | `#FEBC2E` | `#FEBC2E` | |
 | Traffic light max | `#28C840` | `#28C840` | |
 
+### Titlebar Height (CubeLite)
+
+Altezza canonica **28pt** per la titlebar di tutte le finestre principali, dialog e panel. Allineata a `kit-titlebar-light/dark` (h=30pt nel kit, 28pt nelle istanze applicative — il kit include 2pt di margine visivo del board).
+
+| Tipo finestra | Titlebar | Toolbar (se presente) | Totale chrome |
+|---|---|---|---|
+| MainView (con toolbar unificata) | `28pt` | `44pt` | `72pt` |
+| Preferences (panel) | `28pt` | `52pt` (tabbar) | `80pt` |
+| Namespace View / Deployment Detail | `28pt` | — (toolbar inline) | `28pt` |
+| Logs & Errors Panel | `28pt`* | — | `28pt`* |
+| First Launch | `28pt` | — | `28pt` |
+
+\* La board `Logs & Errors Panel – Light` ha `titlebar-bg h=32pt` come residuo storico; `– Dark` è già a `28pt`. Allineamento futuro tracciato (non bloccante).
+
+**Centratura traffic lights**: i tre cerchi 12×12pt sono centrati verticalmente nella titlebar:
+- Per `h=28`: `y = (28 − 12) / 2 = 8pt` dal top della titlebar
+- Per `h=32` (legacy): `y = 10pt`
+
+**Centratura titolo**: testo titolo ~15pt di altezza, centrato:
+- Per `h=28`: `y ≈ (28 − 15) / 2 = 6.5pt` → `7pt` dal top
+
+> Convenzione: ogni nuova board macOS deve usare `h=28pt` per la titlebar. Eccezioni richiedono giustificazione esplicita nel design review.
+
 ### Dark Mode
 
 - Rispettare la scelta di sistema — **mai offrire impostazione app-specifica** per aspetto

--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -226,7 +226,7 @@ Questi quattro board rappresentano un prototipo precedente di stile web/Tailwind
 
 ### 2.2 MainView – Empty – Light / – Dark (1200×700) ⚠️
 
-**Titlebar**: 32pt ✅ (leggermente alto ma conforme)  
+**Titlebar**: 28pt ✅ (uniformato al kit `kit-titlebar-light/dark` standard — PR #178)  
 **Toolbar**: 44pt ✅ (standard macOS NSToolbar)  
 **Sidebar**: 220pt ✅ (HIG sidebar tipicamente 180-260pt)  
 **Separatore sidebar-toolbar**: 1pt ✅  
@@ -350,7 +350,7 @@ Struttura identica a Empty, con placeholder "no kubeconfig" nella sidebar.
 
 > ⚠️ **P2** — Light: `tl-min` #ffbd2e (vs standard #febc2e), `tl-max` #28c940 (vs standard #28c840). Variazioni minime nei colori traffic lights rispetto al kit standard.
 
-> ⚠️ **P2** — Altezza titlebar: 28pt in Namespace/Preferences/Deployment, ma 32pt in MainView — inconsistenza nel "chrome" dell'app. Le finestre dovrebbero usare la stessa altezza titlebar.
+> ✅ **P2 — Risolto (#178)** — Altezza titlebar uniformata a **28pt** (kit standard) su tutte le 8 board MainView. Traffic lights ricentrati `(28−12)/2 = 8pt` dal top board.
 
 ---
 
@@ -457,7 +457,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 | P2-06 | macOS – Namespace View Light/Dark | Ordine colonne tabella diverso tra Light e Dark | Allineare schema colonne tra varianti — ✅ Risolto (#177) — verificato via MCP: l'**ordine degli element-name** dei header è già **uniforme** tra Light e Dark: `th-name → th-ns → th-status → th-age → th-restarts`. Schema canonico Pod table documentato in `docs/cubelite-macos-design-instructions.md` § "Namespace View — Pod Table". Defetti strutturali residui nella variante Light (header off-board, x mis-aligned con dati, semantica colonne invertita) trasferiti a issue dedicato #185 per Bug Discovery Workflow |
 | P2-07 | macOS – Namespace View Light/Dark | Badge radius r:9 (Light) vs r:4 (Dark) | Uniformare — ✅ Risolto (#166) — `all-ns-badge-bg` portato a `r:9` su entrambe le varianti (pill style su altezza 18pt). Probe MCP ha mostrato che entrambi erano in realtà `r:4`; ora entrambi `r:9` |
 | P2-08 | macOS – Namespace View / Deployment Detail (Light) | Titlebar bg #e0e0e0 invece di standard #e8e8e8; traffic light colors diversi | Uniformare al kit standard — ✅ Risolto (#167) — verificato via MCP: entrambe le board hanno già `titlebar-bg #e8e8e8` e traffic lights `#ff5f57 / #febc2e / #28c840` (allineati al kit). Rilevato in PR precedenti (#143, #151); doc aggiornata per tracciamento |
-| P2-09 | Altezza titlebar | 28pt in Namespace/Preferences/Deployment vs 32pt in MainView | Definire altezza standard per ogni tipo di finestra e documentarla |
+| P2-09 | Altezza titlebar | 28pt in Namespace/Preferences/Deployment vs 32pt in MainView | Definire altezza standard per ogni tipo di finestra e documentarla — ✅ Risolto (#178) — le 8 board MainView (Empty/Error/No Config/Select NS × Light/Dark) portate da `titlebar-bg h=32pt` a **`h=28pt`** (kit-titlebar standard). `titlebar-bdr` y -= 4 (1pt strip al nuovo bottom titlebar), traffic lights e `tb-title` ricentrati y -= 2 ((28−12)/2=8pt), toolbar-bg + sidebar + tutto il contenuto sotto y -= 4 per chiudere il gap. Verificato visualmente via export PNG. Standard documentato in `docs/cubelite-macos-design-instructions.md` § "Titlebar Height" |
 | P2-10 | Preferences Advanced (TLS) | Input height 24pt invece di 28pt standard | Portare a 28pt — ✅ Risolto (#179) — verificato via MCP: gli input TLS (`r1-field`, `r2-field`, `r4-field`) su `Preferences – Advanced (TLS) – Light/Dark` sono già `220×28pt`, allineati a `kit-formfield` standard. Probabilmente normalizzati nel PR #145 (TLS toggle redesign). Nessuna mutation Penpot necessaria, doc aggiornata per tracciamento |
 | P2-11 | Resource Browser | Icon colors sidebar non standard (#5856d6/#5e5ce6 purple, #ff6b00 orange, #0070c9/#0096ff blue) | Sostituire con Apple system colors — ✅ Risolto (#168) — verificato via MCP: tutte le 12 icone sidebar `icon-*` (Light + Dark) usano già colori Apple system (`systemBlue/Purple/Orange/Green` con varianti light/dark). Mappatura icona→colore documentata in `docs/cubelite-macos-design-instructions.md` § "Mappatura Icone Sidebar Resource Browser" |
 | P2-12 | cubelite-icon board | `icon-image` rect ha fill `undefined` | Collegare risorsa immagine — ✅ Risolto (#180) — verificato via MCP: `icon-image` (400×400pt) ha fill image valido `cubelite-icon-512.png` (512×512 PNG, mtype `image/png`, opacity 1). L'audit doc originale citava `fill: undefined` come stato precedente; risorsa ora collegata. Nessuna mutation Penpot necessaria, doc aggiornata per tracciamento |


### PR DESCRIPTION
## Closes #178

## Mutation applied via Penpot MCP

8 boards updated on the **macOS Native** page:
- `MainView – Empty – Light` / `– Dark`
- `MainView – Select NS – Light` / `– Dark`
- `MainView – Error – Light` / `– Dark`
- `MainView – No Config – Light` / `– Dark`

Per board:
1. `titlebar-bg` resized: `h=32pt → 28pt`
2. `titlebar-bdr` shifted: `y -= 4` (now at `parentY=27` = 1pt strip at new titlebar bottom)
3. Traffic lights (`btn-close`, `btn-min`, `btn-zoom`) shifted: `y -= 2` → centered at `parentY=8 = (28−12)/2`
4. `tb-title` shifted: `y -= 2` → centered in 28pt titlebar
5. `toolbar-bg` and **all** content below original titlebar (parentY ≥ 28) shifted: `y -= 4` to close the gap

Children moved per board:
| Board | Moves |
|---|---|
| Empty L/D | 24 each |
| Select NS L/D | 28 each |
| Error L/D | 34 each |
| No Config L/D | 19 each |

## Verification
- Numeric probe confirms: `titlebar-bg.h = 28`, `btn-close.parentY = 8`, `toolbar-bg.parentY = 28` on all 8 boards
- Visual export PNG of `MainView – Empty – Light` shows compact 28pt titlebar with centered traffic lights and "CubeLite" title; toolbar flush below; no gaps

## Documentation
- `docs/cubelite-macos-design-instructions.md`: new § "Titlebar Height" defining canonical `28pt` for all macOS windows + traffic light / title centering math
- `docs/hig-review-report.md`: P2-09 row marked ✅ Risolto with verification

## Note
`Logs & Errors Panel – Light` still has `titlebar-bg h=32pt` (Logs Panel – Dark already `28pt`). Documented as known residual; not blocking, separate alignment task.

## Acceptance
- [x] All MainView titlebars = 28pt — verified on 8 boards
- [x] Vertical centering of traffic lights/title verified — `parentY=8` for circles
- [x] Height documented in `docs/cubelite-macos-design-instructions.md`
- [x] `docs/hig-review-report.md` § P2-09 marked ✅ Risolto with PR ref