### PR TITLE
fix(macos): integrate SMAppService for Login Item registration

### DIFF
--- a/apps/macos/cubelite/cubelite/CubeliteApp.swift
+++ b/apps/macos/cubelite/cubelite/CubeliteApp.swift
@@ -6,6 +6,7 @@ struct CubeliteApp: App {
 
     @State private var clusterState = ClusterState()
     @State private var appSettings = AppSettings()
+    @State private var loginItemController: LoginItemController
     private let kubeconfigService: KubeconfigService
     private let kubeAPIService: KubeAPIService
 
@@ -17,6 +18,9 @@ struct CubeliteApp: App {
         let ks = KubeconfigService()
         self.kubeconfigService = ks
         self.kubeAPIService = KubeAPIService(kubeconfigService: ks)
+        // Default-initialised; the real `onError` closure is bound in `.task`
+        // once `logStore` and `appSettings` are available in scope.
+        self._loginItemController = State(initialValue: LoginItemController())
     }
 
     var body: some Scene {
@@ -26,6 +30,7 @@ struct CubeliteApp: App {
                     .environment(clusterState)
                     .environment(appSettings)
                     .environment(logStore)
+                    .environment(loginItemController)
                     .preferredColorScheme(appSettings.colorScheme)
                     .onChange(of: appSettings.appearanceMode) { _, newMode in
                         applyNSAppearance(newMode)
@@ -51,6 +56,7 @@ struct CubeliteApp: App {
                         await kubeAPIService.updateSkipTLS(appSettings.skipTLSVerification)
                         let urls = appSettings.kubeconfigPaths.map { URL(fileURLWithPath: $0) }
                         await kubeconfigService.configure(paths: urls)
+                        configureLoginItem()
                     }
             } else {
                 FirstLaunchView(
@@ -77,6 +83,43 @@ struct CubeliteApp: App {
         Settings {
             PreferencesView()
                 .environment(appSettings)
+                .environment(loginItemController)
+        }
+    }
+
+    /// Wires the login-item controller's error reporter into the shared
+    /// `LogStore` and reconciles the persisted `launchAtLogin` setting with
+    /// the live `SMAppService` status.
+    ///
+    /// - If the user previously enabled "Launch at login" but the system
+    ///   reports the app is no longer registered (e.g. the app bundle was
+    ///   moved, or the user disabled it from System Settings), this attempts
+    ///   to re-register. On failure, the persisted flag is set back to `false`
+    ///   so the UI reflects reality.
+    /// - If the persisted flag is `false` we just refresh status without
+    ///   forcing an unregister, to avoid clobbering a fresh first-launch
+    ///   registration the user might have just toggled on.
+    @MainActor
+    private func configureLoginItem() {
+        loginItemController.onError = { [logStore] message, details in
+            logStore.append(
+                LogEntry(
+                    severity: .error,
+                    source: "LoginItem",
+                    message: message,
+                    details: details
+                )
+            )
+        }
+        loginItemController.refresh()
+
+        if appSettings.launchAtLogin, !loginItemController.status.isEnabled {
+            let ok = loginItemController.setEnabled(true)
+            if !ok { appSettings.launchAtLogin = false }
+        } else {
+            // Keep the persisted flag in sync with reality so a stale `true`
+            // doesn't survive an external unregister.
+            appSettings.launchAtLogin = loginItemController.status.isEnabled
         }
     }
 

--- a/apps/macos/cubelite/cubelite/Services/LoginItemService.swift
+++ b/apps/macos/cubelite/cubelite/Services/LoginItemService.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Observation
+import ServiceManagement
+
+// MARK: - Status
+
+/// Login Item registration state surfaced to the UI.
+///
+/// Mirrors `SMAppService.Status` but is `Sendable` and stable across SDKs,
+/// so it can be passed through `@Observable` state and used in tests.
+enum LoginItemStatus: Sendable, Equatable {
+    /// The app is not registered as a login item.
+    case notRegistered
+    /// The app is registered and will launch at login.
+    case enabled
+    /// The app is registered but the user has not yet approved it in
+    /// System Settings → General → Login Items.
+    case requiresApproval
+    /// The registration was found in a non-standard location (e.g. moved app).
+    case notFound
+
+    /// `true` when the app is effectively set to launch at login from the
+    /// user's point of view (registered, even if pending approval).
+    var isEnabled: Bool {
+        switch self {
+        case .enabled, .requiresApproval: true
+        case .notRegistered, .notFound: false
+        }
+    }
+
+    init(_ status: SMAppService.Status) {
+        switch status {
+        case .enabled: self = .enabled
+        case .requiresApproval: self = .requiresApproval
+        case .notFound: self = .notFound
+        case .notRegistered: self = .notRegistered
+        @unknown default: self = .notRegistered
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// Abstraction over `SMAppService` so the controller can be unit-tested
+/// without touching the real system service.
+///
+/// Implementations are only ever called from the main actor (via
+/// ``LoginItemController``); no cross-actor isolation is required.
+protocol LoginItemRegistering {
+    func register() throws
+    func unregister() throws
+    func currentStatus() -> LoginItemStatus
+}
+
+// MARK: - Concrete Implementation
+
+/// Concrete `LoginItemRegistering` backed by `SMAppService.mainApp`.
+///
+/// Uses the modern login-item API available on macOS 13+ (the project's
+/// deployment target is 14.6, so no `#available` gate is required).
+struct SMAppServiceLoginItem: LoginItemRegistering {
+
+    func register() throws {
+        try SMAppService.mainApp.register()
+    }
+
+    func unregister() throws {
+        try SMAppService.mainApp.unregister()
+    }
+
+    func currentStatus() -> LoginItemStatus {
+        LoginItemStatus(SMAppService.mainApp.status)
+    }
+}
+
+// MARK: - Controller
+
+/// Observable controller bridging the persisted "Launch at login" preference
+/// to the real `SMAppService` registration state.
+///
+/// The controller is the source of truth the UI binds to: toggling
+/// ``setEnabled(_:)`` calls register/unregister on the injected
+/// ``LoginItemRegistering`` service, refreshes ``status``, and reports any
+/// failure to the supplied logging closure.
+@Observable
+@MainActor
+final class LoginItemController {
+
+    // MARK: Observable state
+
+    /// Latest known login-item status. Updated after every register/unregister
+    /// and on ``refresh()``.
+    private(set) var status: LoginItemStatus
+
+    // MARK: Dependencies
+
+    private let service: LoginItemRegistering
+    /// Receives `(message, details)` whenever a register/unregister attempt
+    /// throws. Settable after init so SwiftUI scenes can bind it to a log
+    /// store once one is in scope.
+    var onError: @MainActor (String, String?) -> Void
+
+    // MARK: Init
+
+    /// - Parameters:
+    ///   - service: Backing registration service. Defaults to the real
+    ///     `SMAppService.mainApp` wrapper.
+    ///   - onError: Called with `(message, details)` whenever a register or
+    ///     unregister attempt throws. The default is a no-op so the controller
+    ///     remains usable in previews and tests without wiring a log store.
+    init(
+        service: LoginItemRegistering = SMAppServiceLoginItem(),
+        onError: @escaping @MainActor (String, String?) -> Void = { _, _ in }
+    ) {
+        self.service = service
+        self.onError = onError
+        self.status = service.currentStatus()
+    }
+
+    // MARK: API
+
+    /// Re-reads the current status from the underlying service.
+    func refresh() {
+        status = service.currentStatus()
+    }
+
+    /// Enable or disable the login item.
+    ///
+    /// Returns `true` if the underlying call succeeded (regardless of whether
+    /// the resulting status is `.enabled` or `.requiresApproval`). Returns
+    /// `false` and invokes the `onError` reporter when the call throws.
+    @discardableResult
+    func setEnabled(_ enabled: Bool) -> Bool {
+        do {
+            if enabled {
+                try service.register()
+            } else {
+                try service.unregister()
+            }
+            status = service.currentStatus()
+            return true
+        } catch {
+            // Keep the observed status in sync with reality even after failure.
+            status = service.currentStatus()
+            let action = enabled ? "register" : "unregister"
+            onError(
+                "Failed to \(action) Launch at Login",
+                (error as NSError).localizedDescription
+            )
+            return false
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Services/LoginItemService.swift
+++ b/apps/macos/cubelite/cubelite/Services/LoginItemService.swift
@@ -45,7 +45,9 @@ enum LoginItemStatus: Sendable, Equatable {
 /// without touching the real system service.
 ///
 /// Implementations are only ever called from the main actor (via
-/// ``LoginItemController``); no cross-actor isolation is required.
+/// ``LoginItemController``); the protocol is `@MainActor`-isolated so
+/// implementations may safely touch main-actor state.
+@MainActor
 protocol LoginItemRegistering {
     func register() throws
     func unregister() throws

--- a/apps/macos/cubelite/cubelite/Views/PreferencesView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PreferencesView.swift
@@ -26,6 +26,7 @@ struct PreferencesView: View {
 private struct GeneralPreferencesTab: View {
 
     @Environment(AppSettings.self) private var settings
+    @Environment(LoginItemController.self) private var loginItem
 
     private static let refreshOptions: [(label: String, value: Int)] = [
         ("Off", 0),
@@ -35,6 +36,21 @@ private struct GeneralPreferencesTab: View {
         ("2 minutes", 120),
     ]
 
+    /// Binding that routes toggle changes through the `LoginItemController`
+    /// so the system registration stays in sync with the persisted setting.
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { settings.launchAtLogin },
+            set: { newValue in
+                let ok = loginItem.setEnabled(newValue)
+                // Only persist the user's intent when the system accepted it.
+                // On failure, leave the toggle reflecting the real status so
+                // the UI doesn't silently disagree with the system.
+                settings.launchAtLogin = ok ? newValue : loginItem.status.isEnabled
+            }
+        )
+    }
+
     var body: some View {
         Form {
             Picker("Auto-refresh:", selection: Bindable(settings).autoRefreshInterval) {
@@ -42,11 +58,19 @@ private struct GeneralPreferencesTab: View {
                     Text(option.label).tag(option.value)
                 }
             }
-            Toggle("Launch at login", isOn: Bindable(settings).launchAtLogin)
+            Toggle("Launch at login", isOn: launchAtLoginBinding)
+            if loginItem.status == .requiresApproval {
+                Text(
+                    "Approval required in System Settings → General → Login Items."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
             Toggle("Show system namespaces", isOn: Bindable(settings).showSystemNamespaces)
         }
         .formStyle(.grouped)
         .padding()
+        .task { loginItem.refresh() }
     }
 }
 

--- a/apps/macos/cubelite/cubeliteTests/LoginItemServiceTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/LoginItemServiceTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+
+@testable import cubelite
+
+/// Stub `LoginItemRegistering` that records calls and can simulate failures.
+@MainActor
+private final class StubLoginItemService: LoginItemRegistering {
+    var status: LoginItemStatus = .notRegistered
+    var registerError: Error?
+    var unregisterError: Error?
+
+    private(set) var registerCallCount = 0
+    private(set) var unregisterCallCount = 0
+
+    func register() throws {
+        registerCallCount += 1
+        if let err = registerError { throw err }
+        status = .enabled
+    }
+
+    func unregister() throws {
+        unregisterCallCount += 1
+        if let err = unregisterError { throw err }
+        status = .notRegistered
+    }
+
+    func currentStatus() -> LoginItemStatus { status }
+}
+
+/// Unit tests for ``LoginItemController`` and ``LoginItemStatus``.
+@MainActor
+final class LoginItemServiceTests: XCTestCase {
+
+    // MARK: - LoginItemStatus.isEnabled
+
+    func testStatusEnabledIsEnabled() {
+        XCTAssertTrue(LoginItemStatus.enabled.isEnabled)
+    }
+
+    func testStatusRequiresApprovalIsEnabled() {
+        XCTAssertTrue(LoginItemStatus.requiresApproval.isEnabled)
+    }
+
+    func testStatusNotRegisteredIsDisabled() {
+        XCTAssertFalse(LoginItemStatus.notRegistered.isEnabled)
+    }
+
+    func testStatusNotFoundIsDisabled() {
+        XCTAssertFalse(LoginItemStatus.notFound.isEnabled)
+    }
+
+    // MARK: - Controller init
+
+    func testInitReadsInitialStatusFromService() {
+        let stub = makeStub(status: .enabled)
+        let sut = LoginItemController(service: stub)
+        XCTAssertEqual(sut.status, .enabled)
+    }
+
+    // MARK: - setEnabled(true)
+
+    func testEnableCallsRegisterAndUpdatesStatus() {
+        let stub = makeStub(status: .notRegistered)
+        let sut = LoginItemController(service: stub)
+
+        let ok = sut.setEnabled(true)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(stub.registerCallCount, 1)
+        XCTAssertEqual(stub.unregisterCallCount, 0)
+        XCTAssertEqual(sut.status, .enabled)
+    }
+
+    func testEnableFailureReportsErrorAndKeepsStatusInSync() {
+        let stub = makeStub(status: .notRegistered)
+        stub.registerError = TestError.simulated
+        var reportedMessage: String?
+        var reportedDetails: String?
+        let sut = LoginItemController(service: stub) { msg, details in
+            reportedMessage = msg
+            reportedDetails = details
+        }
+
+        let ok = sut.setEnabled(true)
+
+        XCTAssertFalse(ok)
+        XCTAssertEqual(sut.status, .notRegistered)
+        XCTAssertEqual(reportedMessage, "Failed to register Launch at Login")
+        XCTAssertNotNil(reportedDetails)
+    }
+
+    // MARK: - setEnabled(false)
+
+    func testDisableCallsUnregisterAndUpdatesStatus() {
+        let stub = makeStub(status: .enabled)
+        let sut = LoginItemController(service: stub)
+
+        let ok = sut.setEnabled(false)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(stub.unregisterCallCount, 1)
+        XCTAssertEqual(stub.registerCallCount, 0)
+        XCTAssertEqual(sut.status, .notRegistered)
+    }
+
+    func testDisableFailureReportsError() {
+        let stub = makeStub(status: .enabled)
+        stub.unregisterError = TestError.simulated
+        var reportedMessage: String?
+        let sut = LoginItemController(service: stub) { msg, _ in
+            reportedMessage = msg
+        }
+
+        let ok = sut.setEnabled(false)
+
+        XCTAssertFalse(ok)
+        XCTAssertEqual(reportedMessage, "Failed to unregister Launch at Login")
+    }
+
+    // MARK: - refresh
+
+    func testRefreshPullsLatestStatus() {
+        let stub = makeStub(status: .notRegistered)
+        let sut = LoginItemController(service: stub)
+        XCTAssertEqual(sut.status, .notRegistered)
+
+        stub.status = .requiresApproval
+        sut.refresh()
+
+        XCTAssertEqual(sut.status, .requiresApproval)
+    }
+
+    // MARK: - onError reassignment
+
+    func testOnErrorCanBeReassignedAfterInit() {
+        let stub = makeStub(status: .notRegistered)
+        stub.registerError = TestError.simulated
+        let sut = LoginItemController(service: stub)
+
+        var captured: String?
+        sut.onError = { msg, _ in captured = msg }
+
+        _ = sut.setEnabled(true)
+
+        XCTAssertEqual(captured, "Failed to register Launch at Login")
+    }
+
+    // MARK: - Helpers
+
+    private func makeStub(status: LoginItemStatus) -> StubLoginItemService {
+        let stub = StubLoginItemService()
+        stub.status = status
+        return stub
+    }
+
+    private enum TestError: Error { case simulated }
+}


### PR DESCRIPTION
Closes #118

## Problem
The "Launch at login" toggle in Preferences was wired only to UserDefaults — flipping it did nothing at the OS level. macOS 13+ requires `SMAppService.mainApp` to register the app as a login item.

## Fix

### New `LoginItemService.swift` (`apps/macos/cubelite/cubelite/Services/`)
- `LoginItemStatus` — `Sendable` enum mirroring `SMAppService.Status` (`enabled`, `requiresApproval`, `notRegistered`, `notFound`) with an `isEnabled` helper.
- `LoginItemRegistering` protocol — `register() throws`, `unregister() throws`, `currentStatus()` — used for dependency injection in tests.
- `SMAppServiceLoginItem` — concrete `LoginItemRegistering` backed by `SMAppService.mainApp`.
- `LoginItemController` — `@Observable @MainActor final class` exposing observable `status`, a `setEnabled(_: Bool) -> Bool` that calls register/unregister, a `refresh()` method, and a settable `onError` reporter. The controller catches every thrown error, keeps its observed `status` in sync with the real system state even after failure, and routes errors to the reporter without crashing.

### `CubeliteApp` wiring
- New `@State private var loginItemController = LoginItemController()` injected into both the main window scene and the `Settings` scene via `.environment(loginItemController)`.
- New `configureLoginItem()` (called from `.task`):
  - Binds `onError` to append an `error`-severity `LogEntry` (source `"LoginItem"`) to the shared `LogStore`, so the existing `ErrorBannerView` surfaces failures automatically.
  - Refreshes the live status.
  - If `appSettings.launchAtLogin` was previously `true` but the system reports the app isn't registered, it attempts to re-register; on failure it flips the persisted flag back to `false` so the UI matches reality.
  - Otherwise reconciles the persisted flag with the live status (handles the case where the user disabled the login item from System Settings).

### `PreferencesView` toggle
- `GeneralPreferencesTab` now reads `LoginItemController` from the environment.
- The "Launch at login" `Toggle` uses a computed `Binding<Bool>` that calls `loginItem.setEnabled(newValue)` and only persists the user's intent when the system accepted it; on failure it reverts to the controller's actual status so the UI and OS never disagree silently.
- When status is `.requiresApproval`, a caption directs the user to System Settings → General → Login Items.

### Acceptance criteria coverage
- ✅ `SMAppService.mainApp.register()` called when the toggle is enabled.
- ✅ `SMAppService.mainApp.unregister()` called when the toggle is disabled.
- ✅ Status reflected in UI: the toggle reads `status.isEnabled` (true for `.enabled` and `.requiresApproval`); a hint is shown for `.requiresApproval`.
- ✅ Errors surfaced via the existing error banner (via `LogStore` append of an `.error` entry, which `ErrorBannerView` already consumes through `unreadErrorCount`).
- ✅ Unit tests via a mock `LoginItemRegistering` (`StubLoginItemService` in tests).

## Tests
New `LoginItemServiceTests` (11 cases):
- Status helpers: `testStatusEnabledIsEnabled`, `testStatusRequiresApprovalIsEnabled`, `testStatusNotRegisteredIsDisabled`, `testStatusNotFoundIsDisabled`.
- Init: `testInitReadsInitialStatusFromService`.
- Enable path: `testEnableCallsRegisterAndUpdatesStatus`, `testEnableFailureReportsErrorAndKeepsStatusInSync`.
- Disable path: `testDisableCallsUnregisterAndUpdatesStatus`, `testDisableFailureReportsError`.
- Misc: `testRefreshPullsLatestStatus`, `testOnErrorCanBeReassignedAfterInit`.

## Local quality gates
- Build: `xcodebuild build-for-testing -project apps/macos/cubelite/cubelite.xcodeproj -scheme cubelite -destination 'platform=macOS' -derivedDataPath /tmp/cubelite-build` → **TEST BUILD SUCCEEDED**
- Tests: `xcodebuild test-without-building ... -skip-testing cubeliteUITests` → **352 passed, 0 failed** (incl. all 11 new `LoginItemServiceTests` cases observed passing in log). `xcodebuild` itself hangs on the macOS 26.5 SDK `logarchive` finalisation after `Testing started completed` — a known toolchain issue unrelated to this change.

## Notes
- Deployment target is **macOS 14.6**, so `SMAppService` (introduced in 13) is unconditionally available — no `#available` guards needed.
- No force-unwrap / force-try / force-cast in new code; all `SMAppService` calls go through `do/try/catch`.
- No changes outside `apps/macos/**`. `.github/agents/coordinator.agent.md` untouched.
- No new entitlement is required for `SMAppService.mainApp` (the app registers itself, not a separate helper bundle).