### PR TITLE
design(macos): replace kit-dropdown chevron with SF Symbol chevron.down artwork

### DIFF
--- a/docs/penpot-macos-audit.md
+++ b/docs/penpot-macos-audit.md
@@ -189,7 +189,7 @@ by category below.
 | `common/controls/toggle` | `kit-toggle-on/off-light/dark` | ✅ | 4pt frame width drift between on/off (P3, see HIG report §1.4) |
 | `common/controls/checkbox` | `kit-checkbox-checked/unchecked-light/dark` | ⚠️ **P1** | 18×18pt — under HIG 20pt minimum; dark unchecked missing border |
 | `common/controls/text-field` | `kit-formfield-light/dark` (+ focused, disabled) | ✅ | |
-| `common/controls/dropdown` | `kit-dropdown-light/dark` (+ hover, disabled) | ✅ | Chevron is a placeholder rectangle (verify SF Symbol in code) |
+| `common/controls/dropdown` | `kit-dropdown-light/dark` (+ hover, disabled, focused) | ✅ | Chevron updated to SF Symbol `chevron.down` artwork (12×6pt thin V, 1.5pt round-cap stroke, vector Path) on all 8 variants — #137 |
 | `common/controls/segmented-control` | `kit-tabbar-light/dark` | ✅ | |
 
 ### 3.2 chrome/
@@ -272,9 +272,18 @@ follow-up issue tracked under #73.
 9. **Checkbox sub-spec** (P1) — `kit-checkbox-*` is 18pt; raise to 20pt
    (HIG absolute minimum). Verify Swift implementation does not also
    render at 18pt.
-10. **Dropdown chevron** — visually a rectangle in `kit-dropdown-*`. Verify
-    Swift uses the SF Symbol `chevron.down` and update the Penpot artwork
-    to match.
+10. **Dropdown chevron** — ✅ resolved by #137.
+    Replaced the previous `▾` (U+25BE) text glyph in `kit-dropdown-{,hover-,disabled-,focused-}{light,dark}`
+    with a vector `Path` tracing SF Symbol `chevron.down`
+    (12×6pt thin V, 1.5pt round-cap stroke, system gray `#86868b` light /
+    `#98989d` dark, muted on disabled). Hover and disabled variants
+    previously had no chevron at all — chevrons added to all 8 variants.
+    Swift parity: `PreferencesView` uses `Picker(...)` and `LogsView` uses
+    `Picker("Filter", ...)` with the default pop-up style, which on macOS
+    renders the system chevron automatically — no manual SF Symbol use is
+    required in code. The only explicit `Image(systemName: "chevron.down")`
+    in `Views/` is the namespace section disclosure in `MainView+Sidebar.swift`,
+    which already uses the correct symbol. No macos-agent follow-up needed.
 
 ---
 


### PR DESCRIPTION
Closes #137. Refs #73.

## Summary

Replaces the placeholder text glyph (▾ U+25BE) used as the chevron in the Penpot `kit-dropdown-*` boards with a vector `Path` that traces SF Symbol `chevron.down`. SF Symbols cannot be embedded directly in Penpot, so the acceptance criteria explicitly allows vector tracing.

## Penpot changes

Updated **8 variants** on the `States & Components` page:

| Variant | Previous chevron | New chevron |
|---|---|---|
| `kit-dropdown-light` | text `▾` 12pt | Path V 12×6pt, 1.5pt stroke, `#86868b` |
| `kit-dropdown-dark` | text `▾` 12pt | Path V 12×6pt, 1.5pt stroke, `#98989d` |
| `kit-dropdown-focused-light` | text `▾` 12pt | Path V 12×6pt, 1.5pt stroke, `#86868b` |
| `kit-dropdown-focused-dark` | text `▾` 12pt | Path V 12×6pt, 1.5pt stroke, `#98989d` |
| `kit-dropdown-hover-light` | _missing_ | Path V 12×6pt, 1.5pt stroke, `#86868b` |
| `kit-dropdown-hover-dark` | _missing_ | Path V 12×6pt, 1.5pt stroke, `#98989d` |
| `kit-dropdown-disabled-light` | _missing_ | Path V 12×6pt, 1.5pt stroke, `#c7c7cc` (muted) |
| `kit-dropdown-disabled-dark` | _missing_ | Path V 12×6pt, 1.5pt stroke, `#636366` (muted) |

Hover and disabled variants previously had **no chevron at all** — added for consistency.

## Swift parity verification (no macos-agent follow-up needed)

Audited all chevron / picker usages under `apps/macos/cubelite/cubelite/Views/`:

- `PreferencesView.swift` lines 40, 62, 69 → `Picker(...)` default pop-up style → macOS renders the system chevron automatically. ✅
- `LogsView.swift` line 72 → `Picker("Filter", ...)` default style. ✅
- `MainView+Sidebar.swift` line 272 → explicit `Image(systemName: chevron.down/right)` for the namespace section disclosure. ✅ Already correct symbol.

No SwiftUI changes required.

## Docs

`docs/penpot-macos-audit.md` §3.1 / §4.10 updated.

## Workspace URL

https://design.penpot.app/#/workspace?file-id=30c95215-44cf-80fa-8007-dc318de1085f&page-id=1b8565c6-f550-8090-8007-de5c859bcd4a