### PR TITLE
design(macos): raise kit-checkbox squares to 20pt (HIG hit-target minimum)

### DIFF
--- a/docs/penpot-macos-audit.md
+++ b/docs/penpot-macos-audit.md
@@ -187,7 +187,7 @@ by category below.
 | `common/controls/button/destructive` | _none_ | ❌ gap | System red |
 | `common/controls/button/icon` | _none_ | ❌ gap | 28×28pt SF Symbol-only |
 | `common/controls/toggle` | `kit-toggle-on/off-light/dark` | ✅ | 4pt frame width drift between on/off (P3, see HIG report §1.4) |
-| `common/controls/checkbox` | `kit-checkbox-checked/unchecked-light/dark` | ⚠️ **P1** | 18×18pt — under HIG 20pt minimum; dark unchecked missing border |
+| `common/controls/checkbox` | `kit-checkbox-checked/unchecked-light/dark` | ✅ | 20×20pt squares (HIG hit-target minimum); dark unchecked has visible 1pt border — #136 |
 | `common/controls/text-field` | `kit-formfield-light/dark` (+ focused, disabled) | ✅ | |
 | `common/controls/dropdown` | `kit-dropdown-light/dark` (+ hover, disabled, focused) | ✅ | Chevron updated to SF Symbol `chevron.down` artwork (12×6pt thin V, 1.5pt round-cap stroke, vector Path) on all 8 variants — #137 |
 | `common/controls/segmented-control` | `kit-tabbar-light/dark` | ✅ | |
@@ -268,9 +268,18 @@ follow-up issue tracked under #73.
 8. **Identifier coverage** — top-level boards already carry meaningful
    names but their child shapes mostly do not follow the `screen/...`
    pattern. Apply the convention progressively (one screen per PR).
-9. **Checkbox sub-spec** (P1) — `kit-checkbox-*` is 18pt; raise to 20pt
-   (HIG absolute minimum). Verify Swift implementation does not also
-   render at 18pt.
+9. **Checkbox sub-spec** — ✅ resolved by #136.
+   `kit-checkbox-{checked,unchecked}-{light,dark}` resized from 18×18pt to
+   20×20pt (HIG hit-target minimum); checkmark glyph re-centred at 13pt;
+   labels shifted +2pt right; board heights raised 22→24pt to keep a 2pt
+   vertical safe area. The dark unchecked board already carried a 1pt
+   `#48484a` inner-stroke border (`kit-cb-border-d`) — verified present.
+   Swift parity: a workspace-wide grep of `apps/macos/cubelite/cubelite/Views/`
+   for `.checkbox`, `CheckboxToggleStyle`, `toggleStyle` returns **0 matches**
+   — all `Toggle(...)` usages (PreferencesView "Launch at login", "Show
+   system namespaces", "Skip TLS certificate verification") render as the
+   standard macOS switch (NSSwitch), not a checkbox. There is no Swift
+   checkbox to audit against the 20pt minimum.
 10. **Dropdown chevron** — ✅ resolved by #137.
     Replaced the previous `▾` (U+25BE) text glyph in `kit-dropdown-{,hover-,disabled-,focused-}{light,dark}`
     with a vector `Path` tracing SF Symbol `chevron.down`


### PR DESCRIPTION
Closes #136. Refs #73.

## Summary

Resizes all four `kit-checkbox-*` boards on the Penpot `States & Components` page from 18×18pt to **20×20pt**, the HIG hit-target minimum. This clears the P1 marker in the audit.

## Penpot changes

| Variant | Before | After |
|---|---|---|
| `kit-checkbox-unchecked-light` | 18×18 square, 94×22 board | 20×20 square, 96×24 board |
| `kit-checkbox-checked-light` | 18×18 square, 84×22 board | 20×20 square, 86×24 board |
| `kit-checkbox-unchecked-dark` | 18×18 square, 94×22 board | 20×20 square, 96×24 board |
| `kit-checkbox-checked-dark` | 18×18 square, 84×22 board | 20×20 square, 86×24 board |

Per-shape adjustments:

- **bg rectangle** (`kit-cb-bg-*`): 18→20pt, parent `(0,0)` anchor preserved.
- **dark unchecked border** (`kit-cb-border-d`): 18→20pt. **Already present** with a visible 1pt `#48484a` inner-stroke border — no change required to add a border (audit copy was outdated).
- **light border overlay** (`kit-cb-border-l`): 18→20pt.
- **checkmark glyph** (`kit-cb-mark-*`): font size 12→13pt, re-centred at parent `(3,3)` inside the 20pt square.
- **label** (`kit-cb-lbl-*`): shifted +2pt right (parentX 24→26) to keep the 4pt gap from the enlarged square.
- **board frame**: width +2pt, height 22→24pt to keep a 2pt vertical safe area around the 20pt square.

## Swift parity verification (no macos-agent follow-up needed)

Workspace-wide grep of `apps/macos/cubelite/cubelite/Views/` for `.checkbox|CheckboxToggleStyle|toggleStyle` returns **0 matches**.

All `Toggle(...)` usages in the codebase:

- `PreferencesView.swift:45` "Launch at login"
- `PreferencesView.swift:46` "Show system namespaces"
- `PreferencesView.swift:96` "Skip TLS certificate verification"

…render as the standard macOS switch (NSSwitch), **not** as a checkbox. There is no Swift checkbox to verify against the 20pt minimum — the Code section of the acceptance criteria is vacuously satisfied. No macos-agent delegation required.

## Docs

`docs/penpot-macos-audit.md` §3.1 / §4.9 updated; the ⚠️ P1 marker has been removed.

## Workspace URL

https://design.penpot.app/#/workspace?file-id=30c95215-44cf-80fa-8007-dc318de1085f&page-id=1b8565c6-f550-8090-8007-de5c859bcd4a