### PR TITLE
fix(design): P3-01 — verify kit-toggle frame widths uniform at 78pt

### DIFF
--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -468,7 +468,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 
 | ID | Board/Componente | Problema | Suggerimento |
 |---|---|---|---|
-| P3-01 | kit-toggle-off/on | Frame width diverso (off: 78pt, on: 74pt) | Uniformare larghezza frame se usati in layout fisso |
+| P3-01 | kit-toggle-off/on | Frame width diverso (off: 78pt, on: 74pt) | Uniformare larghezza frame se usati in layout fisso — ✅ Risolto (#189) — verificato via MCP: tutti e 4 i board (`kit-toggle-off-light`, `kit-toggle-on-light`, `kit-toggle-off-dark`, `kit-toggle-on-dark`) hanno larghezza **78pt × 26pt**. `kit-toggle-on-dark` mostra `77.99999999999994` (Δ ≈ 6e-14pt, artefatto floating-point sub-pixel non normalizzabile via `resize`). L'audit doc originale citava `74pt` come misreading. Nessuna mutation Penpot necessaria |
 | P3-02 | kit-badge-* | Border radius 3pt troppo quadrato per macOS | Aumentare a r:11 (metà altezza 22pt) per stile "pill" |
 | P3-03 | kit-button | Mancano varianti: disabled, hover, pressed, secondary, tertiary | Aggiungere stati nel design system |
 | P3-04 | kit-dropdown | Mancano stati: disabled, hover, focused | Aggiungere stati nel design system |


### PR DESCRIPTION
Closes #189

## Verified-only ✅

## Audit P3-01 — kit-toggle frame width unify

Audit doc claimed `kit-toggle-off` (78pt) vs `kit-toggle-on` (74pt) had divergent frame widths.

## Penpot evidence (verified via MCP probe)

| Board | id | width | height |
|---|---|---|---|
| `kit-toggle-off-light` | `981e33cb-2a55-804c-8007-dff2c213674b` | **78pt** | 26pt |
| `kit-toggle-on-light` | `981e33cb-2a55-804c-8007-dff2c2182907` | **78pt** | 26pt |
| `kit-toggle-off-dark` | `981e33cb-2a55-804c-8007-dff2c21d4722` | **78pt** | 26pt |
| `kit-toggle-on-dark` | `981e33cb-2a55-804c-8007-dff2c221705a` | **77.99999999999994pt** | 26pt |

All four boards already share the same frame width within floating-point epsilon (Δ ≈ 6e-14pt — visually identical, sub-pixel). The float artefact on `kit-toggle-on-dark` cannot be normalised via `shape.resize(78, 26)` — Penpot stores the same internal value.

## Updated docs
- `docs/hig-review-report.md` — P3-01 marked ✅ with evidence
