### PR TITLE
fix(ci): always run Build & Test macOS check on pull requests

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -7,8 +7,9 @@ on:
       - "apps/macos/**"
   pull_request:
     branches: [main]
-    paths:
-      - "apps/macos/**"
+    # No paths filter: "Build & Test macOS" is a required status check.
+    # GitHub branch protection requires the check to report on every PR,
+    # even when no macOS files changed. Expensive steps are gated below.
 
 permissions:
   contents: read
@@ -17,14 +18,34 @@ jobs:
   build-macos:
     name: Build & Test macOS
     runs-on: macos-15
-    timeout-minutes: 15
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: apps/macos/cubelite
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Check for macOS changes
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- apps/macos/ || true)
+            if [ -n "$CHANGED" ]; then
+              echo "macos_changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "macos_changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # push event: paths filter already ensures only macOS changes reach here
+            echo "macos_changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build
+        if: steps.changes.outputs.macos_changed == 'true'
         run: |
           xcodebuild build \
             -project cubelite.xcodeproj \
@@ -35,6 +56,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Test
+        if: steps.changes.outputs.macos_changed == 'true'
         run: |
           xcodebuild test \
             -project cubelite.xcodeproj \


### PR DESCRIPTION
## Problem

The `Build & Test macOS` check is required by branch protection on `main`, but `ci-macos.yml` had a `paths: apps/macos/**` filter on the `pull_request` trigger. This meant the check **never ran** on PRs that don't touch macOS files (e.g. JS dependency bumps, Rust changes, workflow edits).

Result: every non-macOS PR was permanently **BLOCKED** (`mergeStateStatus: BLOCKED`) because the required check never reported — even with all other checks green and a review approval.

Observed on Dependabot PRs #219 and #220 (brace-expansion / @sveltejs/kit).

## Fix

- **Remove `paths` filter from `pull_request` trigger** → the job always runs on every PR, so the required check always reports.
- **Add `Check for macOS changes` step** (git diff vs PR base SHA) that sets `macos_changed` output.
- **Gate `Build` and `Test` steps** on `steps.changes.outputs.macos_changed == 'true'` → macos-15 runner minutes only consumed when `apps/macos/**` actually changed.
- **Raise `timeout-minutes` from 15 → 60** to match observed build times (CodeQL Analyze swift ~25 min).
- Keep `paths` filter on `push` events (no change needed there).

## After merge

Once this lands on `main`, Dependabot PRs #219 and #220 must be updated (comment `@dependabot rebase`) to trigger a fresh CI run that now includes `Build & Test macOS`. They can then be squash-merged.