### PR TITLE
feat(core+desktop): aggregated pod log streaming and Logs view

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -1,5 +1,6 @@
 use cubelite_core::{
     client::KubeClient,
+    logs::stream_pod_logs,
     resources::{
         ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
         ServiceInfo,
@@ -7,6 +8,7 @@ use cubelite_core::{
     ResourceType, ResourceWatcher, WatchEvent,
 };
 use futures::StreamExt;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -16,6 +18,30 @@ use tokio::task::JoinHandle;
 
 /// Monotonically increasing counter for generating unique watch IDs.
 static WATCH_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Monotonically increasing counter for generating unique log stream IDs.
+static LOG_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Maximum number of pods aggregated into one log stream.
+const MAX_LOG_PODS: usize = 20;
+
+/// Tauri managed state holding all active log stream task handles.
+///
+/// Keyed by the stream ID string returned from [`stream_logs`]; each stream
+/// aggregates one task per followed pod.
+#[derive(Default)]
+pub struct LogState {
+    handles: Mutex<HashMap<String, Vec<JoinHandle<()>>>>,
+}
+
+/// A pod to follow in an aggregated log stream.
+#[derive(Debug, Deserialize)]
+pub struct PodRef {
+    /// Namespace of the pod.
+    pub namespace: String,
+    /// Pod name.
+    pub name: String,
+}
 
 /// Tauri managed state holding all active watch task handles.
 ///
@@ -212,6 +238,66 @@ pub async fn watch_resources(
         .insert(watch_id.clone(), handle);
 
     Ok(watch_id)
+}
+
+/// Start an aggregated log stream over the given pods (capped at 20).
+///
+/// Each line is parsed (timestamp + severity) and emitted as a `"log-line"`
+/// Tauri event with a `LogLine` payload. Returns a stream ID for
+/// [`stop_logs`].
+#[tauri::command]
+pub async fn stream_logs(
+    app: AppHandle,
+    kubeconfig_path: String,
+    pods: Vec<PodRef>,
+    context: Option<String>,
+) -> Result<String, String> {
+    let kube_client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+    let client = kube_client.client();
+
+    let stream_id = LOG_COUNTER.fetch_add(1, Ordering::SeqCst).to_string();
+    let mut handles = Vec::new();
+
+    for pod in pods.into_iter().take(MAX_LOG_PODS) {
+        let app_clone = app.clone();
+        let mut stream = stream_pod_logs(client.clone(), pod.namespace, pod.name, 50);
+        handles.push(tokio::spawn(async move {
+            while let Some(line) = stream.next().await {
+                // Ignore emit errors — the frontend window may have been closed.
+                let _ = app_clone.emit("log-line", line);
+            }
+        }));
+    }
+
+    app.state::<LogState>()
+        .handles
+        .lock()
+        .await
+        .insert(stream_id.clone(), handles);
+
+    Ok(stream_id)
+}
+
+/// Stop an aggregated log stream by its stream ID.
+///
+/// All per-pod tasks are aborted. Silently succeeds if `stream_id` is not
+/// found.
+#[tauri::command]
+pub async fn stop_logs(app: AppHandle, stream_id: String) -> Result<(), String> {
+    if let Some(handles) = app
+        .state::<LogState>()
+        .handles
+        .lock()
+        .await
+        .remove(&stream_id)
+    {
+        for handle in handles {
+            handle.abort();
+        }
+    }
+    Ok(())
 }
 
 /// Stop a running watch stream by its watch ID.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,13 +3,14 @@ pub mod commands;
 use commands::kubernetes::{
     get_current_context, list_configmaps, list_contexts, list_deployments, list_events,
     list_ingresses, list_namespaces, list_pods, list_secrets, list_services, set_context,
-    unwatch_resources, watch_resources, WatchState,
+    stop_logs, stream_logs, unwatch_resources, watch_resources, LogState, WatchState,
 };
 
 /// Entry point for the Tauri application.
 pub fn run() {
     if let Err(e) = tauri::Builder::default()
         .manage(WatchState::default())
+        .manage(LogState::default())
         .invoke_handler(tauri::generate_handler![
             list_pods,
             list_namespaces,
@@ -21,6 +22,8 @@ pub fn run() {
             list_events,
             watch_resources,
             unwatch_resources,
+            stream_logs,
+            stop_logs,
             list_contexts,
             get_current_context,
             set_context,

--- a/apps/desktop/src/lib/components/deployments/DeploymentDrawer.svelte
+++ b/apps/desktop/src/lib/components/deployments/DeploymentDrawer.svelte
@@ -5,6 +5,7 @@
 	import StatusPill from '$lib/components/ui/StatusPill.svelte';
 	import { deploymentStatus, podStatusLabel, podTone, toneColor } from '$lib/status';
 	import { app } from '$lib/stores/app.svelte';
+	import { logs } from '$lib/stores/logs.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
 	import type { DeploymentInfo } from '$lib/tauri';
 
@@ -85,6 +86,7 @@
 			class="focus-ring type-body flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md bg-accent text-surface-window hover:brightness-110"
 			onclick={() => {
 				onClose();
+				logs.textFilter = deployment.name;
 				app.navigate('logs');
 			}}
 		>

--- a/apps/desktop/src/lib/components/pods/PodDrawer.svelte
+++ b/apps/desktop/src/lib/components/pods/PodDrawer.svelte
@@ -7,6 +7,7 @@
 	import StatusPill from '$lib/components/ui/StatusPill.svelte';
 	import { podStatusLabel, podTone } from '$lib/status';
 	import { app } from '$lib/stores/app.svelte';
+	import { logs } from '$lib/stores/logs.svelte';
 	import type { PodInfo } from '$lib/tauri';
 
 	let { pod, onClose }: { pod: PodInfo; onClose: () => void } = $props();
@@ -60,6 +61,7 @@
 			class="focus-ring type-body flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md bg-accent text-surface-window hover:brightness-110"
 			onclick={() => {
 				onClose();
+				logs.textFilter = pod.name;
 				app.navigate('logs');
 			}}
 		>

--- a/apps/desktop/src/lib/components/views/LogsView.svelte
+++ b/apps/desktop/src/lib/components/views/LogsView.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { logs, type LevelFilter } from '$lib/stores/logs.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+	import { app } from '$lib/stores/app.svelte';
+	import type { LogLevel } from '$lib/tauri';
+
+	let container = $state<HTMLDivElement | null>(null);
+
+	// (Re)start the aggregated stream when cluster/namespace change.
+	$effect(() => {
+		void [app.activeCluster, app.namespace];
+		const pods = resources.pods.map((p) => ({ namespace: p.namespace, name: p.name }));
+		void logs.start(pods);
+		return () => void logs.stop();
+	});
+
+	// Auto-scroll to bottom while following.
+	$effect(() => {
+		void logs.filtered.length;
+		if (logs.following && container) {
+			container.scrollTop = container.scrollHeight;
+		}
+	});
+
+	const chips: { value: LevelFilter; label: string; color: string | null }[] = [
+		{ value: 'all', label: 'ALL', color: null },
+		{ value: 'info', label: 'INFO', color: 'var(--color-status-info)' },
+		{ value: 'warn', label: 'WARN', color: 'var(--color-status-warn)' },
+		{ value: 'error', label: 'ERROR', color: 'var(--color-status-err)' }
+	];
+
+	const levelColor: Record<LogLevel, string> = {
+		info: 'var(--color-status-info)',
+		warn: 'var(--color-status-warn)',
+		error: 'var(--color-status-err)'
+	};
+
+	function rowStyle(level: LogLevel): string {
+		if (level === 'error')
+			return 'border-left: 2px solid var(--color-status-err); background: var(--alpha-log-error-row);';
+		if (level === 'warn')
+			return 'border-left: 2px solid color-mix(in srgb, var(--color-status-warn) 50%, transparent); background: var(--alpha-log-warn-row);';
+		return 'border-left: 2px solid transparent;';
+	}
+
+	function clock(iso: string | null): string {
+		if (!iso) return '—';
+		const d = new Date(iso);
+		return Number.isNaN(d.getTime()) ? '—' : d.toLocaleTimeString([], { hour12: false });
+	}
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-3 p-4">
+	<div class="flex items-center gap-2">
+		<h1 class="type-title flex-1">Logs</h1>
+
+		<div class="flex overflow-hidden rounded-md border border-border-default">
+			{#each chips as chip (chip.value)}
+				{@const active = logs.level === chip.value}
+				<button
+					type="button"
+					class="type-section h-7 border-r border-border-default px-2.5 last:border-r-0"
+					style={active
+						? chip.color
+							? `background: ${chip.color}; color: var(--color-surface-window);`
+							: 'background: var(--color-text-secondary); color: var(--color-surface-window);'
+						: 'color: var(--color-text-tertiary);'}
+					onclick={() => (logs.level = chip.value)}
+				>
+					{chip.label}
+				</button>
+			{/each}
+		</div>
+
+		<input
+			type="text"
+			placeholder="Filter…"
+			bind:value={logs.textFilter}
+			class="focus-ring h-7 w-44 rounded-md border border-border-default bg-surface-window px-2.5 text-[11.5px] text-text-primary placeholder:text-text-disabled"
+		/>
+
+		<button
+			type="button"
+			class="type-caption flex h-7 items-center gap-1.5 rounded-md px-2.5 font-medium"
+			style={logs.following
+				? 'background: var(--color-status-ok); color: var(--color-surface-window);'
+				: 'background: var(--alpha-pill-warn); color: var(--color-status-warn);'}
+			onclick={() => logs.toggleFollow()}
+		>
+			{logs.following ? '● Following' : '⏸ Paused'}
+		</button>
+
+		<button
+			type="button"
+			class="focus-ring type-caption flex h-7 items-center rounded-md border border-border-default bg-surface-raised px-2.5 text-text-secondary hover:brightness-110"
+			onclick={() => logs.clear()}
+		>
+			Clear
+		</button>
+	</div>
+
+	<div class="relative min-h-0 flex-1 overflow-hidden rounded-lg border border-border-default bg-surface-sunken">
+		{#if !logs.following && logs.bufferedWhilePaused > 0}
+			<div class="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
+				<span
+					class="type-caption animate-pulse rounded-full px-2.5 py-1"
+					style="background: var(--alpha-pill-warn); color: var(--color-status-warn);"
+				>
+					paused — new lines buffered
+				</span>
+			</div>
+		{/if}
+
+		<div bind:this={container} class="h-full overflow-y-auto py-1">
+			{#if logs.filtered.length === 0}
+				<p class="py-8 text-center text-xs text-text-disabled">
+					{logs.lines.length === 0 ? 'Waiting for log lines…' : 'No lines match the filter.'}
+				</p>
+			{:else}
+				{#each logs.filtered as line, i (i)}
+					<div class="flex items-baseline gap-2.5 px-2.5 py-px" style={rowStyle(line.level)}>
+						<span class="shrink-0 font-mono text-[10.5px] text-text-disabled">{clock(line.time)}</span>
+						<span
+							class="w-[38px] shrink-0 font-mono text-[10px] font-semibold uppercase"
+							style="color: {levelColor[line.level]};"
+						>
+							{line.level}
+						</span>
+						<span class="shrink-0 font-mono text-[10.5px] text-text-secondary">{line.pod}</span>
+						<span class="type-log break-all text-text-log">{line.message}</span>
+					</div>
+				{/each}
+			{/if}
+		</div>
+	</div>
+</div>

--- a/apps/desktop/src/lib/components/views/index.ts
+++ b/apps/desktop/src/lib/components/views/index.ts
@@ -12,6 +12,7 @@ import DeploymentsView from "./DeploymentsView.svelte";
 import EmptyStateView from "./EmptyStateView.svelte";
 import EventsView from "./EventsView.svelte";
 import IngressesView from "./IngressesView.svelte";
+import LogsView from "./LogsView.svelte";
 import OverviewView from "./OverviewView.svelte";
 import PodsView from "./PodsView.svelte";
 import SecretsView from "./SecretsView.svelte";
@@ -46,5 +47,5 @@ export const viewRegistry: Record<View, ViewEntry> = {
   configmaps: asEntry(ConfigMapsView),
   secrets: asEntry(SecretsView),
   events: asEntry(EventsView),
-  logs: emptyState("The Logs view"),
+  logs: asEntry(LogsView),
 };

--- a/apps/desktop/src/lib/components/views/logs-view.test.ts
+++ b/apps/desktop/src/lib/components/views/logs-view.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+
+vi.mock("$lib/tauri", () => ({
+  listContexts: vi.fn(),
+  setContext: vi.fn(),
+  listPods: vi.fn(),
+  listNamespaces: vi.fn(),
+  listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
+  listServices: vi.fn(async () => []),
+  listIngresses: vi.fn(async () => []),
+  listConfigMaps: vi.fn(async () => []),
+  listSecrets: vi.fn(async () => []),
+  streamLogs: vi.fn(async () => "1"),
+  stopLogs: vi.fn(async () => undefined),
+  watchResources: vi.fn(),
+  unwatchResources: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+import LogsView from "./LogsView.svelte";
+import { app } from "$lib/stores/app.svelte";
+import { logs } from "$lib/stores/logs.svelte";
+import { resources } from "$lib/stores/resources.svelte";
+import type { LogLine } from "$lib/tauri";
+
+function line(overrides: Partial<LogLine> = {}): LogLine {
+  return {
+    pod: "api-0",
+    namespace: "default",
+    time: "2026-07-11T10:00:00Z",
+    level: "info",
+    message: "listening on :8080",
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await logs.stop();
+  logs.clear();
+  logs.level = "all";
+  logs.textFilter = "";
+  logs.following = true;
+  app.view = "logs";
+  app.activeCluster = "prod";
+  app.kubeconfigPath = "/home/u/.kube/config";
+  app.namespace = null;
+  resources.pods = [];
+});
+
+describe("LogsView", () => {
+  it("renders severity chips, follow toggle and clear", () => {
+    render(LogsView);
+    for (const chip of ["ALL", "INFO", "WARN", "ERROR"]) {
+      expect(screen.getByText(chip)).toBeInTheDocument();
+    }
+    expect(screen.getByText("● Following")).toBeInTheDocument();
+    expect(screen.getByText("Clear")).toBeInTheDocument();
+  });
+
+  it("renders lines with time, level, pod and message", () => {
+    logs.push(line());
+    logs.push(line({ pod: "worker-1", level: "error", message: "ERROR boom" }));
+    render(LogsView);
+    expect(screen.getByText("listening on :8080")).toBeInTheDocument();
+    expect(screen.getByText("ERROR boom")).toBeInTheDocument();
+    expect(screen.getByText("worker-1")).toBeInTheDocument();
+    const errorRow = screen.getByText("ERROR boom").closest("div");
+    expect(errorRow?.getAttribute("style")).toContain("--alpha-log-error-row");
+  });
+
+  it("filters by severity chip", async () => {
+    logs.push(line({ message: "info line" }));
+    logs.push(line({ level: "warn", message: "warn line" }));
+    render(LogsView);
+    await fireEvent.click(screen.getByText("WARN"));
+    expect(screen.queryByText("info line")).toBeNull();
+    expect(screen.getByText("warn line")).toBeInTheDocument();
+  });
+
+  it("shows the paused pill when paused with buffered lines", async () => {
+    render(LogsView);
+    await fireEvent.click(screen.getByText("● Following"));
+    logs.push(line());
+    expect(await screen.findByText("paused — new lines buffered")).toBeInTheDocument();
+    expect(screen.getByText("⏸ Paused")).toBeInTheDocument();
+  });
+
+  it("clears the buffer", async () => {
+    logs.push(line());
+    render(LogsView);
+    await fireEvent.click(screen.getByText("Clear"));
+    expect(logs.lines).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/lib/stores/logs.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/logs.svelte.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("$lib/tauri", () => ({
+  streamLogs: vi.fn(async () => "1"),
+  stopLogs: vi.fn(async () => undefined),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+import { streamLogs, type LogLine } from "$lib/tauri";
+import { logs } from "./logs.svelte";
+import { app } from "./app.svelte";
+
+function line(overrides: Partial<LogLine> = {}): LogLine {
+  return {
+    pod: "api-0",
+    namespace: "default",
+    time: "2026-07-11T10:00:00Z",
+    level: "info",
+    message: "listening on :8080",
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await logs.stop();
+  logs.clear();
+  logs.level = "all";
+  logs.textFilter = "";
+  logs.following = true;
+  app.kubeconfigPath = "/home/u/.kube/config";
+  app.activeCluster = "prod";
+});
+
+describe("logs buffer", () => {
+  it("caps the buffer at 180 lines", () => {
+    for (let i = 0; i < 200; i++) logs.push(line({ message: `m${i}` }));
+    expect(logs.lines).toHaveLength(180);
+    expect(logs.lines[0].message).toBe("m20");
+  });
+
+  it("counts lines arriving while paused and resets on resume", () => {
+    logs.toggleFollow();
+    expect(logs.following).toBe(false);
+    logs.push(line());
+    logs.push(line());
+    expect(logs.bufferedWhilePaused).toBe(2);
+    logs.toggleFollow();
+    expect(logs.bufferedWhilePaused).toBe(0);
+  });
+
+  it("clear empties buffer and paused counter", () => {
+    logs.push(line());
+    logs.toggleFollow();
+    logs.push(line());
+    logs.clear();
+    expect(logs.lines).toHaveLength(0);
+    expect(logs.bufferedWhilePaused).toBe(0);
+  });
+});
+
+describe("logs filters", () => {
+  it("filters by level", () => {
+    logs.push(line({ level: "info" }));
+    logs.push(line({ level: "error", message: "boom" }));
+    logs.level = "error";
+    expect(logs.filtered).toHaveLength(1);
+    expect(logs.filtered[0].message).toBe("boom");
+  });
+
+  it("filters by text across pod and message", () => {
+    logs.push(line({ pod: "api-0", message: "hello" }));
+    logs.push(line({ pod: "worker-1", message: "crunching" }));
+    logs.textFilter = "worker";
+    expect(logs.filtered).toHaveLength(1);
+    expect(logs.filtered[0].pod).toBe("worker-1");
+  });
+});
+
+describe("start/stop", () => {
+  it("starts a stream with the given pods", async () => {
+    await logs.start([{ namespace: "default", name: "api-0" }]);
+    expect(streamLogs).toHaveBeenCalledWith(
+      "/home/u/.kube/config",
+      [{ namespace: "default", name: "api-0" }],
+      "prod",
+    );
+    expect(logs.streaming).toBe(true);
+    await logs.stop();
+    expect(logs.streaming).toBe(false);
+  });
+
+  it("does not start with no pods", async () => {
+    await logs.start([]);
+    expect(streamLogs).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/stores/logs.svelte.ts
+++ b/apps/desktop/src/lib/stores/logs.svelte.ts
@@ -1,0 +1,90 @@
+/**
+ * Aggregated multi-pod log stream state: rolling buffer (~180 lines),
+ * severity/text filters, follow toggle with paused-buffer counter.
+ */
+
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { stopLogs, streamLogs, type LogLine, type PodRef } from "$lib/tauri";
+import { errorMessage } from "$lib/errors";
+import { app } from "./app.svelte";
+import { toasts } from "./toasts.svelte";
+
+/** Spec: buffer cap ~180 lines. */
+const BUFFER_CAP = 180;
+
+export type LevelFilter = "all" | "info" | "warn" | "error";
+
+class LogsStore {
+  lines = $state<LogLine[]>([]);
+  following = $state(true);
+  level = $state<LevelFilter>("all");
+  textFilter = $state("");
+  /** Lines that arrived while paused (drives the "buffered" pill). */
+  bufferedWhilePaused = $state(0);
+  streaming = $state(false);
+
+  #streamId: string | null = null;
+  #unlisten: UnlistenFn | null = null;
+
+  get filtered(): LogLine[] {
+    const text = this.textFilter.toLowerCase();
+    return this.lines.filter((line) => {
+      if (this.level !== "all" && line.level !== this.level) return false;
+      if (text && !`${line.pod} ${line.message}`.toLowerCase().includes(text)) return false;
+      return true;
+    });
+  }
+
+  push(line: LogLine): void {
+    this.lines = [...this.lines, line].slice(-BUFFER_CAP);
+    if (!this.following) this.bufferedWhilePaused += 1;
+  }
+
+  toggleFollow(): void {
+    this.following = !this.following;
+    if (this.following) this.bufferedWhilePaused = 0;
+  }
+
+  clear(): void {
+    this.lines = [];
+    this.bufferedWhilePaused = 0;
+  }
+
+  /** Start streaming the given pods (restarts any previous stream). */
+  async start(pods: PodRef[]): Promise<void> {
+    await this.stop();
+    const kc = app.kubeconfigPath;
+    const cluster = app.activeCluster;
+    if (!kc || !cluster || pods.length === 0) return;
+
+    try {
+      this.#unlisten = await listen<LogLine>("log-line", (event) => {
+        this.push(event.payload);
+      });
+      this.#streamId = await streamLogs(kc, pods, cluster);
+      this.streaming = true;
+    } catch (e) {
+      toasts.push(`Log stream failed: ${errorMessage(e)}`, "err");
+      await this.stop();
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.streaming = false;
+    if (this.#unlisten) {
+      this.#unlisten();
+      this.#unlisten = null;
+    }
+    const id = this.#streamId;
+    this.#streamId = null;
+    if (id) {
+      try {
+        await stopLogs(id);
+      } catch {
+        // Backend may already have dropped the stream.
+      }
+    }
+  }
+}
+
+export const logs = new LogsStore();

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -183,6 +183,37 @@ export function listEvents(
   });
 }
 
+export type LogLevel = "info" | "warn" | "error";
+
+export type LogLine = {
+  pod: string;
+  namespace: string;
+  time: string | null;
+  level: LogLevel;
+  message: string;
+};
+
+export type PodRef = {
+  namespace: string;
+  name: string;
+};
+
+export function streamLogs(
+  kubeconfigPath: string,
+  pods: PodRef[],
+  context?: string,
+): Promise<string> {
+  return invoke<string>("stream_logs", {
+    kubeconfigPath,
+    pods,
+    context: context ?? null,
+  });
+}
+
+export function stopLogs(streamId: string): Promise<void> {
+  return invoke("stop_logs", { streamId });
+}
+
 export function watchResources(
   kubeconfigPath: string,
   resourceType: string,

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod client;
 pub mod context;
 pub mod error;
 pub mod kubeconfig;
+pub mod logs;
 pub mod resources;
 pub mod types;
 pub mod watcher;
@@ -40,6 +41,7 @@ pub mod watcher;
 pub use client::KubeClient;
 pub use error::{ContextError, KubeconfigError};
 pub use kubeconfig::KubeConfig;
+pub use logs::{LogLevel, LogLine};
 pub use resources::{
     ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
     ServiceInfo,

--- a/crates/cubelite-core/src/logs.rs
+++ b/crates/cubelite-core/src/logs.rs
@@ -1,0 +1,166 @@
+//! Pod log streaming with lightweight level/timestamp parsing.
+//!
+//! [`stream_pod_logs`] follows a single pod's log and yields [`LogLine`]
+//! items; callers aggregate multiple pods by merging streams. Lines are
+//! requested with `timestamps=true` so each line carries an RFC 3339 prefix
+//! that is split off into [`LogLine::time`].
+
+use std::pin::Pin;
+
+use futures::{AsyncBufReadExt, Stream, StreamExt, TryStreamExt};
+use k8s_openapi::api::core::v1::Pod;
+use kube::{api::LogParams, Api, Client};
+use serde::{Deserialize, Serialize};
+
+/// Severity bucket for a log line (UI filter chips: INFO / WARN / ERROR).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// Informational output (default when no marker is found).
+    Info,
+    /// Warning markers (`WARN`, `WARNING`).
+    Warn,
+    /// Error markers (`ERROR`, `ERR:`, `FATAL`, `PANIC`).
+    Error,
+}
+
+/// A single parsed log line from one pod.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogLine {
+    /// Pod name the line came from.
+    pub pod: String,
+    /// Namespace of the pod.
+    pub namespace: String,
+    /// RFC 3339 timestamp from the kubelet prefix, when present.
+    pub time: Option<String>,
+    /// Detected severity.
+    pub level: LogLevel,
+    /// Message with the timestamp prefix stripped.
+    pub message: String,
+}
+
+/// Detect the severity of a raw message via common level markers.
+fn detect_level(message: &str) -> LogLevel {
+    let upper = message.to_uppercase();
+    if ["ERROR", "ERR:", "FATAL", "PANIC"]
+        .iter()
+        .any(|m| upper.contains(m))
+    {
+        LogLevel::Error
+    } else if upper.contains("WARN") {
+        LogLevel::Warn
+    } else {
+        LogLevel::Info
+    }
+}
+
+/// Parse a raw kubelet log line (with `timestamps=true` prefix) into a
+/// [`LogLine`], splitting the RFC 3339 prefix when present.
+pub fn parse_log_line(pod: &str, namespace: &str, raw: &str) -> LogLine {
+    let (time, message) = match raw.split_once(' ') {
+        Some((first, rest)) if k8s_openapi::chrono::DateTime::parse_from_rfc3339(first).is_ok() => {
+            (Some(first.to_string()), rest)
+        }
+        _ => (None, raw),
+    };
+
+    LogLine {
+        pod: pod.to_string(),
+        namespace: namespace.to_string(),
+        time,
+        level: detect_level(message),
+        message: message.to_string(),
+    }
+}
+
+/// Follow one pod's logs as a stream of parsed [`LogLine`] items.
+///
+/// The stream opens the connection lazily; a failure to open yields a single
+/// [`LogLevel::Error`] line describing the problem, then ends. Read errors
+/// end the stream silently (the pod likely terminated).
+pub fn stream_pod_logs(
+    client: Client,
+    namespace: String,
+    pod: String,
+    tail_lines: i64,
+) -> Pin<Box<dyn Stream<Item = LogLine> + Send>> {
+    Box::pin(
+        futures::stream::once(async move {
+            let api: Api<Pod> = Api::namespaced(client, &namespace);
+            let params = LogParams {
+                follow: true,
+                timestamps: true,
+                tail_lines: Some(tail_lines),
+                ..Default::default()
+            };
+
+            match api.log_stream(&pod, &params).await {
+                Ok(reader) => {
+                    let ns = namespace.clone();
+                    let pod_name = pod.clone();
+                    reader
+                        .lines()
+                        .map_ok(move |raw| parse_log_line(&pod_name, &ns, &raw))
+                        .filter_map(|res| async move { res.ok() })
+                        .boxed()
+                }
+                Err(e) => futures::stream::once(async move {
+                    LogLine {
+                        pod: pod.clone(),
+                        namespace: namespace.clone(),
+                        time: None,
+                        level: LogLevel::Error,
+                        message: format!("failed to stream logs: {e}"),
+                    }
+                })
+                .boxed(),
+            }
+        })
+        .flatten(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_strips_rfc3339_prefix() {
+        let line = parse_log_line(
+            "api-0",
+            "default",
+            "2026-07-11T10:00:00.123456789Z listening on :8080",
+        );
+        assert_eq!(line.time.as_deref(), Some("2026-07-11T10:00:00.123456789Z"));
+        assert_eq!(line.message, "listening on :8080");
+        assert_eq!(line.level, LogLevel::Info);
+        assert_eq!(line.pod, "api-0");
+    }
+
+    #[test]
+    fn parse_without_timestamp_keeps_message() {
+        let line = parse_log_line("api-0", "default", "plain output");
+        assert!(line.time.is_none());
+        assert_eq!(line.message, "plain output");
+    }
+
+    #[test]
+    fn detects_levels_case_insensitively() {
+        assert_eq!(detect_level("some ERROR happened"), LogLevel::Error);
+        assert_eq!(detect_level("panic: index out of range"), LogLevel::Error);
+        assert_eq!(detect_level("warning: deprecated flag"), LogLevel::Warn);
+        assert_eq!(detect_level("all good"), LogLevel::Info);
+    }
+
+    #[test]
+    fn log_level_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&LogLevel::Warn).expect("serialize"),
+            "\"warn\""
+        );
+        let line = parse_log_line("p", "ns", "ERROR boom");
+        let json = serde_json::to_value(&line).expect("serialize");
+        assert_eq!(json["level"], "error");
+        assert_eq!(json["pod"], "p");
+    }
+}


### PR DESCRIPTION
Closes #239

## Backend
- `cubelite_core::logs`: `LogLine`/`LogLevel`, kubelet `timestamps=true` RFC 3339 prefix parsing, severity detection (ERROR/ERR:/FATAL/PANIC → error, WARN → warn, else info), `stream_pod_logs` following one pod via kube `log_stream` (lazy open; open failure yields a single error line)
- `stream_logs` Tauri command: aggregates up to 20 pods, one task each, emitting `log-line` events; `stop_logs` aborts by stream ID (`LogState` managed state)

## Frontend
- `logs` store: 180-line rolling buffer (spec cap), severity + text filters, follow toggle with paused-buffer counter
- **Logs view** per design handoff:
  - severity chips ALL/INFO/WARN/ERROR — active chip filled with the level color, dark text
  - Follow toggle: ok-filled "● Following" / warn-tinted "⏸ Paused" + centered pulsing "paused — new lines buffered" pill
  - rows in bg/sunken: time (mono 10.5 disabled) · LEVEL (mono 600 10px, 38px col, level color) · pod · message
  - error rows: 2px err left edge + err-7% bg; warn rows: 50% warn edge + warn-4.5% bg
  - auto-scroll to bottom while following; Clear
- Pod/Deployment drawer **Logs** buttons deep-link with the pod/deployment name preset in the text filter

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace` (4 new parser/serde tests)
- `pnpm --filter desktop lint / typecheck / test / build` — 126 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)