### PR TITLE
fix(design): P3-02 — verify kit-badge pill radius already at 11pt

### DIFF
--- a/docs/hig-review-report.md
+++ b/docs/hig-review-report.md
@@ -469,7 +469,7 @@ In `MainView – Error`, il banner inline era visualizzato come:
 | ID | Board/Componente | Problema | Suggerimento |
 |---|---|---|---|
 | P3-01 | kit-toggle-off/on | Frame width diverso (off: 78pt, on: 74pt) | Uniformare larghezza frame se usati in layout fisso — ✅ Risolto (#189) — verificato via MCP: tutti e 4 i board (`kit-toggle-off-light`, `kit-toggle-on-light`, `kit-toggle-off-dark`, `kit-toggle-on-dark`) hanno larghezza **78pt × 26pt**. `kit-toggle-on-dark` mostra `77.99999999999994` (Δ ≈ 6e-14pt, artefatto floating-point sub-pixel non normalizzabile via `resize`). L'audit doc originale citava `74pt` come misreading. Nessuna mutation Penpot necessaria |
-| P3-02 | kit-badge-* | Border radius 3pt troppo quadrato per macOS | Aumentare a r:11 (metà altezza 22pt) per stile "pill" |
+| P3-02 | kit-badge-* | Border radius 3pt troppo quadrato per macOS | Aumentare a r:11 (metà altezza 22pt) per stile "pill" — ✅ Risolto (#190) — verificato via MCP: tutti e 6 i background rectangles (`kit-bdg-{err,warn,info}-bg-{l,d}`) hanno già `borderRadius: 11pt` su altezza 18pt (Penpot rendera pill completo, r > h/2 = 9). Colori semantici Apple: light `#ff3b30`/`#ff9500`/`#007aff`, dark `#ff453a`/`#ff9f0a`/`#0a84ff`. L'audit doc originale citava `3pt` come stale. Nessuna mutation Penpot necessaria |
 | P3-03 | kit-button | Mancano varianti: disabled, hover, pressed, secondary, tertiary | Aggiungere stati nel design system |
 | P3-04 | kit-dropdown | Mancano stati: disabled, hover, focused | Aggiungere stati nel design system |
 | P3-05 | kit-formfield | Mancano stati: focused (ring blu), disabled | Aggiungere stati nel design system |


### PR DESCRIPTION
Closes #190

## Verified-only ✅

## Audit P3-02 — kit-badge border radius pill style

Audit doc claimed badge `border-radius: 3pt` (too square for macOS).

## Penpot evidence (verified via MCP probe)

| Board | bg shape | width | height | borderRadius | fill |
|---|---|---|---|---|---|
| `kit-badge-error-light` | `kit-bdg-err-bg-l` | 52pt | 18pt | **11pt** | `#ff3b30` |
| `kit-badge-warn-light` | `kit-bdg-warn-bg-l` | 62pt | 18pt | **11pt** | `#ff9500` |
| `kit-badge-info-light` | `kit-bdg-info-bg-l` | 40pt | 18pt | **11pt** | `#007aff` |
| `kit-badge-error-dark` | `kit-bdg-err-bg-d` | 52pt | 18pt | **11pt** | `#ff453a` |
| `kit-badge-warn-dark` | `kit-bdg-warn-bg-d` | 62pt | 18pt | **11pt** | `#ff9f0a` |
| `kit-badge-info-dark` | `kit-bdg-info-bg-d` | 40pt | 18pt | **11pt** | `#0a84ff` |

All 6 badge background rectangles already have `borderRadius: 11pt`. Bg height is 18pt, so `r=11 > h/2=9` — Penpot caps at full pill (h/2), result is correct pill style. Audit's "3pt" claim is stale.

## Updated docs
- `docs/hig-review-report.md` — P3-02 marked ✅ with evidence
