### PR TITLE
feat(core+desktop): list/watch Services, Ingresses, ConfigMaps, Secrets

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -1,6 +1,8 @@
 use cubelite_core::{
     client::KubeClient,
-    resources::{DeploymentInfo, NamespaceInfo, PodInfo},
+    resources::{
+        ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+    },
     ResourceType, ResourceWatcher, WatchEvent,
 };
 use futures::StreamExt;
@@ -69,9 +71,81 @@ pub async fn list_deployments(
         .map_err(|e| e.to_string())
 }
 
+/// List services in the given namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_services(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<ServiceInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_services(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List ingresses in the given namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_ingresses(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<IngressInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_ingresses(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List config maps in the given namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_configmaps(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<ConfigMapInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_configmaps(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List secrets in the given namespace (all namespaces when `None`).
+///
+/// Secret values are base64-decoded locally in the Rust backend and never
+/// leave the machine.
+#[tauri::command]
+pub async fn list_secrets(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<SecretInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_secrets(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Start watching a Kubernetes resource type and emit Tauri events for each change.
 ///
-/// `resource_type` must be one of `"pod"`, `"namespace"`, or `"deployment"`.
+/// `resource_type` must be one of `"pod"`, `"namespace"`, `"deployment"`,
+/// `"service"`, `"ingress"`, `"configmap"`, or `"secret"`.
 /// Returns a unique watch ID that can be passed to [`unwatch_resources`] to stop
 /// the stream.
 ///

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod commands;
 
 use commands::kubernetes::{
-    get_current_context, list_contexts, list_deployments, list_namespaces, list_pods, set_context,
-    unwatch_resources, watch_resources, WatchState,
+    get_current_context, list_configmaps, list_contexts, list_deployments, list_ingresses,
+    list_namespaces, list_pods, list_secrets, list_services, set_context, unwatch_resources,
+    watch_resources, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -13,6 +14,10 @@ pub fn run() {
             list_pods,
             list_namespaces,
             list_deployments,
+            list_services,
+            list_ingresses,
+            list_configmaps,
+            list_secrets,
             watch_resources,
             unwatch_resources,
             list_contexts,

--- a/apps/desktop/src/lib/age.test.ts
+++ b/apps/desktop/src/lib/age.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { formatAge } from "$lib/age";
+
+const now = new Date("2026-07-11T12:00:00Z");
+
+describe("formatAge", () => {
+  it("returns a dash for missing or invalid timestamps", () => {
+    expect(formatAge(null, now)).toBe("—");
+    expect(formatAge("not-a-date", now)).toBe("—");
+  });
+
+  it("formats seconds and minutes", () => {
+    expect(formatAge("2026-07-11T11:59:30Z", now)).toBe("30s");
+    expect(formatAge("2026-07-11T11:15:00Z", now)).toBe("45m");
+  });
+
+  it("formats hours with minute detail under 10h", () => {
+    expect(formatAge("2026-07-11T09:30:00Z", now)).toBe("2h30m");
+    expect(formatAge("2026-07-11T01:00:00Z", now)).toBe("11h");
+  });
+
+  it("formats days with hour detail under 10d", () => {
+    expect(formatAge("2026-07-08T06:00:00Z", now)).toBe("3d6h");
+    expect(formatAge("2026-06-01T12:00:00Z", now)).toBe("40d");
+  });
+
+  it("clamps future timestamps to zero", () => {
+    expect(formatAge("2026-07-11T12:05:00Z", now)).toBe("0s");
+  });
+});

--- a/apps/desktop/src/lib/age.ts
+++ b/apps/desktop/src/lib/age.ts
@@ -1,0 +1,20 @@
+/** kubectl-style relative age from an RFC 3339 timestamp (e.g. "3d", "5h12m"). */
+export function formatAge(iso: string | null, now: Date = new Date()): string {
+  if (!iso) return "—";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "—";
+
+  let seconds = Math.floor((now.getTime() - then) / 1000);
+  if (seconds < 0) seconds = 0;
+
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (days >= 10) return `${days}d`;
+  if (days >= 1) return hours > 0 ? `${days}d${hours}h` : `${days}d`;
+  if (hours >= 10) return `${hours}h`;
+  if (hours >= 1) return minutes > 0 ? `${hours}h${minutes}m` : `${hours}h`;
+  if (minutes >= 1) return `${minutes}m`;
+  return `${seconds}s`;
+}

--- a/apps/desktop/src/lib/components/views/ConfigMapsView.svelte
+++ b/apps/desktop/src/lib/components/views/ConfigMapsView.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('configmaps');
+	});
+
+	const grid = 'grid-template-columns: 3fr 0.6fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">ConfigMaps</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Data</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.configmaps.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No config maps found.</p>
+				{:else}
+					{#each resources.configmaps as cm (cm.namespace + '/' + cm.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+							<span class="type-data truncate text-text-data-bright">{cm.name}</span>
+							<span class="type-data-sm text-text-secondary">{cm.data_count}</span>
+							<span class="type-data-sm text-text-secondary">{formatAge(cm.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/IngressesView.svelte
+++ b/apps/desktop/src/lib/components/views/IngressesView.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('ingresses');
+	});
+
+	const grid = 'grid-template-columns: 1.8fr 0.7fr 1.6fr 1.1fr 0.7fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">Ingresses</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Class</span>
+				<span class="type-colhead">Hosts</span>
+				<span class="type-colhead">Address</span>
+				<span class="type-colhead">Ports</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.ingresses.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No ingresses found.</p>
+				{:else}
+					{#each resources.ingresses as ing (ing.namespace + '/' + ing.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+							<span class="type-data truncate text-text-data-bright">{ing.name}</span>
+							<span class="type-data-sm text-text-secondary">{ing.class ?? '—'}</span>
+							<span class="type-data-sm truncate {ing.hosts.length ? 'text-text-secondary' : 'text-text-disabled'}">
+								{ing.hosts.length ? ing.hosts.join(', ') : '*'}
+							</span>
+							<span class="type-data-sm truncate {ing.addresses.length ? 'text-text-secondary' : 'text-text-disabled'}">
+								{ing.addresses.length ? ing.addresses.join(', ') : '—'}
+							</span>
+							<span class="type-data-sm text-text-secondary">{ing.tls ? '80, 443' : '80'}</span>
+							<span class="type-data-sm text-text-secondary">{formatAge(ing.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/SecretsView.svelte
+++ b/apps/desktop/src/lib/components/views/SecretsView.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import Eye from '@lucide/svelte/icons/eye';
+	import EyeOff from '@lucide/svelte/icons/eye-off';
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('secrets');
+	});
+
+	// Per-visit reveal state; cleared when the view unmounts.
+	let revealed = $state<Record<string, boolean>>({});
+
+	function keyOf(ns: string, name: string): string {
+		return `${ns}/${name}`;
+	}
+
+	function toggle(ns: string, name: string) {
+		const key = keyOf(ns, name);
+		revealed = { ...revealed, [key]: !revealed[key] };
+	}
+
+	const grid = 'grid-template-columns: 2.2fr 1.3fr 0.5fr 0.55fr 0.7fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<div class="flex items-center gap-3">
+		<h1 class="type-title flex-1">Secrets</h1>
+		<span
+			class="rounded-full px-2.5 py-1 text-[10.5px] font-medium"
+			style="background: var(--alpha-pill-warn); color: var(--color-status-warn);"
+		>
+			values decoded locally — never leave this machine
+		</span>
+	</div>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Type</span>
+				<span class="type-colhead">Data</span>
+				<span class="type-colhead">Age</span>
+				<span class="type-colhead">Reveal</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.secrets.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No secrets found.</p>
+				{:else}
+					{#each resources.secrets as secret (secret.namespace + '/' + secret.name)}
+						{@const isRevealed = revealed[keyOf(secret.namespace, secret.name)] ?? false}
+						<div class="border-b border-border-faint last:border-b-0">
+							<div
+								class="grid items-center gap-x-3 px-3 hover:bg-surface-row-hover"
+								style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+							>
+								<span class="type-data truncate text-text-data-bright">{secret.name}</span>
+								<span class="type-data-sm truncate text-text-secondary">{secret.secret_type ?? '—'}</span>
+								<span class="type-data-sm text-text-secondary">{Object.keys(secret.data).length}</span>
+								<span class="type-data-sm text-text-secondary">{formatAge(secret.creation_timestamp)}</span>
+								<button
+									type="button"
+									class="focus-ring type-caption flex h-6 w-fit items-center gap-1 rounded-md border border-border-default bg-surface-raised px-2 text-text-secondary hover:brightness-110"
+									onclick={() => toggle(secret.namespace, secret.name)}
+								>
+									{#if isRevealed}
+										<EyeOff class="h-3 w-3" />
+										Hide
+									{:else}
+										<Eye class="h-3 w-3" />
+										Reveal
+									{/if}
+								</button>
+							</div>
+							{#if Object.keys(secret.data).length > 0}
+								<div class="flex flex-col gap-1 bg-surface-sunken px-3 py-2">
+									{#each Object.entries(secret.data) as [key, value] (key)}
+										<div class="flex items-baseline gap-3">
+											<span class="type-data-sm w-44 shrink-0 truncate text-text-tertiary">{key}</span>
+											<span
+												class="type-data-sm break-all {isRevealed ? 'text-text-log' : 'text-text-disabled'}"
+											>
+												{isRevealed ? value : '••••••••'}
+											</span>
+										</div>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/ServicesView.svelte
+++ b/apps/desktop/src/lib/components/views/ServicesView.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('services');
+	});
+
+	const grid = 'grid-template-columns: 2fr 0.9fr 1fr 1fr 1.4fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">Services</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Type</span>
+				<span class="type-colhead">Cluster-IP</span>
+				<span class="type-colhead">External-IP</span>
+				<span class="type-colhead">Ports</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.services.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No services found.</p>
+				{:else}
+					{#each resources.services as svc (svc.namespace + '/' + svc.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+							<span class="type-data truncate text-text-data-bright">{svc.name}</span>
+							<span class="type-data-sm text-text-secondary">{svc.service_type ?? '—'}</span>
+							<span class="type-data-sm truncate text-text-secondary">{svc.cluster_ip ?? '—'}</span>
+							<span class="type-data-sm truncate {svc.external_ips.length ? 'text-text-secondary' : 'text-text-disabled'}">
+								{svc.external_ips.length ? svc.external_ips.join(', ') : '—'}
+							</span>
+							<span class="type-data-sm truncate text-text-secondary">{svc.ports.join(', ') || '—'}</span>
+							<span class="type-data-sm text-text-secondary">{formatAge(svc.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/index.ts
+++ b/apps/desktop/src/lib/components/views/index.ts
@@ -7,10 +7,14 @@
 import type { Component } from "svelte";
 import type { View } from "$lib/stores/app.svelte";
 import AllClustersView from "./AllClustersView.svelte";
+import ConfigMapsView from "./ConfigMapsView.svelte";
 import DeploymentsView from "./DeploymentsView.svelte";
 import EmptyStateView from "./EmptyStateView.svelte";
+import IngressesView from "./IngressesView.svelte";
 import OverviewView from "./OverviewView.svelte";
 import PodsView from "./PodsView.svelte";
+import SecretsView from "./SecretsView.svelte";
+import ServicesView from "./ServicesView.svelte";
 
 export interface ViewEntry {
   component: Component<Record<string, unknown>>;
@@ -36,10 +40,10 @@ export const viewRegistry: Record<View, ViewEntry> = {
   pods: asEntry(PodsView),
   deployments: asEntry(DeploymentsView),
   helm: emptyState("The Helm Releases view"),
-  services: emptyState("The Services view"),
-  ingresses: emptyState("The Ingresses view"),
-  configmaps: emptyState("The ConfigMaps view"),
-  secrets: emptyState("The Secrets view"),
+  services: asEntry(ServicesView),
+  ingresses: asEntry(IngressesView),
+  configmaps: asEntry(ConfigMapsView),
+  secrets: asEntry(SecretsView),
   events: emptyState("The Events view"),
   logs: emptyState("The Logs view"),
 };

--- a/apps/desktop/src/lib/components/views/kind-views.test.ts
+++ b/apps/desktop/src/lib/components/views/kind-views.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+
+vi.mock("$lib/tauri", () => ({
+  listContexts: vi.fn(),
+  setContext: vi.fn(),
+  listPods: vi.fn(),
+  listNamespaces: vi.fn(),
+  listDeployments: vi.fn(),
+  listServices: vi.fn(async () => []),
+  listIngresses: vi.fn(async () => []),
+  listConfigMaps: vi.fn(async () => []),
+  listSecrets: vi.fn(async () => []),
+  watchResources: vi.fn(),
+  unwatchResources: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+import ServicesView from "./ServicesView.svelte";
+import IngressesView from "./IngressesView.svelte";
+import ConfigMapsView from "./ConfigMapsView.svelte";
+import SecretsView from "./SecretsView.svelte";
+import { app } from "$lib/stores/app.svelte";
+import { resources } from "$lib/stores/resources.svelte";
+
+beforeEach(() => {
+  app.view = "services";
+  app.activeCluster = "prod";
+  app.kubeconfigPath = "/home/u/.kube/config";
+  app.namespace = null;
+  resources.clear();
+});
+
+describe("ServicesView", () => {
+  it("renders kubectl-convention columns and rows", () => {
+    resources.services = [
+      {
+        name: "web",
+        namespace: "default",
+        service_type: "LoadBalancer",
+        cluster_ip: "10.0.0.1",
+        external_ips: ["203.0.113.9"],
+        ports: ["80/TCP", "443:30443/TCP"],
+        creation_timestamp: null,
+      },
+    ];
+    render(ServicesView);
+    for (const h of ["Name", "Type", "Cluster-IP", "External-IP", "Ports", "Age"]) {
+      expect(screen.getByText(h)).toBeInTheDocument();
+    }
+    expect(screen.getByText("web")).toBeInTheDocument();
+    expect(screen.getByText("LoadBalancer")).toBeInTheDocument();
+    expect(screen.getByText("80/TCP, 443:30443/TCP")).toBeInTheDocument();
+  });
+
+  it("shows the empty state", () => {
+    render(ServicesView);
+    expect(screen.getByText("No services found.")).toBeInTheDocument();
+  });
+
+  it("shows the load error", async () => {
+    const { listServices } = await import("$lib/tauri");
+    vi.mocked(listServices).mockRejectedValueOnce(new Error("forbidden"));
+    render(ServicesView);
+    expect(await screen.findByText("forbidden")).toBeInTheDocument();
+  });
+});
+
+describe("IngressesView", () => {
+  it("renders hosts, tls ports and address", () => {
+    resources.ingresses = [
+      {
+        name: "web",
+        namespace: "default",
+        class: "nginx",
+        hosts: ["app.example.com"],
+        addresses: ["203.0.113.9"],
+        tls: true,
+        creation_timestamp: null,
+      },
+    ];
+    render(IngressesView);
+    expect(screen.getByText("app.example.com")).toBeInTheDocument();
+    expect(screen.getByText("80, 443")).toBeInTheDocument();
+    expect(screen.getByText("nginx")).toBeInTheDocument();
+  });
+});
+
+describe("ConfigMapsView", () => {
+  it("renders name and data count", () => {
+    resources.configmaps = [
+      { name: "settings", namespace: "default", data_count: 3, creation_timestamp: null },
+    ];
+    render(ConfigMapsView);
+    expect(screen.getByText("settings")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+});
+
+describe("SecretsView", () => {
+  const secret = {
+    name: "creds",
+    namespace: "default",
+    secret_type: "Opaque",
+    data: { password: "hunter2" },
+    creation_timestamp: null,
+  };
+
+  async function renderWithSecret() {
+    const { listSecrets } = await import("$lib/tauri");
+    vi.mocked(listSecrets).mockResolvedValue([secret]);
+    render(SecretsView);
+    await screen.findByText("creds");
+  }
+
+  it("masks values and shows the local-only warning pill", async () => {
+    await renderWithSecret();
+    expect(screen.getByText(/never leave this machine/)).toBeInTheDocument();
+    expect(screen.getByText("••••••••")).toBeInTheDocument();
+    expect(screen.queryByText("hunter2")).toBeNull();
+  });
+
+  it("reveals and hides values per row", async () => {
+    await renderWithSecret();
+    await fireEvent.click(screen.getByRole("button", { name: /Reveal/ }));
+    expect(screen.getByText("hunter2")).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole("button", { name: /Hide/ }));
+    expect(screen.queryByText("hunter2")).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/stores/resources.svelte.ts
+++ b/apps/desktop/src/lib/stores/resources.svelte.ts
@@ -6,14 +6,22 @@
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
+  listConfigMaps,
   listDeployments,
+  listIngresses,
   listNamespaces,
   listPods,
+  listSecrets,
+  listServices,
   unwatchResources,
   watchResources,
+  type ConfigMapInfo,
   type DeploymentInfo,
+  type IngressInfo,
   type NamespaceInfo,
   type PodInfo,
+  type SecretInfo,
+  type ServiceInfo,
 } from "$lib/tauri";
 import { errorMessage } from "$lib/errors";
 import { app } from "./app.svelte";
@@ -21,14 +29,30 @@ import { settings } from "./settings.svelte";
 
 const RELOAD_DEBOUNCE_MS = 300;
 
+/** Resource kinds loaded on demand when their view is opened. */
+export type ExtraKind = "services" | "ingresses" | "configmaps" | "secrets";
+
+const EXTRA_KINDS: readonly ExtraKind[] = ["services", "ingresses", "configmaps", "secrets"];
+
+export function isExtraKind(v: unknown): v is ExtraKind {
+  return typeof v === "string" && (EXTRA_KINDS as readonly string[]).includes(v);
+}
+
 class ResourcesStore {
   pods = $state<PodInfo[]>([]);
   namespaces = $state<NamespaceInfo[]>([]);
   deployments = $state<DeploymentInfo[]>([]);
+  services = $state<ServiceInfo[]>([]);
+  ingresses = $state<IngressInfo[]>([]);
+  configmaps = $state<ConfigMapInfo[]>([]);
+  secrets = $state<SecretInfo[]>([]);
   loading = $state(false);
   error = $state<string | null>(null);
+  extraLoading = $state(false);
+  extraError = $state<string | null>(null);
 
   #loadSeq = 0;
+  #extraSeq = 0;
   #watchIds: string[] = [];
   #unlisteners: UnlistenFn[] = [];
   #reloadTimer: ReturnType<typeof setTimeout> | null = null;
@@ -88,6 +112,8 @@ class ResourcesStore {
       this.pods = podList;
       this.namespaces = nsList;
       this.deployments = depList;
+      // Keep the currently open extra view in sync with refresh/watch cycles.
+      if (isExtraKind(app.view)) void this.loadKind(app.view);
       return true;
     } catch (e) {
       if (seq === this.#loadSeq) this.error = errorMessage(e);
@@ -97,14 +123,61 @@ class ResourcesStore {
     }
   }
 
+  /** Load one on-demand kind (services/ingresses/configmaps/secrets). */
+  async loadKind(kind: ExtraKind): Promise<void> {
+    const seq = ++this.#extraSeq;
+    const kc = app.kubeconfigPath;
+    const cluster = app.activeCluster;
+    const ns = app.namespace ?? undefined;
+    if (!kc || !cluster) return;
+
+    this.extraLoading = true;
+    this.extraError = null;
+    try {
+      switch (kind) {
+        case "services": {
+          const list = await listServices(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.services = list;
+          break;
+        }
+        case "ingresses": {
+          const list = await listIngresses(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.ingresses = list;
+          break;
+        }
+        case "configmaps": {
+          const list = await listConfigMaps(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.configmaps = list;
+          break;
+        }
+        case "secrets": {
+          const list = await listSecrets(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.secrets = list;
+          break;
+        }
+      }
+    } catch (e) {
+      if (seq === this.#extraSeq) this.extraError = errorMessage(e);
+    } finally {
+      if (seq === this.#extraSeq) this.extraLoading = false;
+    }
+  }
+
   /** Invalidate in-flight loads and clear data (call before switching cluster). */
   clear(): void {
     this.#loadSeq++;
+    this.#extraSeq++;
     this.pods = [];
     this.namespaces = [];
     this.deployments = [];
+    this.services = [];
+    this.ingresses = [];
+    this.configmaps = [];
+    this.secrets = [];
     this.error = null;
     this.loading = false;
+    this.extraError = null;
+    this.extraLoading = false;
   }
 
   #scheduleReload(): void {

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -29,6 +29,42 @@ export type ContextInfo = {
   is_active: boolean;
 };
 
+export type ServiceInfo = {
+  name: string;
+  namespace: string;
+  service_type: string | null;
+  cluster_ip: string | null;
+  external_ips: string[];
+  ports: string[];
+  creation_timestamp: string | null;
+};
+
+export type IngressInfo = {
+  name: string;
+  namespace: string;
+  class: string | null;
+  hosts: string[];
+  addresses: string[];
+  tls: boolean;
+  creation_timestamp: string | null;
+};
+
+export type ConfigMapInfo = {
+  name: string;
+  namespace: string;
+  data_count: number;
+  creation_timestamp: string | null;
+};
+
+export type SecretInfo = {
+  name: string;
+  namespace: string;
+  secret_type: string | null;
+  /** Values decoded locally by the backend — they never leave this machine. */
+  data: Record<string, string>;
+  creation_timestamp: string | null;
+};
+
 // --- Invoke wrappers ---
 
 export function listContexts(): Promise<ContextInfo[]> {
@@ -73,6 +109,54 @@ export function listDeployments(
   return invoke<DeploymentInfo[]>("list_deployments", {
     kubeconfigPath,
     namespace,
+    context: context ?? null,
+  });
+}
+
+export function listServices(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<ServiceInfo[]> {
+  return invoke<ServiceInfo[]>("list_services", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listIngresses(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<IngressInfo[]> {
+  return invoke<IngressInfo[]>("list_ingresses", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listConfigMaps(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<ConfigMapInfo[]> {
+  return invoke<ConfigMapInfo[]>("list_configmaps", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listSecrets(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<SecretInfo[]> {
+  return invoke<SecretInfo[]>("list_secrets", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
     context: context ?? null,
   });
 }

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -4,7 +4,8 @@
 //! methods for listing the most common Kubernetes resources.
 
 use k8s_openapi::api::apps::v1::Deployment;
-use k8s_openapi::api::core::v1::{Namespace, Pod};
+use k8s_openapi::api::core::v1::{ConfigMap, Namespace, Pod, Secret, Service};
+use k8s_openapi::api::networking::v1::Ingress;
 use kube::{
     config::{KubeConfigOptions, Kubeconfig},
     Api, Client, Config,
@@ -13,7 +14,10 @@ use std::path::Path;
 
 use crate::{
     error::KubeconfigError,
-    resources::{DeploymentInfo, NamespaceInfo, PodInfo},
+    resources::{
+        ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+    },
+    watcher::{configmap_to_info, ingress_to_info, secret_to_info, service_to_info},
 };
 
 /// An async Kubernetes client pre-configured from a kubeconfig file.
@@ -186,5 +190,99 @@ impl KubeClient {
             .collect();
 
         Ok(deployments)
+    }
+
+    /// List services in `namespace`, or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_services(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<ServiceInfo>, KubeconfigError> {
+        let api: Api<Service> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.into_iter().filter_map(service_to_info).collect())
+    }
+
+    /// List ingresses in `namespace`, or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_ingresses(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<IngressInfo>, KubeconfigError> {
+        let api: Api<Ingress> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.into_iter().filter_map(ingress_to_info).collect())
+    }
+
+    /// List config maps in `namespace`, or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_configmaps(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<ConfigMapInfo>, KubeconfigError> {
+        let api: Api<ConfigMap> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list
+            .items
+            .into_iter()
+            .filter_map(configmap_to_info)
+            .collect())
+    }
+
+    /// List secrets in `namespace`, or across all namespaces when `None`.
+    ///
+    /// Values are base64-decoded locally and never leave the machine.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_secrets(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<SecretInfo>, KubeconfigError> {
+        let api: Api<Secret> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.into_iter().filter_map(secret_to_info).collect())
     }
 }

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -40,7 +40,9 @@ pub mod watcher;
 pub use client::KubeClient;
 pub use error::{ContextError, KubeconfigError};
 pub use kubeconfig::KubeConfig;
-pub use resources::{DeploymentInfo, NamespaceInfo, PodInfo};
+pub use resources::{
+    ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+};
 pub use types::{
     ClusterDetails, ContextDetails, ContextInfo, KubeConfigFile, NamedCluster, NamedContext,
     NamedUser, UserDetails,

--- a/crates/cubelite-core/src/resources.rs
+++ b/crates/cubelite-core/src/resources.rs
@@ -36,3 +36,72 @@ pub struct DeploymentInfo {
     /// Number of replicas currently reporting as ready.
     pub ready_replicas: i32,
 }
+
+/// Lightweight representation of a Kubernetes Service.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceInfo {
+    /// The service name.
+    pub name: String,
+    /// The namespace the service belongs to.
+    pub namespace: String,
+    /// The service type (e.g. `"ClusterIP"`, `"NodePort"`, `"LoadBalancer"`).
+    pub service_type: Option<String>,
+    /// The cluster-internal IP, if assigned (`"None"` for headless services).
+    pub cluster_ip: Option<String>,
+    /// External IPs or load-balancer hostnames/addresses, if any.
+    pub external_ips: Vec<String>,
+    /// Exposed ports rendered kubectl-style (e.g. `"80/TCP"`, `"443:30443/TCP"`).
+    pub ports: Vec<String>,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes Ingress.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IngressInfo {
+    /// The ingress name.
+    pub name: String,
+    /// The namespace the ingress belongs to.
+    pub namespace: String,
+    /// The ingress class name, if set.
+    pub class: Option<String>,
+    /// Hostnames covered by the ingress rules.
+    pub hosts: Vec<String>,
+    /// Load-balancer addresses (IPs or hostnames) assigned to the ingress.
+    pub addresses: Vec<String>,
+    /// `true` when a TLS section is present (ports 80+443 vs 80 only).
+    pub tls: bool,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes ConfigMap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigMapInfo {
+    /// The config map name.
+    pub name: String,
+    /// The namespace the config map belongs to.
+    pub namespace: String,
+    /// Number of data entries (`data` + `binaryData` keys).
+    pub data_count: usize,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes Secret.
+///
+/// Values are base64-decoded locally by the backend and never leave the
+/// machine; binary values are replaced with a `"(binary)"` placeholder.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecretInfo {
+    /// The secret name.
+    pub name: String,
+    /// The namespace the secret belongs to.
+    pub namespace: String,
+    /// The secret type (e.g. `"Opaque"`, `"kubernetes.io/tls"`).
+    pub secret_type: Option<String>,
+    /// Decoded key/value entries, sorted by key.
+    pub data: std::collections::BTreeMap<String, String>,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}

--- a/crates/cubelite-core/src/watcher.rs
+++ b/crates/cubelite-core/src/watcher.rs
@@ -23,12 +23,15 @@ use std::pin::Pin;
 use futures::{Stream, StreamExt};
 use k8s_openapi::api::{
     apps::v1::Deployment,
-    core::v1::{Namespace, Pod},
+    core::v1::{ConfigMap, Namespace, Pod, Secret, Service},
+    networking::v1::Ingress,
 };
 use kube::{runtime::watcher, Api, Client};
 use serde::{Deserialize, Serialize};
 
-use crate::resources::{DeploymentInfo, NamespaceInfo, PodInfo};
+use crate::resources::{
+    ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+};
 
 /// Selects which Kubernetes resource type to watch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -40,6 +43,14 @@ pub enum ResourceType {
     Namespace,
     /// Watch deployments.
     Deployment,
+    /// Watch services.
+    Service,
+    /// Watch ingresses.
+    Ingress,
+    /// Watch config maps.
+    ConfigMap,
+    /// Watch secrets.
+    Secret,
 }
 
 /// A Kubernetes resource payload, discriminated by type.
@@ -54,6 +65,14 @@ pub enum ResourceInfo {
     Namespace(NamespaceInfo),
     /// A deployment resource.
     Deployment(DeploymentInfo),
+    /// A service resource.
+    Service(ServiceInfo),
+    /// An ingress resource.
+    Ingress(IngressInfo),
+    /// A config map resource.
+    ConfigMap(ConfigMapInfo),
+    /// A secret resource.
+    Secret(SecretInfo),
 }
 
 /// A single watch event emitted from a [`ResourceWatcher`] stream.
@@ -132,6 +151,42 @@ impl ResourceWatcher {
                     map_event(ev, deployment_to_info, ResourceInfo::Deployment)
                 }))
             }
+            ResourceType::Service => {
+                let api: Api<Service> = match ns.as_deref() {
+                    Some(n) => Api::namespaced(client, n),
+                    None => Api::all(client),
+                };
+                Box::pin(watcher::watcher(api, config).filter_map(|ev| async move {
+                    map_event(ev, service_to_info, ResourceInfo::Service)
+                }))
+            }
+            ResourceType::Ingress => {
+                let api: Api<Ingress> = match ns.as_deref() {
+                    Some(n) => Api::namespaced(client, n),
+                    None => Api::all(client),
+                };
+                Box::pin(watcher::watcher(api, config).filter_map(|ev| async move {
+                    map_event(ev, ingress_to_info, ResourceInfo::Ingress)
+                }))
+            }
+            ResourceType::ConfigMap => {
+                let api: Api<ConfigMap> = match ns.as_deref() {
+                    Some(n) => Api::namespaced(client, n),
+                    None => Api::all(client),
+                };
+                Box::pin(watcher::watcher(api, config).filter_map(|ev| async move {
+                    map_event(ev, configmap_to_info, ResourceInfo::ConfigMap)
+                }))
+            }
+            ResourceType::Secret => {
+                let api: Api<Secret> = match ns.as_deref() {
+                    Some(n) => Api::namespaced(client, n),
+                    None => Api::all(client),
+                };
+                Box::pin(watcher::watcher(api, config).filter_map(|ev| async move {
+                    map_event(ev, secret_to_info, ResourceInfo::Secret)
+                }))
+            }
         }
     }
 }
@@ -193,6 +248,141 @@ fn namespace_to_info(ns: Namespace) -> Option<NamespaceInfo> {
     Some(NamespaceInfo { name, phase })
 }
 
+/// RFC 3339 creation timestamp from object metadata, if present.
+fn creation_timestamp(
+    meta: &k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
+) -> Option<String> {
+    meta.creation_timestamp.as_ref().map(|t| t.0.to_rfc3339())
+}
+
+/// Convert a raw [`Service`] object into a [`ServiceInfo`], returning `None`
+/// if there is no name.
+pub(crate) fn service_to_info(s: Service) -> Option<ServiceInfo> {
+    let name = s.metadata.name.clone()?;
+    let namespace = s.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&s.metadata);
+    let spec = s.spec.unwrap_or_default();
+
+    let mut external_ips: Vec<String> = spec.external_ips.unwrap_or_default();
+    if let Some(lb) = s.status.and_then(|st| st.load_balancer) {
+        for ing in lb.ingress.unwrap_or_default() {
+            if let Some(ip) = ing.ip {
+                external_ips.push(ip);
+            } else if let Some(host) = ing.hostname {
+                external_ips.push(host);
+            }
+        }
+    }
+
+    let ports = spec
+        .ports
+        .unwrap_or_default()
+        .into_iter()
+        .map(|p| {
+            let protocol = p.protocol.unwrap_or_else(|| "TCP".to_string());
+            match p.node_port {
+                Some(np) => format!("{}:{np}/{protocol}", p.port),
+                None => format!("{}/{protocol}", p.port),
+            }
+        })
+        .collect();
+
+    Some(ServiceInfo {
+        name,
+        namespace,
+        service_type: spec.type_,
+        cluster_ip: spec.cluster_ip,
+        external_ips,
+        ports,
+        creation_timestamp: creation,
+    })
+}
+
+/// Convert a raw [`Ingress`] object into an [`IngressInfo`], returning `None`
+/// if there is no name.
+pub(crate) fn ingress_to_info(i: Ingress) -> Option<IngressInfo> {
+    let name = i.metadata.name.clone()?;
+    let namespace = i.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&i.metadata);
+
+    let (class, hosts, tls) = match i.spec {
+        Some(spec) => {
+            let hosts = spec
+                .rules
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|r| r.host)
+                .collect();
+            let tls = spec.tls.is_some_and(|t| !t.is_empty());
+            (spec.ingress_class_name, hosts, tls)
+        }
+        None => (None, Vec::new(), false),
+    };
+
+    let addresses = i
+        .status
+        .and_then(|st| st.load_balancer)
+        .and_then(|lb| lb.ingress)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|ing| ing.ip.or(ing.hostname))
+        .collect();
+
+    Some(IngressInfo {
+        name,
+        namespace,
+        class,
+        hosts,
+        addresses,
+        tls,
+        creation_timestamp: creation,
+    })
+}
+
+/// Convert a raw [`ConfigMap`] object into a [`ConfigMapInfo`], returning
+/// `None` if there is no name.
+pub(crate) fn configmap_to_info(cm: ConfigMap) -> Option<ConfigMapInfo> {
+    let name = cm.metadata.name.clone()?;
+    let namespace = cm.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&cm.metadata);
+    let data_count = cm.data.map_or(0, |d| d.len()) + cm.binary_data.map_or(0, |d| d.len());
+
+    Some(ConfigMapInfo {
+        name,
+        namespace,
+        data_count,
+        creation_timestamp: creation,
+    })
+}
+
+/// Convert a raw [`Secret`] object into a [`SecretInfo`], returning `None`
+/// if there is no name.
+///
+/// Values are decoded to UTF-8 locally; non-UTF-8 payloads are replaced with
+/// a `"(binary)"` placeholder so raw bytes never cross the IPC boundary.
+pub(crate) fn secret_to_info(s: Secret) -> Option<SecretInfo> {
+    let name = s.metadata.name.clone()?;
+    let namespace = s.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&s.metadata);
+
+    let mut data = std::collections::BTreeMap::new();
+    for (key, value) in s.data.unwrap_or_default() {
+        let decoded = String::from_utf8(value.0).unwrap_or_else(|_| "(binary)".to_string());
+        data.insert(key, decoded);
+    }
+    for (key, value) in s.string_data.unwrap_or_default() {
+        data.insert(key, value);
+    }
+
+    Some(SecretInfo {
+        name,
+        namespace,
+        secret_type: s.type_,
+        data,
+        creation_timestamp: creation,
+    })
+}
+
 /// Convert a raw [`Deployment`] object into a [`DeploymentInfo`], returning
 /// `None` if there is no name.
 fn deployment_to_info(d: Deployment) -> Option<DeploymentInfo> {
@@ -230,6 +420,10 @@ mod tests {
             (ResourceType::Pod, "\"pod\""),
             (ResourceType::Namespace, "\"namespace\""),
             (ResourceType::Deployment, "\"deployment\""),
+            (ResourceType::Service, "\"service\""),
+            (ResourceType::Ingress, "\"ingress\""),
+            (ResourceType::ConfigMap, "\"configmap\""),
+            (ResourceType::Secret, "\"secret\""),
         ];
         for (rt, expected_json) in cases {
             let json = serde_json::to_string(&rt).unwrap();
@@ -334,6 +528,143 @@ mod tests {
         let info = namespace_to_info(ns).unwrap();
         assert_eq!(info.name, "production");
         assert_eq!(info.phase.as_deref(), Some("Active"));
+    }
+
+    #[test]
+    fn service_to_info_conversion() {
+        use k8s_openapi::api::core::v1::{
+            LoadBalancerIngress, LoadBalancerStatus, Service, ServicePort, ServiceSpec,
+            ServiceStatus,
+        };
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let svc = Service {
+            metadata: ObjectMeta {
+                name: Some("web".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: Some(ServiceSpec {
+                type_: Some("LoadBalancer".to_string()),
+                cluster_ip: Some("10.0.0.1".to_string()),
+                ports: Some(vec![
+                    ServicePort {
+                        port: 80,
+                        ..Default::default()
+                    },
+                    ServicePort {
+                        port: 443,
+                        node_port: Some(30443),
+                        protocol: Some("TCP".to_string()),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }),
+            status: Some(ServiceStatus {
+                load_balancer: Some(LoadBalancerStatus {
+                    ingress: Some(vec![LoadBalancerIngress {
+                        ip: Some("203.0.113.9".to_string()),
+                        ..Default::default()
+                    }]),
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let info = service_to_info(svc).unwrap();
+        assert_eq!(info.name, "web");
+        assert_eq!(info.service_type.as_deref(), Some("LoadBalancer"));
+        assert_eq!(info.cluster_ip.as_deref(), Some("10.0.0.1"));
+        assert_eq!(info.external_ips, vec!["203.0.113.9"]);
+        assert_eq!(info.ports, vec!["80/TCP", "443:30443/TCP"]);
+    }
+
+    #[test]
+    fn ingress_to_info_conversion() {
+        use k8s_openapi::api::networking::v1::{Ingress, IngressRule, IngressSpec, IngressTLS};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let ing = Ingress {
+            metadata: ObjectMeta {
+                name: Some("web".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: Some(IngressSpec {
+                ingress_class_name: Some("nginx".to_string()),
+                rules: Some(vec![IngressRule {
+                    host: Some("app.example.com".to_string()),
+                    ..Default::default()
+                }]),
+                tls: Some(vec![IngressTLS::default()]),
+                ..Default::default()
+            }),
+            status: None,
+        };
+
+        let info = ingress_to_info(ing).unwrap();
+        assert_eq!(info.class.as_deref(), Some("nginx"));
+        assert_eq!(info.hosts, vec!["app.example.com"]);
+        assert!(info.tls);
+        assert!(info.addresses.is_empty());
+    }
+
+    #[test]
+    fn configmap_to_info_counts_data_and_binary_data() {
+        use k8s_openapi::api::core::v1::ConfigMap;
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+        use k8s_openapi::ByteString;
+        use std::collections::BTreeMap;
+
+        let cm = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some("settings".to_string()),
+                ..Default::default()
+            },
+            data: Some(BTreeMap::from([(
+                "config.yaml".to_string(),
+                "a: 1".to_string(),
+            )])),
+            binary_data: Some(BTreeMap::from([(
+                "blob".to_string(),
+                ByteString(vec![0xff]),
+            )])),
+            ..Default::default()
+        };
+
+        let info = configmap_to_info(cm).unwrap();
+        assert_eq!(info.data_count, 2);
+    }
+
+    #[test]
+    fn secret_to_info_decodes_utf8_and_masks_binary() {
+        use k8s_openapi::api::core::v1::Secret;
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+        use k8s_openapi::ByteString;
+        use std::collections::BTreeMap;
+
+        let secret = Secret {
+            metadata: ObjectMeta {
+                name: Some("creds".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            type_: Some("Opaque".to_string()),
+            data: Some(BTreeMap::from([
+                ("password".to_string(), ByteString(b"hunter2".to_vec())),
+                ("cert".to_string(), ByteString(vec![0xff, 0xfe])),
+            ])),
+            ..Default::default()
+        };
+
+        let info = secret_to_info(secret).unwrap();
+        assert_eq!(info.secret_type.as_deref(), Some("Opaque"));
+        assert_eq!(
+            info.data.get("password").map(String::as_str),
+            Some("hunter2")
+        );
+        assert_eq!(info.data.get("cert").map(String::as_str), Some("(binary)"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #237

## Backend (cubelite-core + src-tauri)
- `ServiceInfo` / `IngressInfo` / `ConfigMapInfo` / `SecretInfo` with RFC 3339 creation timestamps
- `KubeClient::list_services / list_ingresses / list_configmaps / list_secrets` — namespace optional, cluster-wide when `None`
- `ResourceType` / `ResourceInfo` watch variants for all four kinds (converters shared between client and watcher)
- Secret values are base64-decoded **locally** in Rust; non-UTF-8 payloads masked as `(binary)` so raw bytes never cross IPC
- Tauri commands registered + one typed wrapper per command in `lib/tauri.ts`

## Frontend
- `resources` store: on-demand `loadKind()` with stale-result guard; the open view refreshes alongside pods/deployments on watch events and auto-refresh
- **Services / Ingresses / ConfigMaps**: kubectl-convention tables per the design handoff (mono names, spec empty states)
- **Secrets**: masked `••••••••` values, per-row Reveal/Hide, warn pill "values decoded locally — never leave this machine"
- kubectl-style relative AGE (`lib/age.ts`)

## Verification (all exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace` (68 tests, incl. 9 new converter/serde tests)
- `pnpm --filter desktop lint / typecheck / test / build` — 112 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)