### PR TITLE
feat(core+desktop): Events listing and Events view

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -1,7 +1,8 @@
 use cubelite_core::{
     client::KubeClient,
     resources::{
-        ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+        ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
+        ServiceInfo,
     },
     ResourceType, ResourceWatcher, WatchEvent,
 };
@@ -138,6 +139,24 @@ pub async fn list_secrets(
 
     client
         .list_secrets(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List events in the given namespace (all namespaces when `None`),
+/// sorted most-recent first.
+#[tauri::command]
+pub async fn list_events(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<EventInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_events(namespace.as_deref())
         .await
         .map_err(|e| e.to_string())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod commands;
 
 use commands::kubernetes::{
-    get_current_context, list_configmaps, list_contexts, list_deployments, list_ingresses,
-    list_namespaces, list_pods, list_secrets, list_services, set_context, unwatch_resources,
-    watch_resources, WatchState,
+    get_current_context, list_configmaps, list_contexts, list_deployments, list_events,
+    list_ingresses, list_namespaces, list_pods, list_secrets, list_services, set_context,
+    unwatch_resources, watch_resources, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -18,6 +18,7 @@ pub fn run() {
             list_ingresses,
             list_configmaps,
             list_secrets,
+            list_events,
             watch_resources,
             unwatch_resources,
             list_contexts,

--- a/apps/desktop/src/lib/components/CommandPalette.test.ts
+++ b/apps/desktop/src/lib/components/CommandPalette.test.ts
@@ -8,6 +8,7 @@ vi.mock("$lib/tauri", () => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));

--- a/apps/desktop/src/lib/components/overlays.test.ts
+++ b/apps/desktop/src/lib/components/overlays.test.ts
@@ -8,6 +8,7 @@ vi.mock("$lib/tauri", () => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));

--- a/apps/desktop/src/lib/components/shell/Sidebar.svelte
+++ b/apps/desktop/src/lib/components/shell/Sidebar.svelte
@@ -51,6 +51,7 @@
 	];
 
 	const issueCount = $derived(resources.issuePods.length);
+	const warningCount = $derived(resources.warningEvents.length);
 
 	function countFor(view: View): number | null {
 		if (view === 'pods') return resources.pods.length;
@@ -78,6 +79,9 @@
 					</span>
 					{#if item.view === 'pods' && issueCount > 0}
 						<span class="font-mono text-[10.5px] text-status-err">{issueCount}</span>
+					{/if}
+					{#if item.view === 'events' && warningCount > 0}
+						<span class="font-mono text-[10.5px] text-status-err">{warningCount}</span>
 					{/if}
 					{#if count !== null}
 						<span class="font-mono text-[10.5px] text-text-tertiary">{count}</span>

--- a/apps/desktop/src/lib/components/shell/StatusBar.svelte
+++ b/apps/desktop/src/lib/components/shell/StatusBar.svelte
@@ -7,7 +7,7 @@
 	const server = $derived(
 		clusters.contexts.find((c) => c.name === app.activeCluster)?.cluster_server ?? null
 	);
-	const issueCount = $derived(resources.issuePods.length);
+	const warningCount = $derived(resources.warningEvents.length);
 	const refreshLabel = $derived(
 		settings.refreshInterval.value === 0
 			? 'refresh off'
@@ -25,13 +25,13 @@
 	{/if}
 	<span>{refreshLabel}</span>
 	<span class="flex-1"></span>
-	{#if issueCount > 0}
+	{#if warningCount > 0}
 		<button
 			type="button"
 			class="focus-ring rounded-sm text-status-warn hover:brightness-110"
-			onclick={() => app.navigate('pods')}
+			onclick={() => app.navigate('events')}
 		>
-			{issueCount} issue{issueCount === 1 ? '' : 's'}
+			{warningCount} warning{warningCount === 1 ? '' : 's'}
 		</button>
 	{/if}
 </footer>

--- a/apps/desktop/src/lib/components/shell/shell.test.ts
+++ b/apps/desktop/src/lib/components/shell/shell.test.ts
@@ -8,6 +8,7 @@ vi.mock("$lib/tauri", () => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));
@@ -49,6 +50,7 @@ beforeEach(() => {
   resources.pods = [];
   resources.namespaces = [];
   resources.deployments = [];
+  resources.events = [];
 });
 
 describe("Titlebar", () => {
@@ -140,13 +142,23 @@ describe("Sidebar", () => {
 });
 
 describe("StatusBar", () => {
-  it("shows server, refresh interval and clickable issue count", async () => {
-    resources.pods = [pod({ ready: false, phase: "Pending" })];
+  it("shows server, refresh interval and clickable warning count", async () => {
+    resources.events = [
+      {
+        event_type: "Warning",
+        reason: "BackOff",
+        object: "Pod/api-0",
+        message: "Back-off restarting failed container",
+        namespace: "default",
+        count: 3,
+        last_timestamp: null,
+      },
+    ];
     render(StatusBar);
     expect(screen.getByText("https://prod.azmk8s.io:443")).toBeInTheDocument();
     expect(screen.getByText(/refresh/)).toBeInTheDocument();
-    const issues = screen.getByText("1 issue");
-    await fireEvent.click(issues);
-    expect(app.view).toBe("pods");
+    const warnings = screen.getByText("1 warning");
+    await fireEvent.click(warnings);
+    expect(app.view).toBe("events");
   });
 });

--- a/apps/desktop/src/lib/components/views/EventsView.svelte
+++ b/apps/desktop/src/lib/components/views/EventsView.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	const grid = 'grid-template-columns: 0.7fr 1fr 1.4fr 2.6fr 0.5fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">Events</h1>
+
+	<div class="overflow-hidden rounded-lg border border-border-default">
+		<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+			<span class="type-colhead">Type</span>
+			<span class="type-colhead">Reason</span>
+			<span class="type-colhead">Object</span>
+			<span class="type-colhead">Message</span>
+			<span class="type-colhead">Age</span>
+		</div>
+		<div class="bg-surface-panel">
+			{#if resources.events.length === 0}
+				<p class="py-8 text-center text-xs text-text-disabled">No events found.</p>
+			{:else}
+				{#each resources.events as event, i (i)}
+					{@const warning = event.event_type === 'Warning'}
+					<div
+						class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+						style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default); {warning
+							? 'background: var(--alpha-log-warn-row);'
+							: ''}"
+					>
+						<span>
+							<span
+								class="inline-flex rounded-full px-2 py-0.5 text-[10.5px] font-medium"
+								style={warning
+									? 'background: var(--alpha-pill-warn); color: var(--color-status-warn);'
+									: 'background: var(--color-surface-raised); color: var(--color-text-secondary);'}
+							>
+								{event.event_type ?? '—'}
+							</span>
+						</span>
+						<span class="type-data-sm truncate text-text-secondary">
+							{event.reason ?? '—'}{event.count > 1 ? ` ×${event.count}` : ''}
+						</span>
+						<span class="type-data-sm truncate text-text-secondary">{event.object}</span>
+						<span class="type-caption truncate text-text-secondary">{event.message ?? '—'}</span>
+						<span class="type-data-sm text-text-secondary">{formatAge(event.last_timestamp)}</span>
+					</div>
+				{/each}
+			{/if}
+		</div>
+	</div>
+</div>

--- a/apps/desktop/src/lib/components/views/OverviewView.svelte
+++ b/apps/desktop/src/lib/components/views/OverviewView.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
+	import { formatAge } from '$lib/age';
 	import MeterBar from '$lib/components/ui/MeterBar.svelte';
 	import StatCard from '$lib/components/ui/StatCard.svelte';
-	import { podStatusLabel, podTone, toneColor } from '$lib/status';
 	import { app } from '$lib/stores/app.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
 
-	const issues = $derived(resources.issuePods);
+	const warnings = $derived(resources.warningEvents);
 </script>
 
 <div class="flex flex-col gap-4 p-4">
@@ -16,7 +16,7 @@
 		<StatCard label="Nodes" value="—" />
 		<StatCard label="Pods running" value={resources.runningPods} />
 		<StatCard label="Deployments" value={resources.deployments.length} />
-		<StatCard label="Issues" value={issues.length} tone={issues.length > 0 ? 'warn' : 'ok'} />
+		<StatCard label="Warnings" value={warnings.length} tone={warnings.length > 0 ? 'warn' : 'ok'} />
 	</div>
 
 	<div class="grid gap-3 xl:grid-cols-2">
@@ -31,37 +31,35 @@
 
 		<div class="rounded-xl border border-border-default bg-surface-surface p-4">
 			<div class="mb-2 flex items-center">
-				<div class="type-colhead flex-1">Recent issues</div>
+				<div class="type-colhead flex-1">Recent warnings</div>
 				<button
 					type="button"
 					class="focus-ring type-caption flex items-center gap-1 rounded-sm text-text-tertiary hover:text-text-secondary"
-					onclick={() => app.navigate('pods')}
+					onclick={() => app.navigate('events')}
 				>
-					All pods
+					All events
 					<ArrowRight class="h-3 w-3" />
 				</button>
 			</div>
-			{#if issues.length === 0}
-				<p class="type-caption text-text-disabled">No pod issues detected.</p>
+			{#if warnings.length === 0}
+				<p class="type-caption text-text-disabled">No warning events.</p>
 			{:else}
 				<div class="flex flex-col">
-					{#each issues.slice(0, 5) as pod (pod.namespace + '/' + pod.name)}
+					{#each warnings.slice(0, 5) as event, i (i)}
 						<button
 							type="button"
 							class="flex items-center gap-2 rounded-md px-1.5 py-1 text-left hover:bg-surface-row-hover"
-							onclick={() => {
-								app.navigate('pods');
-								app.selectedPod = pod;
-							}}
+							onclick={() => app.navigate('events')}
 						>
 							<span
 								class="h-1.5 w-1.5 shrink-0 rounded-full"
-								style="background: {toneColor[podTone(pod)]};"
+								style="background: var(--color-status-warn);"
 							></span>
-							<span class="type-data-sm flex-1 truncate text-text-secondary">
-								{pod.namespace}/{pod.name}
+							<span class="type-data-sm w-40 shrink-0 truncate text-text-secondary">{event.object}</span>
+							<span class="type-caption flex-1 truncate text-text-tertiary">
+								{event.message ?? event.reason ?? '—'}
 							</span>
-							<span class="type-caption text-text-tertiary">{podStatusLabel(pod)}</span>
+							<span class="type-caption text-text-tertiary">{formatAge(event.last_timestamp)}</span>
 						</button>
 					{/each}
 				</div>

--- a/apps/desktop/src/lib/components/views/index.ts
+++ b/apps/desktop/src/lib/components/views/index.ts
@@ -10,6 +10,7 @@ import AllClustersView from "./AllClustersView.svelte";
 import ConfigMapsView from "./ConfigMapsView.svelte";
 import DeploymentsView from "./DeploymentsView.svelte";
 import EmptyStateView from "./EmptyStateView.svelte";
+import EventsView from "./EventsView.svelte";
 import IngressesView from "./IngressesView.svelte";
 import OverviewView from "./OverviewView.svelte";
 import PodsView from "./PodsView.svelte";
@@ -44,6 +45,6 @@ export const viewRegistry: Record<View, ViewEntry> = {
   ingresses: asEntry(IngressesView),
   configmaps: asEntry(ConfigMapsView),
   secrets: asEntry(SecretsView),
-  events: emptyState("The Events view"),
+  events: asEntry(EventsView),
   logs: emptyState("The Logs view"),
 };

--- a/apps/desktop/src/lib/components/views/kind-views.test.ts
+++ b/apps/desktop/src/lib/components/views/kind-views.test.ts
@@ -8,6 +8,7 @@ vi.mock("$lib/tauri", () => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
   listServices: vi.fn(async () => []),
   listIngresses: vi.fn(async () => []),
   listConfigMaps: vi.fn(async () => []),

--- a/apps/desktop/src/lib/components/views/views.test.ts
+++ b/apps/desktop/src/lib/components/views/views.test.ts
@@ -8,6 +8,7 @@ vi.mock("$lib/tauri", () => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));
@@ -17,6 +18,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 import EmptyStateView from "./EmptyStateView.svelte";
 import UnreachableView from "./UnreachableView.svelte";
+import EventsView from "./EventsView.svelte";
 import OverviewView from "./OverviewView.svelte";
 import AllClustersView from "./AllClustersView.svelte";
 import PodsView from "./PodsView.svelte";
@@ -55,6 +57,7 @@ beforeEach(() => {
   resources.pods = [];
   resources.namespaces = [];
   resources.deployments = [];
+  resources.events = [];
 });
 
 describe("EmptyStateView", () => {
@@ -79,14 +82,27 @@ describe("UnreachableView", () => {
 });
 
 describe("OverviewView", () => {
-  it("shows real stats, dashes for missing data and the metrics caption", () => {
+  it("shows real stats, metrics caption and recent warning events", () => {
     resources.pods = [pod(), pod({ name: "api-1", ready: false, phase: "Pending" })];
     resources.deployments = [{ name: "api", namespace: "default", replicas: 2, ready_replicas: 1 }];
+    resources.events = [
+      {
+        event_type: "Warning",
+        reason: "FailedScheduling",
+        object: "Pod/api-1",
+        message: "0/3 nodes are available",
+        namespace: "default",
+        count: 1,
+        last_timestamp: null,
+      },
+    ];
     render(OverviewView);
     expect(screen.getByText("Nodes")).toBeInTheDocument();
     expect(screen.getByText("Pods running")).toBeInTheDocument();
     expect(screen.getByText(/metrics unavailable/)).toBeInTheDocument();
-    expect(screen.getByText("default/api-1")).toBeInTheDocument();
+    expect(screen.getByText("Recent warnings")).toBeInTheDocument();
+    expect(screen.getByText("Pod/api-1")).toBeInTheDocument();
+    expect(screen.getByText("0/3 nodes are available")).toBeInTheDocument();
   });
 });
 
@@ -138,5 +154,44 @@ describe("PodDrawer", () => {
     render(PodDrawer, { props: { pod: pod(), onClose } });
     await fireEvent.click(screen.getByLabelText("Close"));
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("EventsView", () => {
+  it("renders type pills, warning row tint and count suffix", () => {
+    resources.events = [
+      {
+        event_type: "Warning",
+        reason: "BackOff",
+        object: "Pod/api-0",
+        message: "Back-off restarting failed container",
+        namespace: "default",
+        count: 7,
+        last_timestamp: null,
+      },
+      {
+        event_type: "Normal",
+        reason: "Scheduled",
+        object: "Pod/api-1",
+        message: "Successfully assigned default/api-1",
+        namespace: "default",
+        count: 1,
+        last_timestamp: null,
+      },
+    ];
+    render(EventsView);
+    for (const h of ["Type", "Reason", "Object", "Message", "Age"]) {
+      expect(screen.getByText(h)).toBeInTheDocument();
+    }
+    expect(screen.getByText("Warning")).toBeInTheDocument();
+    expect(screen.getByText("Normal")).toBeInTheDocument();
+    expect(screen.getByText(/BackOff ×7/)).toBeInTheDocument();
+    const warningRow = screen.getByText("Pod/api-0").closest("div");
+    expect(warningRow?.getAttribute("style")).toContain("--alpha-log-warn-row");
+  });
+
+  it("shows the empty state", () => {
+    render(EventsView);
+    expect(screen.getByText("No events found.")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/lib/stores/clusters.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/clusters.svelte.test.ts
@@ -6,6 +6,7 @@ vi.mock("$lib/tauri", () => ({
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));

--- a/apps/desktop/src/lib/stores/resources.svelte.ts
+++ b/apps/desktop/src/lib/stores/resources.svelte.ts
@@ -8,6 +8,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   listConfigMaps,
   listDeployments,
+  listEvents,
   listIngresses,
   listNamespaces,
   listPods,
@@ -17,6 +18,7 @@ import {
   watchResources,
   type ConfigMapInfo,
   type DeploymentInfo,
+  type EventInfo,
   type IngressInfo,
   type NamespaceInfo,
   type PodInfo,
@@ -42,6 +44,7 @@ class ResourcesStore {
   pods = $state<PodInfo[]>([]);
   namespaces = $state<NamespaceInfo[]>([]);
   deployments = $state<DeploymentInfo[]>([]);
+  events = $state<EventInfo[]>([]);
   services = $state<ServiceInfo[]>([]);
   ingresses = $state<IngressInfo[]>([]);
   configmaps = $state<ConfigMapInfo[]>([]);
@@ -71,11 +74,16 @@ class ResourcesStore {
     return this.pods.filter((p) => p.phase === "Running").length;
   }
 
-  /** Pods that are not ready or restarting hard — the "warnings" surrogate. */
+  /** Pods that are not ready or restarting hard. */
   get issuePods(): PodInfo[] {
     return this.pods.filter(
       (p) => (!p.ready && p.phase !== "Succeeded") || p.restarts > 3,
     );
+  }
+
+  /** Warning-type events (drives sidebar/status-bar counts and Overview). */
+  get warningEvents(): EventInfo[] {
+    return this.events.filter((e) => e.event_type === "Warning");
   }
 
   /**
@@ -93,9 +101,11 @@ class ResourcesStore {
     this.loading = true;
     this.error = null;
     try {
-      const [podList, nsList] = await Promise.all([
+      const [podList, nsList, eventList] = await Promise.all([
         listPods(kc, ns ?? undefined, cluster),
         listNamespaces(kc, cluster),
+        // Events are non-fatal: the warnings count degrades to empty.
+        listEvents(kc, ns ?? undefined, cluster).catch(() => [] as EventInfo[]),
       ]);
       // list_deployments requires a namespace: fan out when filtering "all".
       const depList = ns
@@ -112,6 +122,7 @@ class ResourcesStore {
       this.pods = podList;
       this.namespaces = nsList;
       this.deployments = depList;
+      this.events = eventList;
       // Keep the currently open extra view in sync with refresh/watch cycles.
       if (isExtraKind(app.view)) void this.loadKind(app.view);
       return true;
@@ -170,6 +181,7 @@ class ResourcesStore {
     this.pods = [];
     this.namespaces = [];
     this.deployments = [];
+    this.events = [];
     this.services = [];
     this.ingresses = [];
     this.configmaps = [];

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -56,6 +56,16 @@ export type ConfigMapInfo = {
   creation_timestamp: string | null;
 };
 
+export type EventInfo = {
+  event_type: string | null;
+  reason: string | null;
+  object: string;
+  message: string | null;
+  namespace: string;
+  count: number;
+  last_timestamp: string | null;
+};
+
 export type SecretInfo = {
   name: string;
   namespace: string;
@@ -155,6 +165,18 @@ export function listSecrets(
   context?: string,
 ): Promise<SecretInfo[]> {
   return invoke<SecretInfo[]>("list_secrets", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listEvents(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<EventInfo[]> {
+  return invoke<EventInfo[]>("list_events", {
     kubeconfigPath,
     namespace: namespace ?? null,
     context: context ?? null,

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -4,7 +4,7 @@
 //! methods for listing the most common Kubernetes resources.
 
 use k8s_openapi::api::apps::v1::Deployment;
-use k8s_openapi::api::core::v1::{ConfigMap, Namespace, Pod, Secret, Service};
+use k8s_openapi::api::core::v1::{ConfigMap, Event, Namespace, Pod, Secret, Service};
 use k8s_openapi::api::networking::v1::Ingress;
 use kube::{
     config::{KubeConfigOptions, Kubeconfig},
@@ -15,7 +15,8 @@ use std::path::Path;
 use crate::{
     error::KubeconfigError,
     resources::{
-        ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+        ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
+        ServiceInfo,
     },
     watcher::{configmap_to_info, ingress_to_info, secret_to_info, service_to_info},
 };
@@ -284,5 +285,112 @@ impl KubeClient {
                     reason: e.to_string(),
                 })?;
         Ok(list.items.into_iter().filter_map(secret_to_info).collect())
+    }
+
+    /// List events in `namespace`, or across all namespaces when `None`,
+    /// sorted most-recent first.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_events(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<EventInfo>, KubeconfigError> {
+        let api: Api<Event> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        let mut events: Vec<EventInfo> = list.items.into_iter().map(event_to_info).collect();
+        events.sort_by(|a, b| b.last_timestamp.cmp(&a.last_timestamp));
+        Ok(events)
+    }
+}
+
+/// Convert a raw [`Event`] object into an [`EventInfo`].
+fn event_to_info(e: Event) -> EventInfo {
+    let object = match (&e.involved_object.kind, &e.involved_object.name) {
+        (Some(kind), Some(name)) => format!("{kind}/{name}"),
+        (None, Some(name)) => name.clone(),
+        _ => "—".to_string(),
+    };
+    // Prefer the most recent signal available: series, lastTimestamp, eventTime.
+    let last_timestamp = e
+        .series
+        .as_ref()
+        .and_then(|s| s.last_observed_time.as_ref().map(|t| t.0.to_rfc3339()))
+        .or_else(|| e.last_timestamp.as_ref().map(|t| t.0.to_rfc3339()))
+        .or_else(|| e.event_time.as_ref().map(|t| t.0.to_rfc3339()));
+
+    EventInfo {
+        event_type: e.type_,
+        reason: e.reason,
+        object,
+        message: e.message,
+        namespace: e.metadata.namespace.unwrap_or_default(),
+        count: e.count.unwrap_or(1),
+        last_timestamp,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{EventSource, ObjectReference};
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, Time};
+
+    #[test]
+    fn event_to_info_full() {
+        let e = Event {
+            metadata: ObjectMeta {
+                name: Some("api-0.evt".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            involved_object: ObjectReference {
+                kind: Some("Pod".to_string()),
+                name: Some("api-0".to_string()),
+                ..Default::default()
+            },
+            type_: Some("Warning".to_string()),
+            reason: Some("BackOff".to_string()),
+            message: Some("Back-off restarting failed container".to_string()),
+            count: Some(7),
+            last_timestamp: Some(Time(
+                k8s_openapi::chrono::DateTime::parse_from_rfc3339("2026-07-11T10:00:00Z")
+                    .expect("valid test timestamp")
+                    .with_timezone(&k8s_openapi::chrono::Utc),
+            )),
+            source: Some(EventSource::default()),
+            ..Default::default()
+        };
+
+        let info = event_to_info(e);
+        assert_eq!(info.event_type.as_deref(), Some("Warning"));
+        assert_eq!(info.reason.as_deref(), Some("BackOff"));
+        assert_eq!(info.object, "Pod/api-0");
+        assert_eq!(info.count, 7);
+        assert!(info
+            .last_timestamp
+            .as_deref()
+            .is_some_and(|t| t.starts_with("2026-07-11T10:00:00")));
+    }
+
+    #[test]
+    fn event_to_info_defaults() {
+        let e = Event {
+            involved_object: ObjectReference::default(),
+            ..Default::default()
+        };
+        let info = event_to_info(e);
+        assert_eq!(info.object, "—");
+        assert_eq!(info.count, 1);
+        assert!(info.last_timestamp.is_none());
     }
 }

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -41,7 +41,8 @@ pub use client::KubeClient;
 pub use error::{ContextError, KubeconfigError};
 pub use kubeconfig::KubeConfig;
 pub use resources::{
-    ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+    ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
+    ServiceInfo,
 };
 pub use types::{
     ClusterDetails, ContextDetails, ContextInfo, KubeConfigFile, NamedCluster, NamedContext,

--- a/crates/cubelite-core/src/resources.rs
+++ b/crates/cubelite-core/src/resources.rs
@@ -88,6 +88,25 @@ pub struct ConfigMapInfo {
     pub creation_timestamp: Option<String>,
 }
 
+/// Lightweight representation of a Kubernetes Event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventInfo {
+    /// Event type (`"Normal"` or `"Warning"`).
+    pub event_type: Option<String>,
+    /// Machine-readable reason (e.g. `"BackOff"`, `"Scheduled"`).
+    pub reason: Option<String>,
+    /// Involved object rendered kubectl-style (e.g. `"Pod/api-0"`).
+    pub object: String,
+    /// Human-readable message.
+    pub message: Option<String>,
+    /// The namespace the event belongs to.
+    pub namespace: String,
+    /// Number of occurrences of this event.
+    pub count: i32,
+    /// RFC 3339 timestamp of the most recent occurrence.
+    pub last_timestamp: Option<String>,
+}
+
 /// Lightweight representation of a Kubernetes Secret.
 ///
 /// Values are base64-decoded locally by the backend and never leave the


### PR DESCRIPTION
Closes #238

## Backend
- `EventInfo` in cubelite-core: type, reason, kubectl-style `Kind/name` object, message, count, most-recent timestamp (series → lastTimestamp → eventTime)
- `KubeClient::list_events` — namespace optional, cluster-wide when `None`, sorted newest first
- `list_events` Tauri command + typed wrapper

## Frontend
- Events loaded eagerly alongside pods/namespaces (non-fatal: warnings count degrades to empty on RBAC failure)
- **Events view** per design handoff: TYPE pill (Warning = warn 10% bg, Normal = raised bg), REASON mono with `×N` count suffix, OBJECT / MESSAGE / AGE, warning rows warn-4% background
- Sidebar Observe→Events shows live warning count in err color
- Status bar warnings count now navigates to Events (was Pods surrogate)
- Overview "Recent warnings" card backed by real events with "All events →" link

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace` (2 new event converter tests)
- `pnpm --filter desktop lint / typecheck / test / build` — 114 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)