### PR TITLE
design(macos): quarantine 16 orphan shapes on macOS Native page

### DIFF
--- a/docs/penpot-macos-audit.md
+++ b/docs/penpot-macos-audit.md
@@ -262,10 +262,14 @@ follow-up issue tracked under #73.
 6. **Component reuse missing** — every kit-* atom is a stand-alone board
    instead of a Penpot library component. Promote the kit-* boards to
    components so screens can instance them.
-7. **Orphan shapes on the macOS Native page** (15 items): `test-rect-dims`,
-   `child-rect`, `section-heading-icon`, `section-subheading-icon`,
-   `pref-title`, `design-note-mono`, plus 9 unnamed `Text` shapes. Move
-   them under a quarantine board or delete (follow-up cleanup PR).
+7. **Orphan shapes on the macOS Native page** — ✅ resolved by #134.
+   16 loose top-level shapes (`test-rect-dims`, `child-rect`,
+   `section-heading-icon`, `section-subheading-icon`, `pref-title`,
+   `design-note-mono`, a stray `resource-count-tile — Light` label, plus
+   9 unnamed `Text` debug shapes) were quarantined into the
+   `[QUARANTINE] orphan-shapes — issue #134` board
+   (id `0070e222-40fd-80c6-8008-193b30bce9ba`) at `(8000, 9500)`.
+   Page root no longer contains any loose shape.
 8. **Identifier coverage** — top-level boards already carry meaningful
    names but their child shapes mostly do not follow the `screen/...`
    pattern. Apply the convention progressively (one screen per PR).


### PR DESCRIPTION
Closes #134. Refs #73.

## Summary

Moves all 16 loose top-level shapes on the Penpot `macOS Native` page into a dedicated quarantine board, leaving the page root free of debris. No shapes deleted — fully reversible.

## Penpot changes

- New board **`[QUARANTINE] orphan-shapes — issue #134`** at `(8000, 9500)` on the macOS Native page (id `0070e222-40fd-80c6-8008-193b30bce9ba`).
- Amber-tinted background + stroke to make its purpose obvious in the workspace.
- 16 shapes moved into it:
  - `test-rect-dims`, `child-rect` (test rectangles)
  - `section-heading-icon`, `section-subheading-icon`, `pref-title`, `design-note-mono` (legacy section labels)
  - 9 unnamed `Text` debug shapes ("Welcome to CubeLite", "Hello CubeLite", "test", "hello")
  - 1 stray "resource-count-tile — Light" label

The audit doc reported **15** orphans; the live page actually had **16** (the extra "resource-count-tile — Light" stray label). The audit doc has been updated accordingly.

## Docs

- `docs/penpot-macos-audit.md` §4.7 updated: marked resolved, lists the quarantine board id and the actual 16 shapes.

## Verification

- Re-checked `page.root.children` after the move: **0 loose shapes remain**.
- Quarantine board contains **16 children**.

## Workspace URL

https://design.penpot.app/#/workspace?file-id=30c95215-44cf-80fa-8007-dc318de1085f&page-id=1b8565c6-f550-8090-8007-de5c859bb57f