### PR TITLE
fix(macos): wire autoRefreshInterval setting to refresh logic

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/AutoRefreshCoordinator.swift
+++ b/apps/macos/cubelite/cubelite/Services/AutoRefreshCoordinator.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Drives periodic execution of a refresh action.
+///
+/// The coordinator owns a single in-flight `Task`. Calling ``schedule(intervalSeconds:action:)``
+/// cancels any previously scheduled task before starting a new one, so changing the
+/// configured interval (e.g. when the user edits Preferences) atomically replaces the
+/// running schedule. An interval of `0` is treated as "disabled" and clears any
+/// pending task without starting a new one.
+///
+/// Each tick awaits the supplied action to completion before scheduling the next
+/// sleep, so successive refreshes can never overlap even if a fetch runs longer
+/// than the configured interval.
+@MainActor
+final class AutoRefreshCoordinator {
+
+    private var task: Task<Void, Never>?
+
+    /// Seconds between ticks for the currently active schedule, or `0` when disabled.
+    private(set) var currentIntervalSeconds: Int = 0
+
+    /// Number of times the scheduled action has completed. Primarily exposed for tests.
+    private(set) var tickCount: Int = 0
+
+    /// Whether a refresh task is currently running.
+    var isActive: Bool {
+        guard let task else { return false }
+        return !task.isCancelled
+    }
+
+    /// Cancels any active schedule and, when `intervalSeconds > 0`, starts a new one
+    /// that invokes `action` every `intervalSeconds` seconds.
+    ///
+    /// - Parameters:
+    ///   - intervalSeconds: tick period in seconds. Values `<= 0` disable auto-refresh.
+    ///   - action: work to perform on each tick. Runs on the main actor.
+    func schedule(
+        intervalSeconds: Int,
+        action: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        cancel()
+        guard intervalSeconds > 0 else { return }
+
+        currentIntervalSeconds = intervalSeconds
+        let nanos = UInt64(intervalSeconds) * 1_000_000_000
+
+        task = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: nanos)
+                } catch {
+                    return
+                }
+                if Task.isCancelled { return }
+                await action()
+                self?.tickCount += 1
+            }
+        }
+    }
+
+    /// Cancels any active schedule. Safe to call when already idle.
+    func cancel() {
+        task?.cancel()
+        task = nil
+        currentIntervalSeconds = 0
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MainView+AutoRefresh.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+AutoRefresh.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+// MARK: - MainView Auto-Refresh Wiring
+//
+// Bridges `AppSettings.autoRefreshInterval` to ``AutoRefreshCoordinator`` by
+// reconfiguring the periodic refresh task whenever the interval, the All
+// Clusters mode flag, or the selected cluster/namespace changes.
+extension MainView {
+
+    /// Reconciles `autoRefreshCoordinator` with the current ``autoRefreshKey``.
+    ///
+    /// - When `autoRefreshInterval` is `0`, all auto-refresh is disabled.
+    /// - When `showAllClusters` is true, periodic ticks reload the cross-cluster
+    ///   dashboard data.
+    /// - When a single cluster/namespace is selected, periodic ticks reload that
+    ///   slice's resources.
+    /// - Otherwise (no active scope), the schedule is cancelled.
+    @MainActor
+    func configureAutoRefresh() {
+        let interval = appSettings.autoRefreshInterval
+
+        if showAllClusters {
+            autoRefreshCoordinator.schedule(intervalSeconds: interval) { @MainActor in
+                await loadCrossClusterData()
+            }
+        } else if let selection = sidebarSelection {
+            let context = selection.context
+            let namespace = selection.namespace
+            autoRefreshCoordinator.schedule(intervalSeconds: interval) { @MainActor in
+                await loadResources(context: context, namespace: namespace)
+            }
+        } else {
+            autoRefreshCoordinator.cancel()
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MainView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView.swift
@@ -97,6 +97,22 @@ struct MainView: View {
     /// watcher's `start`/`stop` lifecycle ties to view appearance.
     @State var watcherBox = WatcherBox()
 
+    /// Drives the periodic refresh of cluster resources based on
+    /// `AppSettings.autoRefreshInterval`. Held in `@State` so its underlying
+    /// task survives view re-evaluations.
+    @State var autoRefreshCoordinator = AutoRefreshCoordinator()
+
+    /// Composite key that captures every input the auto-refresh schedule depends on.
+    /// Whenever any field changes, the schedule is rebuilt by `configureAutoRefresh()`.
+    var autoRefreshKey: AutoRefreshKey {
+        AutoRefreshKey(
+            intervalSeconds: appSettings.autoRefreshInterval,
+            allClusters: showAllClusters,
+            context: sidebarSelection?.context ?? selectedContext,
+            namespace: sidebarSelection?.namespace
+        )
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -125,7 +141,11 @@ struct MainView: View {
         }
         .task { await loadKubeconfig() }
         .task(id: appSettings.kubeconfigPaths) { startKubeconfigWatcher() }
-        .onDisappear { watcherBox.watcher?.stop() }
+        .onChange(of: autoRefreshKey, initial: true) { _, _ in configureAutoRefresh() }
+        .onDisappear {
+            watcherBox.watcher?.stop()
+            autoRefreshCoordinator.cancel()
+        }
         .onChange(of: selectedContext) { _, newValue in
             // Only exit All Clusters mode when selecting a specific context.
             // When All Clusters sets selectedContext = nil, preserve showAllClusters.
@@ -185,6 +205,16 @@ struct MainView: View {
 @MainActor
 final class WatcherBox {
     var watcher: KubeconfigWatcher?
+}
+
+// MARK: - Auto-Refresh Key
+
+/// Identifies the inputs that determine the active auto-refresh schedule.
+struct AutoRefreshKey: Equatable {
+    let intervalSeconds: Int
+    let allClusters: Bool
+    let context: String?
+    let namespace: String?
 }
 
 

--- a/apps/macos/cubelite/cubeliteTests/AutoRefreshCoordinatorTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/AutoRefreshCoordinatorTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+@testable import cubelite
+
+@MainActor
+final class AutoRefreshCoordinatorTests: XCTestCase {
+
+    // MARK: - Disabled (interval == 0)
+
+    func testScheduleWithZeroIntervalIsInactive() {
+        let sut = AutoRefreshCoordinator()
+        sut.schedule(intervalSeconds: 0) { /* never invoked */ }
+
+        XCTAssertFalse(sut.isActive)
+        XCTAssertEqual(sut.currentIntervalSeconds, 0)
+        XCTAssertEqual(sut.tickCount, 0)
+    }
+
+    func testScheduleWithNegativeIntervalIsInactive() {
+        let sut = AutoRefreshCoordinator()
+        sut.schedule(intervalSeconds: -5) { /* never invoked */ }
+
+        XCTAssertFalse(sut.isActive)
+        XCTAssertEqual(sut.currentIntervalSeconds, 0)
+    }
+
+    // MARK: - Active scheduling
+
+    func testScheduleWithPositiveIntervalIsActive() {
+        let sut = AutoRefreshCoordinator()
+        sut.schedule(intervalSeconds: 30) { /* sleeping */ }
+
+        XCTAssertTrue(sut.isActive)
+        XCTAssertEqual(sut.currentIntervalSeconds, 30)
+        sut.cancel()
+    }
+
+    func testReschedulingReplacesPreviousTask() async {
+        let sut = AutoRefreshCoordinator()
+
+        sut.schedule(intervalSeconds: 60) { /* sleeping */ }
+        XCTAssertTrue(sut.isActive)
+        XCTAssertEqual(sut.currentIntervalSeconds, 60)
+
+        sut.schedule(intervalSeconds: 15) { /* sleeping */ }
+        XCTAssertTrue(sut.isActive)
+        XCTAssertEqual(sut.currentIntervalSeconds, 15)
+
+        sut.cancel()
+    }
+
+    func testReschedulingToZeroStopsTask() {
+        let sut = AutoRefreshCoordinator()
+        sut.schedule(intervalSeconds: 30) { /* sleeping */ }
+        XCTAssertTrue(sut.isActive)
+
+        sut.schedule(intervalSeconds: 0) { /* never invoked */ }
+        XCTAssertFalse(sut.isActive)
+        XCTAssertEqual(sut.currentIntervalSeconds, 0)
+    }
+
+    func testCancelStopsActiveTask() {
+        let sut = AutoRefreshCoordinator()
+        sut.schedule(intervalSeconds: 30) { /* sleeping */ }
+        XCTAssertTrue(sut.isActive)
+
+        sut.cancel()
+        XCTAssertFalse(sut.isActive)
+        XCTAssertEqual(sut.currentIntervalSeconds, 0)
+    }
+
+    func testCancelOnIdleCoordinatorIsSafe() {
+        let sut = AutoRefreshCoordinator()
+        sut.cancel()
+        sut.cancel()
+        XCTAssertFalse(sut.isActive)
+    }
+}


### PR DESCRIPTION
Closes #106

## Problem
`AppSettings.autoRefreshInterval` was exposed in Preferences (`Off` / 15s / 30s / 1m / 2m) but nothing in `MainView` consumed it. Resource lists and the All Clusters dashboard only refreshed when the user clicked the toolbar reload button or changed selection — changing the interval had no observable effect.

## Fix

### New `AutoRefreshCoordinator` (`apps/macos/cubelite/cubelite/Services/AutoRefreshCoordinator.swift`)
A small `@MainActor final class` that owns a single in-flight `Task<Void, Never>`:

- `schedule(intervalSeconds:action:)` — cancels any prior task and, if `intervalSeconds > 0`, starts a new one that sleeps then awaits `action()` in a loop. Awaiting before re-sleeping prevents tick overlap even if a fetch runs longer than the interval.
- `cancel()` — cancels the underlying task and resets `currentIntervalSeconds` to `0`. Safe to call when already idle.
- `isActive` / `currentIntervalSeconds` / `tickCount` — observable accessors used by tests.

### `MainView` wiring (`MainView.swift` + new `MainView+AutoRefresh.swift`)
- New `@State var autoRefreshCoordinator = AutoRefreshCoordinator()` so the task survives view re-evaluations.
- New `autoRefreshKey` (`AutoRefreshKey` struct) bundles `(intervalSeconds, allClusters, context, namespace)`. Any change to those inputs invalidates the schedule.
- `.onChange(of: autoRefreshKey, initial: true) { configureAutoRefresh() }` reconciles the coordinator on every input change including first mount.
- `configureAutoRefresh()` picks the right refresh action for the current scope:
  - All Clusters mode → `loadCrossClusterData()`
  - Single cluster/namespace selected → `loadResources(context:namespace:)`
  - Nothing selected → `cancel()` (no work to refresh)
- `.onDisappear` now also calls `autoRefreshCoordinator.cancel()` next to the existing watcher `stop()`, preventing leaked tasks.

### Acceptance criteria coverage
- ✅ Changing the interval in Preferences immediately changes the polling cadence — `autoRefreshKey` carries `appSettings.autoRefreshInterval`, `onChange` re-invokes `schedule` which atomically cancels+replaces the prior task.
- ✅ Setting to 0/Never stops auto-refresh — `schedule(intervalSeconds: 0, ...)` cancels without starting a new task; covered by `testReschedulingToZeroStopsTask` and `testScheduleWithZeroIntervalIsInactive`.
- ✅ Unit test verifies timer rebind on setting change — `testReschedulingReplacesPreviousTask` schedules 60s, reschedules to 15s, and asserts `currentIntervalSeconds == 15` while still active.

## Tests
New `AutoRefreshCoordinatorTests` (6 cases):
- `testScheduleWithZeroIntervalIsInactive`
- `testScheduleWithNegativeIntervalIsInactive`
- `testScheduleWithPositiveIntervalIsActive`
- `testReschedulingReplacesPreviousTask`
- `testReschedulingToZeroStopsTask`
- `testCancelStopsActiveTask` / `testCancelOnIdleCoordinatorIsSafe`

## Local quality gates
- Build: `xcodebuild build-for-testing -project apps/macos/cubelite/cubelite.xcodeproj -scheme cubelite -destination 'platform=macOS' -derivedDataPath /tmp/cubelite-build` → **TEST BUILD SUCCEEDED**
- Tests: `xcodebuild test-without-building ... -skip-testing cubeliteUITests` → **exit 0**, 0 failures (incl. new `AutoRefreshCoordinatorTests` cases observed passing in log)

## Notes
- No force-unwraps, no `try!`. Coordinator uses `[weak self]` inside the periodic `Task` to avoid retaining itself past cancellation.
- No changes outside `apps/macos/**`. `coordinator.agent.md` untouched.