### PR TITLE
design(tokens): import design/tokens.json into Penpot and bind every kit-* fill/stroke

### DIFF
--- a/docs/penpot-macos-audit.md
+++ b/docs/penpot-macos-audit.md
@@ -257,8 +257,7 @@ follow-up issue tracked under #73.
    `PreferencesView - General - *`. Same for Advanced/TLS, Logs and
    Deployment Detail. Pick the newer set, archive the legacy with a
    `[LEGACY]` prefix on the name.
-5. **No Penpot tokens configured** — `penpot.library.local.tokens.sets`
-   is empty. Import `design/tokens.json` so colors/sizes can be bound.
+5. ✅ **Penpot tokens configured (resolved in #132)** — `penpot.library.local.tokens` now contains **9 token sets** (`primitive/color`, `semantic/light`, `semantic/dark`, `spacing`, `radius`, `font/size`, `font/weight`, `apple-system/light`, `apple-system/dark`) totalling **136 tokens**, plus 2 themes in the `Mode` group (`Light`, `Dark`) wired to the corresponding sets. The two `apple-system/*` sets capture the literal NSColor hex values currently in use by the macOS kit (22 light + 19 dark) under semantic names (`label`, `secondary-label`, `surface`, `separator`, `border`, `system-blue`, etc.). **All 46 `kit-*` boards bound**: 127 fill bindings + 11 stroke bindings (138 total) — zero literal hex values remain in any kit-* shape on the States & Components page. The `semantic/*` sets imported from `design/tokens.json` are available for future desktop/web work but the macOS kit is bound to `apple-system/*` to preserve visual fidelity with the Apple system palette.
 6. **Component reuse missing** — every kit-* atom is a stand-alone board
    instead of a Penpot library component. Promote the kit-* boards to
    components so screens can instance them.
@@ -285,9 +284,10 @@ review lives in `docs/hig-review-report.md`.
 
 - **Body text 13pt minimum**, never below 10pt — honoured in current boards.
 - **Control hit target ≥ 20×20pt** — checkbox kit fails (see §4.9).
-- **Use system semantic colors** — current kit uses literal hex values that
-  match the macOS system palette; once Penpot tokens are imported, every
-  fill must bind to a token, not a hex.
+- **Use system semantic colors** — ✅ every kit-* fill / stroke is now bound
+  to a Penpot color token (138 bindings across 46 boards). Bindings target
+  the `apple-system/light` and `apple-system/dark` sets, which mirror the
+  NSColor system palette. See §4.5 for details. (resolved in #132)
 - **Sidebar icons follow user accent** — do not pin a hard color. Verify
   every sidebar row icon in `MainView – *` boards is annotated with
   "tint = accent" rather than a fixed fill.


### PR DESCRIPTION
Closes #132. Refs #73.

## Summary

Imports `design/tokens.json` into Penpot's local token catalog as 9 sets / 136 tokens, creates Light + Dark themes, and binds **every fill and stroke** on the 46 `kit-*` boards (States & Components page) to a Penpot color token. No literal hex remains on any kit shape.

## Token sets created

| Set | Tokens | Source |
|---|---|---|
| `primitive/color` | 11 | `zinc-50` … `zinc-950` hex from `design/tokens.json` |
| `semantic/light` | 27 | shadcn semantic palette (HSL strings) |
| `semantic/dark` | 27 | shadcn semantic palette, dark mode |
| `spacing` | 13 | rem scale `0` … `24` |
| `radius` | 7 | `none` … `full` (borderRadius type) |
| `font/size` | 6 | `xs` … `2xl` |
| `font/weight` | 4 | `normal/medium/semibold/bold` |
| `apple-system/light` | 22 | NSColor palette currently in macOS kit (`label`, `surface`, `separator`, `border`, `system-blue`, traffic lights, etc.) |
| `apple-system/dark` | 19 | NSColor dark palette in macOS kit |

## Themes

Two themes in the `Mode` group:

- **Light**: `primitive/color` + `semantic/light` + `spacing` + `radius` + `font/size` + `font/weight` + `apple-system/light`
- **Dark**: `primitive/color` + `semantic/dark` + `spacing` + `radius` + `font/size` + `font/weight` + `apple-system/dark`

> ⚠️ **Penpot Plugin API quirk**: `TokenTheme.addSet()` records the reference but does not auto-activate the referenced sets when the theme toggles active. Sets are therefore activated directly so that both light and dark kit boards render correctly on canvas. The themes still serve as named presets for UI-driven switching.

## kit-* binding pass

- Walked all 46 `kit-*` boards recursively.
- Bound **127 fills + 11 strokes = 138 total bindings** via `TokenColor.applyToShapes(shape, ["fill" | "strokeColor"])`.
- Light variants → `apple-system/light` tokens; dark variants → `apple-system/dark` tokens.
- 0 unbound hex values remain.
- Verified by exporting `kit-formfield-light` and `kit-button-dark` after the pass — visuals unchanged.

## Why `apple-system/*` and not `semantic/*` from `tokens.json`?

`design/tokens.json` contains shadcn-style HSL semantic neutrals which **do not match Apple's NSColor system palette** used by the macOS kit. Binding kit-* directly to `semantic/*` would have caused visible color drift on every board. Adding `apple-system/*` alongside the imported `semantic/*` keeps both palettes available without regressing the macOS canvas. The `semantic/*` sets are ready for future desktop/web work (`apps/desktop/`) where shadcn neutrals are correct.

## Docs

`docs/penpot-macos-audit.md` §4.5 (Penpot tokens gap) and §5 (HIG 'system semantic colors' note) updated to mark the gap ✅ resolved.

## No Swift changes

Penpot-only. No `apps/macos/` code touched. No macos-agent delegation required.

## Workspace URL

https://design.penpot.app/#/workspace?file-id=30c95215-44cf-80fa-8007-dc318de1085f&page-id=1b8565c6-f550-8090-8007-de5c859bcd4a