### PR TITLE
feat(core+desktop): enrich PodInfo and DeploymentInfo

### DIFF
--- a/apps/desktop/src/lib/components/DeploymentTable.svelte
+++ b/apps/desktop/src/lib/components/DeploymentTable.svelte
@@ -3,6 +3,7 @@
 	import Minus from '@lucide/svelte/icons/minus';
 	import Plus from '@lucide/svelte/icons/plus';
 	import RotateCw from '@lucide/svelte/icons/rotate-cw';
+	import { formatAge } from '$lib/age';
 	import type { DeploymentInfo } from '$lib/tauri';
 	import { deploymentStatus, toneColor } from '$lib/status';
 	import { mutations } from '$lib/stores/mutations.svelte';
@@ -61,7 +62,7 @@
 						<span class="h-1.5 w-1.5 shrink-0 rounded-full" style="background: {toneColor[status.tone]};"></span>
 						<span class="text-[11.5px]" style="color: {toneColor[status.tone]};">{status.label}</span>
 					</span>
-					<span class="type-data-sm text-text-disabled">—</span>
+					<span class="type-data-sm text-text-secondary">{formatAge(dep.creation_timestamp)}</span>
 					<span class="flex items-center gap-1.5">
 						<span class="flex items-center overflow-hidden rounded-md border border-border-default">
 							<button

--- a/apps/desktop/src/lib/components/DeploymentTable.test.ts
+++ b/apps/desktop/src/lib/components/DeploymentTable.test.ts
@@ -37,6 +37,11 @@ function dep(overrides: Partial<DeploymentInfo> = {}): DeploymentInfo {
     namespace: "default",
     replicas: 3,
     ready_replicas: 3,
+    images: [],
+    selector: {},
+    strategy: null,
+    conditions: [],
+    creation_timestamp: null,
     ...overrides,
   };
 }

--- a/apps/desktop/src/lib/components/PodTable.svelte
+++ b/apps/desktop/src/lib/components/PodTable.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { formatAge } from '$lib/age';
 	import type { PodInfo } from '$lib/tauri';
 	import { podStatusLabel, podTone, toneColor } from '$lib/status';
 
@@ -47,8 +48,10 @@
 						<span class="h-1.5 w-1.5 shrink-0 rounded-full" style="background: {toneColor[tone]};"></span>
 						<span class="text-[11.5px]" style="color: {toneColor[tone]};">{podStatusLabel(pod)}</span>
 					</span>
-					<span class="type-data-sm text-text-secondary">{pod.ready ? '1/1' : '0/1'}</span>
-					<span class="type-data-sm text-text-disabled">—</span>
+					<span class="type-data-sm text-text-secondary">
+						{pod.ready_containers}/{pod.total_containers}
+					</span>
+					<span class="type-data-sm text-text-secondary">{formatAge(pod.creation_timestamp)}</span>
 					<span class="type-data-sm text-text-disabled">—</span>
 					<span class="type-data-sm text-text-disabled">—</span>
 					<span

--- a/apps/desktop/src/lib/components/PodTable.test.ts
+++ b/apps/desktop/src/lib/components/PodTable.test.ts
@@ -11,6 +11,14 @@ function pod(overrides: Partial<PodInfo> = {}): PodInfo {
     phase: "Running",
     ready: true,
     restarts: 0,
+    ready_containers: 1,
+    total_containers: 1,
+    node: null,
+    pod_ip: null,
+    qos_class: null,
+    containers: [],
+    labels: {},
+    creation_timestamp: null,
     ...overrides,
   };
 }

--- a/apps/desktop/src/lib/components/deployments/DeploymentDrawer.svelte
+++ b/apps/desktop/src/lib/components/deployments/DeploymentDrawer.svelte
@@ -2,6 +2,8 @@
 	import FileText from '@lucide/svelte/icons/file-text';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import RotateCw from '@lucide/svelte/icons/rotate-cw';
+	import { formatAge } from '$lib/age';
+	import { matchesSelector } from '$lib/k8s-match';
 	import Drawer from '$lib/components/ui/Drawer.svelte';
 	import StatusPill from '$lib/components/ui/StatusPill.svelte';
 	import { deploymentStatus, podStatusLabel, podTone, toneColor } from '$lib/status';
@@ -15,19 +17,24 @@
 
 	const status = $derived(deploymentStatus(deployment));
 	const restarting = $derived(mutations.isRestarting(deployment.namespace, deployment.name));
+	const selectorLabel = $derived(
+		Object.entries(deployment.selector)
+			.map(([k, v]) => `${k}=${v}`)
+			.join(', ')
+	);
 	const meta = $derived<[string, string][]>([
 		['Namespace', deployment.namespace],
 		['Replicas', `${deployment.ready_replicas}/${deployment.replicas}`],
-		['Age', '—'],
-		['Image', '—'],
-		['Selector', '—'],
-		['Strategy', '—']
+		['Age', formatAge(deployment.creation_timestamp)],
+		['Image', deployment.images.join(', ') || '—'],
+		['Selector', selectorLabel || '—'],
+		['Strategy', deployment.strategy ?? '—']
 	]);
 
-	// Best-effort child pods: same namespace, ReplicaSet-style name prefix.
+	// Child pods matched via the deployment's label selector.
 	const childPods = $derived(
 		resources.pods.filter(
-			(p) => p.namespace === deployment.namespace && p.name.startsWith(`${deployment.name}-`)
+			(p) => p.namespace === deployment.namespace && matchesSelector(p.labels, deployment.selector)
 		)
 	);
 
@@ -56,6 +63,34 @@
 				</div>
 			{/each}
 		</div>
+
+		{#if deployment.conditions.length > 0}
+			<div>
+				<div class="type-section mb-1.5 text-text-tertiary">Conditions</div>
+				<div class="flex flex-col gap-1.5">
+					{#each deployment.conditions as condition (condition.condition_type)}
+						<div class="rounded-lg border border-border-faint bg-surface-surface px-2.5 py-1.5">
+							<div class="flex items-center gap-2">
+								<span class="type-body flex-1 text-text-primary">{condition.condition_type}</span>
+								<span
+									class="type-data-sm"
+									style="color: {condition.status === 'True'
+										? 'var(--color-status-ok)'
+										: condition.status === 'False'
+											? 'var(--color-status-err)'
+											: 'var(--color-text-tertiary)'};"
+								>
+									{condition.status}
+								</span>
+							</div>
+							{#if condition.reason}
+								<div class="type-caption mt-0.5 text-text-tertiary">{condition.reason}</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
 
 		<div>
 			<div class="type-section mb-1.5 text-text-tertiary">Pods</div>

--- a/apps/desktop/src/lib/components/overlays.test.ts
+++ b/apps/desktop/src/lib/components/overlays.test.ts
@@ -36,6 +36,14 @@ const pod: PodInfo = {
   phase: "Running",
   ready: true,
   restarts: 0,
+  ready_containers: 1,
+  total_containers: 1,
+  node: null,
+  pod_ip: null,
+  qos_class: null,
+  containers: [],
+  labels: {},
+  creation_timestamp: null,
 };
 
 beforeEach(() => {

--- a/apps/desktop/src/lib/components/pods/PodDrawer.svelte
+++ b/apps/desktop/src/lib/components/pods/PodDrawer.svelte
@@ -3,6 +3,7 @@
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import RotateCw from '@lucide/svelte/icons/rotate-cw';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
+	import { formatAge } from '$lib/age';
 	import Drawer from '$lib/components/ui/Drawer.svelte';
 	import MeterBar from '$lib/components/ui/MeterBar.svelte';
 	import StatusPill from '$lib/components/ui/StatusPill.svelte';
@@ -25,14 +26,13 @@
 		const ok = await mutations.deletePod(pod.namespace, pod.name);
 		if (ok) onClose();
 	}
-	// Fields the backend does not expose yet render as "—" (layout per spec).
 	const meta = $derived<[string, string][]>([
 		['Namespace', pod.namespace],
-		['Node', '—'],
-		['Age', '—'],
+		['Node', pod.node ?? '—'],
+		['Age', formatAge(pod.creation_timestamp)],
 		['Restarts', String(pod.restarts)],
-		['Pod IP', '—'],
-		['QoS', '—']
+		['Pod IP', pod.pod_ip ?? '—'],
+		['QoS', pod.qos_class ?? '—']
 	]);
 
 	const pillTone = $derived.by(() => {
@@ -57,6 +57,28 @@
 				</div>
 			{/each}
 		</div>
+
+		{#if pod.containers.length > 0}
+			<div>
+				<div class="type-section mb-1.5 text-text-tertiary">Containers</div>
+				<div class="overflow-hidden rounded-lg border border-border-faint">
+					{#each pod.containers as container (container.name)}
+						<div class="flex items-center gap-2 border-b border-border-faint bg-surface-surface px-2.5 py-1.5 last:border-b-0">
+							<span
+								class="h-1.5 w-1.5 shrink-0 rounded-full"
+								style="background: {container.ready
+									? 'var(--color-status-ok)'
+									: 'var(--color-status-warn)'};"
+							></span>
+							<span class="type-data-sm shrink-0 text-text-secondary">{container.name}</span>
+							<span class="type-caption min-w-0 flex-1 truncate text-right text-text-tertiary">
+								{container.image ?? ''}
+							</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
 
 		<div class="flex flex-col gap-2 rounded-lg border border-border-faint bg-surface-surface p-3">
 			<MeterBar label="CPU" percent={null} />

--- a/apps/desktop/src/lib/components/shell/shell.test.ts
+++ b/apps/desktop/src/lib/components/shell/shell.test.ts
@@ -35,6 +35,14 @@ function pod(overrides: Partial<PodInfo> = {}): PodInfo {
     phase: "Running",
     ready: true,
     restarts: 0,
+    ready_containers: 1,
+    total_containers: 1,
+    node: null,
+    pod_ip: null,
+    qos_class: null,
+    containers: [],
+    labels: {},
+    creation_timestamp: null,
     ...overrides,
   };
 }
@@ -130,7 +138,7 @@ describe("Sidebar", () => {
   it("shows real counts for pods and deployments", () => {
     resources.pods = [pod(), pod({ name: "api-1" })];
     resources.deployments = [
-      { name: "api", namespace: "default", replicas: 2, ready_replicas: 2 },
+      { name: "api", namespace: "default", replicas: 2, ready_replicas: 2, images: [], selector: {}, strategy: null, conditions: [], creation_timestamp: null },
     ];
     render(Sidebar);
     expect(screen.getByText("2")).toBeInTheDocument();

--- a/apps/desktop/src/lib/components/views/views.test.ts
+++ b/apps/desktop/src/lib/components/views/views.test.ts
@@ -38,6 +38,14 @@ function pod(overrides: Partial<PodInfo> = {}): PodInfo {
     phase: "Running",
     ready: true,
     restarts: 0,
+    ready_containers: 1,
+    total_containers: 1,
+    node: null,
+    pod_ip: null,
+    qos_class: null,
+    containers: [],
+    labels: {},
+    creation_timestamp: null,
     ...overrides,
   };
 }
@@ -87,7 +95,7 @@ describe("UnreachableView", () => {
 describe("OverviewView", () => {
   it("shows real stats, metrics caption and recent warning events", () => {
     resources.pods = [pod(), pod({ name: "api-1", ready: false, phase: "Pending" })];
-    resources.deployments = [{ name: "api", namespace: "default", replicas: 2, ready_replicas: 1 }];
+    resources.deployments = [{ name: "api", namespace: "default", replicas: 2, ready_replicas: 1, images: [], selector: {}, strategy: null, conditions: [], creation_timestamp: null }];
     resources.events = [
       {
         event_type: "Warning",

--- a/apps/desktop/src/lib/k8s-match.test.ts
+++ b/apps/desktop/src/lib/k8s-match.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { matchesSelector } from "$lib/k8s-match";
+
+describe("matchesSelector", () => {
+  it("matches when all selector entries are present", () => {
+    expect(matchesSelector({ app: "api", tier: "web", extra: "x" }, { app: "api", tier: "web" })).toBe(true);
+  });
+
+  it("rejects on any mismatch or missing key", () => {
+    expect(matchesSelector({ app: "api" }, { app: "worker" })).toBe(false);
+    expect(matchesSelector({ tier: "web" }, { app: "api" })).toBe(false);
+  });
+
+  it("never matches an empty selector (would select everything)", () => {
+    expect(matchesSelector({ app: "api" }, {})).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/k8s-match.ts
+++ b/apps/desktop/src/lib/k8s-match.ts
@@ -1,0 +1,9 @@
+/** True when every selector entry is present in the labels map (matchLabels semantics). */
+export function matchesSelector(
+  labels: Record<string, string>,
+  selector: Record<string, string>,
+): boolean {
+  const entries = Object.entries(selector);
+  if (entries.length === 0) return false;
+  return entries.every(([k, v]) => labels[k] === v);
+}

--- a/apps/desktop/src/lib/stores/app.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/app.svelte.test.ts
@@ -8,6 +8,14 @@ const pod: PodInfo = {
   phase: "Running",
   ready: true,
   restarts: 0,
+  ready_containers: 1,
+  total_containers: 1,
+  node: null,
+  pod_ip: null,
+  qos_class: null,
+  containers: [],
+  labels: {},
+  creation_timestamp: null,
 };
 
 beforeEach(() => {

--- a/apps/desktop/src/lib/tauri.test.ts
+++ b/apps/desktop/src/lib/tauri.test.ts
@@ -137,6 +137,14 @@ describe("listPods", () => {
         phase: "Running",
         ready: true,
         restarts: 0,
+        ready_containers: 1,
+        total_containers: 1,
+        node: null,
+        pod_ip: null,
+        qos_class: null,
+        containers: [],
+        labels: {},
+        creation_timestamp: null,
       },
     ];
     mockedInvoke.mockResolvedValueOnce(mockPods);
@@ -171,6 +179,14 @@ describe("listPods", () => {
         phase: null,
         ready: false,
         restarts: 3,
+        ready_containers: 1,
+        total_containers: 1,
+        node: null,
+        pod_ip: null,
+        qos_class: null,
+        containers: [],
+        labels: {},
+        creation_timestamp: null,
       },
     ];
     mockedInvoke.mockResolvedValueOnce(mockPods);
@@ -226,7 +242,7 @@ describe("listDeployments", () => {
 
   it("invokes list_deployments with all parameters", async () => {
     const mockDeployments: DeploymentInfo[] = [
-      { name: "nginx", namespace: "default", replicas: 3, ready_replicas: 3 },
+      { name: "nginx", namespace: "default", replicas: 3, ready_replicas: 3, images: [], selector: {}, strategy: null, conditions: [], creation_timestamp: null },
     ];
     mockedInvoke.mockResolvedValueOnce(mockDeployments);
 
@@ -242,7 +258,7 @@ describe("listDeployments", () => {
 
   it("handles degraded deployments", async () => {
     const mockDeployments: DeploymentInfo[] = [
-      { name: "api", namespace: "prod", replicas: 5, ready_replicas: 2 },
+      { name: "api", namespace: "prod", replicas: 5, ready_replicas: 2, images: [], selector: {}, strategy: null, conditions: [], creation_timestamp: null },
     ];
     mockedInvoke.mockResolvedValueOnce(mockDeployments);
 

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -2,12 +2,26 @@ import { invoke } from "@tauri-apps/api/core";
 
 // --- Types matching Rust structs ---
 
+export type ContainerInfo = {
+  name: string;
+  image: string | null;
+  ready: boolean;
+};
+
 export type PodInfo = {
   name: string;
   namespace: string;
   phase: string | null;
   ready: boolean;
   restarts: number;
+  ready_containers: number;
+  total_containers: number;
+  node: string | null;
+  pod_ip: string | null;
+  qos_class: string | null;
+  containers: ContainerInfo[];
+  labels: Record<string, string>;
+  creation_timestamp: string | null;
 };
 
 export type NamespaceInfo = {
@@ -15,11 +29,22 @@ export type NamespaceInfo = {
   phase: string | null;
 };
 
+export type DeploymentConditionInfo = {
+  condition_type: string;
+  status: string;
+  reason: string | null;
+};
+
 export type DeploymentInfo = {
   name: string;
   namespace: string;
   replicas: number;
   ready_replicas: number;
+  images: string[];
+  selector: Record<string, string>;
+  strategy: string | null;
+  conditions: DeploymentConditionInfo[];
+  creation_timestamp: string | null;
 };
 
 export type ContextInfo = {

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -19,7 +19,10 @@ use crate::{
         ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
         ServiceInfo,
     },
-    watcher::{configmap_to_info, ingress_to_info, secret_to_info, service_to_info},
+    watcher::{
+        configmap_to_info, deployment_to_info, ingress_to_info, namespace_to_info, pod_to_info,
+        secret_to_info, service_to_info,
+    },
 };
 
 /// An async Kubernetes client pre-configured from a kubeconfig file.
@@ -97,31 +100,7 @@ impl KubeClient {
                     reason: e.to_string(),
                 })?;
 
-        let pods = pod_list
-            .items
-            .into_iter()
-            .filter_map(|pod| {
-                let name = pod.metadata.name?;
-                let ns = pod.metadata.namespace.unwrap_or_default();
-                let phase = pod.status.as_ref().and_then(|s| s.phase.clone());
-                let container_statuses = pod
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.container_statuses.as_deref())
-                    .unwrap_or(&[]);
-                let ready = container_statuses.iter().all(|cs| cs.ready);
-                let restarts = container_statuses.iter().map(|cs| cs.restart_count).sum();
-                Some(PodInfo {
-                    name,
-                    namespace: ns,
-                    phase,
-                    ready,
-                    restarts,
-                })
-            })
-            .collect();
-
-        Ok(pods)
+        Ok(pod_list.items.into_iter().filter_map(pod_to_info).collect())
     }
 
     /// List all namespaces visible to the authenticated user.
@@ -139,17 +118,11 @@ impl KubeClient {
                     reason: e.to_string(),
                 })?;
 
-        let namespaces = ns_list
+        Ok(ns_list
             .items
             .into_iter()
-            .filter_map(|ns| {
-                let name = ns.metadata.name?;
-                let phase = ns.status.as_ref().and_then(|s| s.phase.clone());
-                Some(NamespaceInfo { name, phase })
-            })
-            .collect();
-
-        Ok(namespaces)
+            .filter_map(namespace_to_info)
+            .collect())
     }
 
     /// List all deployments in the given `namespace`.
@@ -170,28 +143,11 @@ impl KubeClient {
                     reason: e.to_string(),
                 })?;
 
-        let deployments = deploy_list
+        Ok(deploy_list
             .items
             .into_iter()
-            .filter_map(|d| {
-                let name = d.metadata.name?;
-                let ns = d.metadata.namespace.unwrap_or_default();
-                let replicas = d.spec.as_ref().and_then(|s| s.replicas).unwrap_or(0);
-                let ready_replicas = d
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.ready_replicas)
-                    .unwrap_or(0);
-                Some(DeploymentInfo {
-                    name,
-                    namespace: ns,
-                    replicas,
-                    ready_replicas,
-                })
-            })
-            .collect();
-
-        Ok(deployments)
+            .filter_map(deployment_to_info)
+            .collect())
     }
 
     /// List services in `namespace`, or across all namespaces when `None`.

--- a/crates/cubelite-core/src/resources.rs
+++ b/crates/cubelite-core/src/resources.rs
@@ -1,7 +1,22 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Per-container readiness and image for the pod detail drawer.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContainerInfo {
+    /// Container name.
+    pub name: String,
+    /// Container image reference.
+    pub image: Option<String>,
+    /// `true` when the container reports ready.
+    pub ready: bool,
+}
 
 /// Lightweight representation of a Kubernetes Pod for display purposes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Fields added after v0.1 carry `#[serde(default)]` so older payloads
+/// still deserialize.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PodInfo {
     /// The pod's name within its namespace.
     pub name: String,
@@ -13,6 +28,30 @@ pub struct PodInfo {
     pub ready: bool,
     /// Total number of container restarts across all containers in the pod.
     pub restarts: i32,
+    /// Number of containers reporting ready.
+    #[serde(default)]
+    pub ready_containers: i32,
+    /// Total number of containers in the pod.
+    #[serde(default)]
+    pub total_containers: i32,
+    /// Node the pod is scheduled on.
+    #[serde(default)]
+    pub node: Option<String>,
+    /// Pod IP address.
+    #[serde(default)]
+    pub pod_ip: Option<String>,
+    /// Quality of Service class (`"Guaranteed"`, `"Burstable"`, `"BestEffort"`).
+    #[serde(default)]
+    pub qos_class: Option<String>,
+    /// Containers with per-container readiness and image.
+    #[serde(default)]
+    pub containers: Vec<ContainerInfo>,
+    /// Pod labels (drives selector-based child-pod matching).
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    #[serde(default)]
+    pub creation_timestamp: Option<String>,
 }
 
 /// Lightweight representation of a Kubernetes Namespace.
@@ -24,8 +63,22 @@ pub struct NamespaceInfo {
     pub phase: Option<String>,
 }
 
+/// A deployment condition for the detail drawer cards.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeploymentConditionInfo {
+    /// Condition type (e.g. `"Available"`, `"Progressing"`).
+    pub condition_type: String,
+    /// Condition status (`"True"`, `"False"`, `"Unknown"`).
+    pub status: String,
+    /// Machine-readable reason, when reported.
+    pub reason: Option<String>,
+}
+
 /// Lightweight representation of a Kubernetes Deployment.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Fields added after v0.1 carry `#[serde(default)]` so older payloads
+/// still deserialize.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeploymentInfo {
     /// The deployment name.
     pub name: String,
@@ -35,6 +88,21 @@ pub struct DeploymentInfo {
     pub replicas: i32,
     /// Number of replicas currently reporting as ready.
     pub ready_replicas: i32,
+    /// Container images from the pod template.
+    #[serde(default)]
+    pub images: Vec<String>,
+    /// Label selector (`matchLabels`) used to find owned pods.
+    #[serde(default)]
+    pub selector: BTreeMap<String, String>,
+    /// Rollout strategy type (`"RollingUpdate"`, `"Recreate"`).
+    #[serde(default)]
+    pub strategy: Option<String>,
+    /// Deployment conditions for the drawer cards.
+    #[serde(default)]
+    pub conditions: Vec<DeploymentConditionInfo>,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    #[serde(default)]
+    pub creation_timestamp: Option<String>,
 }
 
 /// Lightweight representation of a Kubernetes Service.

--- a/crates/cubelite-core/src/watcher.rs
+++ b/crates/cubelite-core/src/watcher.rs
@@ -30,7 +30,8 @@ use kube::{runtime::watcher, Api, Client};
 use serde::{Deserialize, Serialize};
 
 use crate::resources::{
-    ConfigMapInfo, DeploymentInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+    ConfigMapInfo, ContainerInfo, DeploymentConditionInfo, DeploymentInfo, IngressInfo,
+    NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
 };
 
 /// Selects which Kubernetes resource type to watch.
@@ -220,29 +221,50 @@ where
 
 /// Convert a raw [`Pod`] object into a [`PodInfo`], returning `None` if the
 /// pod has no name (which is invalid in a well-formed cluster response).
-fn pod_to_info(pod: Pod) -> Option<PodInfo> {
-    let name = pod.metadata.name?;
-    let namespace = pod.metadata.namespace.unwrap_or_default();
-    let phase = pod.status.as_ref().and_then(|s| s.phase.clone());
-    let container_statuses = pod
-        .status
-        .as_ref()
-        .and_then(|s| s.container_statuses.as_deref())
-        .unwrap_or(&[]);
-    let ready = container_statuses.iter().all(|cs| cs.ready);
-    let restarts = container_statuses.iter().map(|cs| cs.restart_count).sum();
+pub(crate) fn pod_to_info(pod: Pod) -> Option<PodInfo> {
+    let name = pod.metadata.name.clone()?;
+    let namespace = pod.metadata.namespace.clone().unwrap_or_default();
+    let labels = pod.metadata.labels.clone().unwrap_or_default();
+    let creation = creation_timestamp(&pod.metadata);
+
+    let spec = pod.spec.unwrap_or_default();
+    let status = pod.status.unwrap_or_default();
+    let statuses = status.container_statuses.unwrap_or_default();
+
+    let containers: Vec<ContainerInfo> = spec
+        .containers
+        .iter()
+        .map(|c| ContainerInfo {
+            name: c.name.clone(),
+            image: c.image.clone(),
+            ready: statuses.iter().any(|cs| cs.name == c.name && cs.ready),
+        })
+        .collect();
+
+    let total_containers = containers.len() as i32;
+    let ready_containers = containers.iter().filter(|c| c.ready).count() as i32;
+    let restarts = statuses.iter().map(|cs| cs.restart_count).sum();
+
     Some(PodInfo {
         name,
         namespace,
-        phase,
-        ready,
+        phase: status.phase,
+        ready: total_containers > 0 && ready_containers == total_containers,
         restarts,
+        ready_containers,
+        total_containers,
+        node: spec.node_name,
+        pod_ip: status.pod_ip,
+        qos_class: status.qos_class,
+        containers,
+        labels,
+        creation_timestamp: creation,
     })
 }
 
 /// Convert a raw [`Namespace`] object into a [`NamespaceInfo`], returning
 /// `None` if there is no name.
-fn namespace_to_info(ns: Namespace) -> Option<NamespaceInfo> {
+pub(crate) fn namespace_to_info(ns: Namespace) -> Option<NamespaceInfo> {
     let name = ns.metadata.name?;
     let phase = ns.status.as_ref().and_then(|s| s.phase.clone());
     Some(NamespaceInfo { name, phase })
@@ -385,20 +407,58 @@ pub(crate) fn secret_to_info(s: Secret) -> Option<SecretInfo> {
 
 /// Convert a raw [`Deployment`] object into a [`DeploymentInfo`], returning
 /// `None` if there is no name.
-fn deployment_to_info(d: Deployment) -> Option<DeploymentInfo> {
-    let name = d.metadata.name?;
-    let namespace = d.metadata.namespace.unwrap_or_default();
-    let replicas = d.spec.as_ref().and_then(|s| s.replicas).unwrap_or(0);
-    let ready_replicas = d
-        .status
-        .as_ref()
-        .and_then(|s| s.ready_replicas)
-        .unwrap_or(0);
+pub(crate) fn deployment_to_info(d: Deployment) -> Option<DeploymentInfo> {
+    let name = d.metadata.name.clone()?;
+    let namespace = d.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&d.metadata);
+
+    let (replicas, images, selector, strategy) = match d.spec {
+        Some(spec) => {
+            let images = spec
+                .template
+                .spec
+                .as_ref()
+                .map(|ps| {
+                    ps.containers
+                        .iter()
+                        .filter_map(|c| c.image.clone())
+                        .collect()
+                })
+                .unwrap_or_default();
+            let selector = spec.selector.match_labels.unwrap_or_default();
+            let strategy = spec.strategy.and_then(|s| s.type_);
+            (spec.replicas.unwrap_or(0), images, selector, strategy)
+        }
+        None => (0, Vec::new(), Default::default(), None),
+    };
+
+    let (ready_replicas, conditions) = match d.status {
+        Some(status) => {
+            let conditions = status
+                .conditions
+                .unwrap_or_default()
+                .into_iter()
+                .map(|c| DeploymentConditionInfo {
+                    condition_type: c.type_,
+                    status: c.status,
+                    reason: c.reason,
+                })
+                .collect();
+            (status.ready_replicas.unwrap_or(0), conditions)
+        }
+        None => (0, Vec::new()),
+    };
+
     Some(DeploymentInfo {
         name,
         namespace,
         replicas,
         ready_replicas,
+        images,
+        selector,
+        strategy,
+        conditions,
+        creation_timestamp: creation,
     })
 }
 
@@ -445,6 +505,7 @@ mod tests {
             phase: Some("Running".to_string()),
             ready: true,
             restarts: 0,
+            ..Default::default()
         }));
 
         let json = serde_json::to_string(&event).unwrap();
@@ -472,17 +533,30 @@ mod tests {
 
     #[test]
     fn pod_to_info_full() {
-        use k8s_openapi::api::core::v1::{ContainerStatus, Pod, PodStatus};
+        use k8s_openapi::api::core::v1::{Container, ContainerStatus, Pod, PodSpec, PodStatus};
         use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+        use std::collections::BTreeMap;
 
         let pod = Pod {
             metadata: ObjectMeta {
                 name: Some("my-pod".to_string()),
                 namespace: Some("kube-system".to_string()),
+                labels: Some(BTreeMap::from([("app".to_string(), "my".to_string())])),
                 ..Default::default()
             },
+            spec: Some(PodSpec {
+                node_name: Some("node-1".to_string()),
+                containers: vec![Container {
+                    name: "main".to_string(),
+                    image: Some("nginx:1.27".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
             status: Some(PodStatus {
                 phase: Some("Running".to_string()),
+                pod_ip: Some("10.1.2.3".to_string()),
+                qos_class: Some("Burstable".to_string()),
                 container_statuses: Some(vec![ContainerStatus {
                     name: "main".to_string(),
                     ready: true,
@@ -491,7 +565,6 @@ mod tests {
                 }]),
                 ..Default::default()
             }),
-            ..Default::default()
         };
 
         let info = pod_to_info(pod).unwrap();
@@ -500,6 +573,14 @@ mod tests {
         assert_eq!(info.phase.as_deref(), Some("Running"));
         assert!(info.ready);
         assert_eq!(info.restarts, 3);
+        assert_eq!(info.ready_containers, 1);
+        assert_eq!(info.total_containers, 1);
+        assert_eq!(info.node.as_deref(), Some("node-1"));
+        assert_eq!(info.pod_ip.as_deref(), Some("10.1.2.3"));
+        assert_eq!(info.qos_class.as_deref(), Some("Burstable"));
+        assert_eq!(info.containers.len(), 1);
+        assert_eq!(info.containers[0].image.as_deref(), Some("nginx:1.27"));
+        assert_eq!(info.labels.get("app").map(String::as_str), Some("my"));
     }
 
     #[test]
@@ -693,5 +774,64 @@ mod tests {
         assert_eq!(info.namespace, "staging");
         assert_eq!(info.replicas, 3);
         assert_eq!(info.ready_replicas, 2);
+    }
+
+    #[test]
+    fn deployment_to_info_enriched_fields() {
+        use k8s_openapi::api::apps::v1::{
+            Deployment, DeploymentCondition, DeploymentSpec, DeploymentStatus, DeploymentStrategy,
+        };
+        use k8s_openapi::api::core::v1::{Container, PodTemplateSpec};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+        use std::collections::BTreeMap;
+
+        let d = Deployment {
+            metadata: ObjectMeta {
+                name: Some("api".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: Some(DeploymentSpec {
+                replicas: Some(2),
+                selector: LabelSelector {
+                    match_labels: Some(BTreeMap::from([("app".to_string(), "api".to_string())])),
+                    ..Default::default()
+                },
+                strategy: Some(DeploymentStrategy {
+                    type_: Some("RollingUpdate".to_string()),
+                    ..Default::default()
+                }),
+                template: PodTemplateSpec {
+                    spec: Some(k8s_openapi::api::core::v1::PodSpec {
+                        containers: vec![Container {
+                            name: "api".to_string(),
+                            image: Some("ghcr.io/x/api:2.1".to_string()),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            status: Some(DeploymentStatus {
+                ready_replicas: Some(2),
+                conditions: Some(vec![DeploymentCondition {
+                    type_: "Available".to_string(),
+                    status: "True".to_string(),
+                    reason: Some("MinimumReplicasAvailable".to_string()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+        };
+
+        let info = deployment_to_info(d).unwrap();
+        assert_eq!(info.images, vec!["ghcr.io/x/api:2.1"]);
+        assert_eq!(info.selector.get("app").map(String::as_str), Some("api"));
+        assert_eq!(info.strategy.as_deref(), Some("RollingUpdate"));
+        assert_eq!(info.conditions.len(), 1);
+        assert_eq!(info.conditions[0].condition_type, "Available");
+        assert_eq!(info.conditions[0].status, "True");
     }
 }

--- a/crates/cubelite-core/tests/resources_and_errors.rs
+++ b/crates/cubelite-core/tests/resources_and_errors.rs
@@ -15,6 +15,7 @@ fn pod_info_serializes_to_json() {
         phase: Some("Running".to_string()),
         ready: true,
         restarts: 0,
+        ..Default::default()
     };
     let json = serde_json::to_string(&pod).expect("serialize");
     assert!(json.contains("\"name\":\"nginx-abc\""));
@@ -42,6 +43,7 @@ fn pod_info_roundtrip() {
         phase: Some("Pending".to_string()),
         ready: false,
         restarts: 3,
+        ..Default::default()
     };
     let json = serde_json::to_string(&original).expect("serialize");
     let deserialized: PodInfo = serde_json::from_str(&json).expect("deserialize");
@@ -100,6 +102,7 @@ fn deployment_info_serializes_to_json() {
         namespace: "default".to_string(),
         replicas: 3,
         ready_replicas: 3,
+        ..Default::default()
     };
     let json = serde_json::to_string(&dep).expect("serialize");
     assert!(json.contains("\"replicas\":3"));
@@ -113,6 +116,7 @@ fn deployment_info_degraded_state() {
         namespace: "production".to_string(),
         replicas: 5,
         ready_replicas: 2,
+        ..Default::default()
     };
     assert!(dep.ready_replicas < dep.replicas);
 }
@@ -124,6 +128,7 @@ fn deployment_info_zero_replicas() {
         namespace: "staging".to_string(),
         replicas: 0,
         ready_replicas: 0,
+        ..Default::default()
     };
     let json = serde_json::to_string(&dep).expect("serialize");
     let deserialized: DeploymentInfo = serde_json::from_str(&json).expect("deserialize");


### PR DESCRIPTION
Closes #241 — last issue of **v0.1.0 — Alpha**.

Stacked on #254 when open; rebase/retarget to `main` after it merges.

## Backend
- `PodInfo`: ready/total container counts, node, pod IP, QoS class, per-container `{name, image, ready}`, labels, creation timestamp
- `DeploymentInfo`: template images, `matchLabels` selector, strategy, conditions, creation timestamp
- Conversion logic deduplicated: `KubeClient` list methods now reuse the watcher converters (previously two hand-rolled copies)
- New fields carry `#[serde(default)]` for backward-compatible deserialization

## Frontend
- Pods table: real **READY x/y** and **AGE**
- Pod drawer: node / age / pod IP / QoS populated; containers list with per-container ready dot + image
- Deployments table: real **AGE**; drawer: age, images, selector, strategy, condition cards (True ok / False err + reason)
- Child pods matched via label selector (`lib/k8s-match.ts`) instead of the name-prefix heuristic

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace` (enriched converter tests)
- `pnpm --filter desktop lint / typecheck / test / build` — 136 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)