### PR TITLE
feat(core+desktop): Helm releases view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,9 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 name = "cubelite-core"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "dirs 5.0.1",
+ "flate2",
  "futures",
  "k8s-openapi",
  "kube",

--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -1,5 +1,6 @@
 use cubelite_core::{
     client::KubeClient,
+    helm::HelmReleaseInfo,
     logs::stream_pod_logs,
     resources::{
         ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
@@ -238,6 +239,24 @@ pub async fn watch_resources(
         .insert(watch_id.clone(), handle);
 
     Ok(watch_id)
+}
+
+/// List Helm v3 releases (latest revision per release) in the given
+/// namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_helm_releases(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<HelmReleaseInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_helm_releases(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Delete a pod (the owning controller will recreate it).

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,9 +2,9 @@ pub mod commands;
 
 use commands::kubernetes::{
     delete_pod, get_current_context, list_configmaps, list_contexts, list_deployments, list_events,
-    list_ingresses, list_namespaces, list_pods, list_secrets, list_services, restart_deployment,
-    scale_deployment, set_context, stop_logs, stream_logs, unwatch_resources, watch_resources,
-    LogState, WatchState,
+    list_helm_releases, list_ingresses, list_namespaces, list_pods, list_secrets, list_services,
+    restart_deployment, scale_deployment, set_context, stop_logs, stream_logs, unwatch_resources,
+    watch_resources, LogState, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -21,6 +21,7 @@ pub fn run() {
             list_configmaps,
             list_secrets,
             list_events,
+            list_helm_releases,
             watch_resources,
             unwatch_resources,
             stream_logs,

--- a/apps/desktop/src/lib/components/DeploymentTable.test.ts
+++ b/apps/desktop/src/lib/components/DeploymentTable.test.ts
@@ -14,6 +14,7 @@ vi.mock("$lib/tauri", () => ({
   listIngresses: vi.fn(async () => []),
   listConfigMaps: vi.fn(async () => []),
   listSecrets: vi.fn(async () => []),
+  listHelmReleases: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));

--- a/apps/desktop/src/lib/components/views/HelmView.svelte
+++ b/apps/desktop/src/lib/components/views/HelmView.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import StatusPill from '$lib/components/ui/StatusPill.svelte';
+	import type { PillTone } from '$lib/components/ui/StatusPill.svelte';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('helm');
+	});
+
+	// Spec: deployed → ok, pending-* → warn, failed → err.
+	function toneOf(status: string | null): PillTone {
+		if (status === 'deployed' || status === 'superseded') return 'ok';
+		if (status?.startsWith('pending')) return 'warn';
+		if (status === 'failed' || status === 'unknown') return 'err';
+		return 'neutral';
+	}
+
+	const grid = 'grid-template-columns: 1.6fr 1fr 0.4fr 1fr 1.4fr 0.6fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">Helm Releases</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Namespace</span>
+				<span class="type-colhead">Rev</span>
+				<span class="type-colhead">Status</span>
+				<span class="type-colhead">Chart</span>
+				<span class="type-colhead">Updated</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.helmReleases.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No Helm releases found.</p>
+				{:else}
+					{#each resources.helmReleases as release (release.namespace + '/' + release.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+							<span class="type-data truncate text-text-data-bright">{release.name}</span>
+							<span class="type-data-sm truncate text-text-secondary">{release.namespace}</span>
+							<span class="type-data-sm text-text-secondary">{release.revision}</span>
+							<span>
+								<StatusPill label={release.status ?? '—'} tone={toneOf(release.status)} />
+							</span>
+							<span class="type-data-sm truncate {release.chart ? 'text-text-secondary' : 'text-text-disabled'}">
+								{release.chart ?? '—'}
+							</span>
+							<span class="type-data-sm text-text-secondary">{formatAge(release.updated)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/index.ts
+++ b/apps/desktop/src/lib/components/views/index.ts
@@ -1,16 +1,12 @@
-/**
- * View registry: maps the app view enum to a component (+ static props).
- * Views without backend support render the spec'd empty state until their
- * Tauri commands exist.
- */
+/** View registry: maps the app view enum to a component (+ static props). */
 
 import type { Component } from "svelte";
 import type { View } from "$lib/stores/app.svelte";
 import AllClustersView from "./AllClustersView.svelte";
 import ConfigMapsView from "./ConfigMapsView.svelte";
 import DeploymentsView from "./DeploymentsView.svelte";
-import EmptyStateView from "./EmptyStateView.svelte";
 import EventsView from "./EventsView.svelte";
+import HelmView from "./HelmView.svelte";
 import IngressesView from "./IngressesView.svelte";
 import LogsView from "./LogsView.svelte";
 import OverviewView from "./OverviewView.svelte";
@@ -31,17 +27,12 @@ export function asEntry<P extends Record<string, unknown>>(
   return { component: component as unknown as ViewEntry["component"], props };
 }
 
-const emptyState = (what: string): ViewEntry =>
-  asEntry(EmptyStateView, {
-    message: `${what} requires backend support — coming soon.`,
-  });
-
 export const viewRegistry: Record<View, ViewEntry> = {
   dashboard: asEntry(AllClustersView),
   overview: asEntry(OverviewView),
   pods: asEntry(PodsView),
   deployments: asEntry(DeploymentsView),
-  helm: emptyState("The Helm Releases view"),
+  helm: asEntry(HelmView),
   services: asEntry(ServicesView),
   ingresses: asEntry(IngressesView),
   configmaps: asEntry(ConfigMapsView),

--- a/apps/desktop/src/lib/components/views/kind-views.test.ts
+++ b/apps/desktop/src/lib/components/views/kind-views.test.ts
@@ -16,6 +16,7 @@ vi.mock("$lib/tauri", () => ({
   listIngresses: vi.fn(async () => []),
   listConfigMaps: vi.fn(async () => []),
   listSecrets: vi.fn(async () => []),
+  listHelmReleases: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));
@@ -133,5 +134,44 @@ describe("SecretsView", () => {
     expect(screen.getByText("hunter2")).toBeInTheDocument();
     await fireEvent.click(screen.getByRole("button", { name: /Hide/ }));
     expect(screen.queryByText("hunter2")).toBeNull();
+  });
+});
+
+describe("HelmView", () => {
+  it("renders columns, status pills and chart", async () => {
+    const { default: HelmView } = await import("./HelmView.svelte");
+    resources.helmReleases = [
+      {
+        name: "web",
+        namespace: "default",
+        revision: 3,
+        status: "deployed",
+        chart: "nginx-15.1.2",
+        app_version: "1.27",
+        updated: null,
+      },
+      {
+        name: "queue",
+        namespace: "default",
+        revision: 1,
+        status: "pending-upgrade",
+        chart: null,
+        app_version: null,
+        updated: null,
+      },
+    ];
+    render(HelmView);
+    for (const h of ["Name", "Namespace", "Rev", "Status", "Chart", "Updated"]) {
+      expect(screen.getByText(h)).toBeInTheDocument();
+    }
+    expect(screen.getByText("deployed")).toBeInTheDocument();
+    expect(screen.getByText("pending-upgrade")).toBeInTheDocument();
+    expect(screen.getByText("nginx-15.1.2")).toBeInTheDocument();
+  });
+
+  it("shows the empty state", async () => {
+    const { default: HelmView } = await import("./HelmView.svelte");
+    render(HelmView);
+    expect(screen.getByText("No Helm releases found.")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/lib/components/views/logs-view.test.ts
+++ b/apps/desktop/src/lib/components/views/logs-view.test.ts
@@ -16,6 +16,7 @@ vi.mock("$lib/tauri", () => ({
   listIngresses: vi.fn(async () => []),
   listConfigMaps: vi.fn(async () => []),
   listSecrets: vi.fn(async () => []),
+  listHelmReleases: vi.fn(async () => []),
   streamLogs: vi.fn(async () => "1"),
   stopLogs: vi.fn(async () => undefined),
   watchResources: vi.fn(),

--- a/apps/desktop/src/lib/stores/mutations.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/mutations.svelte.test.ts
@@ -12,6 +12,7 @@ vi.mock("$lib/tauri", () => ({
   listIngresses: vi.fn(async () => []),
   listConfigMaps: vi.fn(async () => []),
   listSecrets: vi.fn(async () => []),
+  listHelmReleases: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));

--- a/apps/desktop/src/lib/stores/resources.svelte.ts
+++ b/apps/desktop/src/lib/stores/resources.svelte.ts
@@ -9,6 +9,7 @@ import {
   listConfigMaps,
   listDeployments,
   listEvents,
+  listHelmReleases,
   listIngresses,
   listNamespaces,
   listPods,
@@ -19,6 +20,7 @@ import {
   type ConfigMapInfo,
   type DeploymentInfo,
   type EventInfo,
+  type HelmReleaseInfo,
   type IngressInfo,
   type NamespaceInfo,
   type PodInfo,
@@ -32,9 +34,15 @@ import { settings } from "./settings.svelte";
 const RELOAD_DEBOUNCE_MS = 300;
 
 /** Resource kinds loaded on demand when their view is opened. */
-export type ExtraKind = "services" | "ingresses" | "configmaps" | "secrets";
+export type ExtraKind = "services" | "ingresses" | "configmaps" | "secrets" | "helm";
 
-const EXTRA_KINDS: readonly ExtraKind[] = ["services", "ingresses", "configmaps", "secrets"];
+const EXTRA_KINDS: readonly ExtraKind[] = [
+  "services",
+  "ingresses",
+  "configmaps",
+  "secrets",
+  "helm",
+];
 
 export function isExtraKind(v: unknown): v is ExtraKind {
   return typeof v === "string" && (EXTRA_KINDS as readonly string[]).includes(v);
@@ -49,6 +57,7 @@ class ResourcesStore {
   ingresses = $state<IngressInfo[]>([]);
   configmaps = $state<ConfigMapInfo[]>([]);
   secrets = $state<SecretInfo[]>([]);
+  helmReleases = $state<HelmReleaseInfo[]>([]);
   loading = $state(false);
   error = $state<string | null>(null);
   extraLoading = $state(false);
@@ -166,6 +175,11 @@ class ResourcesStore {
           if (seq === this.#extraSeq) this.secrets = list;
           break;
         }
+        case "helm": {
+          const list = await listHelmReleases(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.helmReleases = list;
+          break;
+        }
       }
     } catch (e) {
       if (seq === this.#extraSeq) this.extraError = errorMessage(e);
@@ -186,6 +200,7 @@ class ResourcesStore {
     this.ingresses = [];
     this.configmaps = [];
     this.secrets = [];
+    this.helmReleases = [];
     this.error = null;
     this.loading = false;
     this.extraError = null;

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -208,6 +208,16 @@ export function listEvents(
   });
 }
 
+export type HelmReleaseInfo = {
+  name: string;
+  namespace: string;
+  revision: number;
+  status: string | null;
+  chart: string | null;
+  app_version: string | null;
+  updated: string | null;
+};
+
 export type LogLevel = "info" | "warn" | "error";
 
 export type LogLine = {
@@ -222,6 +232,18 @@ export type PodRef = {
   namespace: string;
   name: string;
 };
+
+export function listHelmReleases(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<HelmReleaseInfo[]> {
+  return invoke<HelmReleaseInfo[]>("list_helm_releases", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
 
 export function streamLogs(
   kubeconfigPath: string,

--- a/crates/cubelite-core/Cargo.toml
+++ b/crates/cubelite-core/Cargo.toml
@@ -14,6 +14,8 @@ dirs = "5"
 kube = { version = "0.97", features = ["runtime", "derive", "client"] }
 serde_json = { workspace = true }
 k8s-openapi = { version = "0.23", features = ["v1_30"] }
+base64 = "0.22"
+flate2 = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -7,7 +7,7 @@ use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{ConfigMap, Event, Namespace, Pod, Secret, Service};
 use k8s_openapi::api::networking::v1::Ingress;
 use kube::{
-    api::{DeleteParams, Patch, PatchParams},
+    api::{DeleteParams, ListParams, Patch, PatchParams},
     config::{KubeConfigOptions, Kubeconfig},
     Api, Client, Config,
 };
@@ -15,6 +15,7 @@ use std::path::Path;
 
 use crate::{
     error::KubeconfigError,
+    helm::{latest_releases, parse_release_secret, HelmReleaseInfo},
     resources::{
         ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
         ServiceInfo,
@@ -242,6 +243,36 @@ impl KubeClient {
                     reason: e.to_string(),
                 })?;
         Ok(list.items.into_iter().filter_map(secret_to_info).collect())
+    }
+
+    /// List Helm v3 releases (latest revision per release) in `namespace`,
+    /// or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_helm_releases(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<HelmReleaseInfo>, KubeconfigError> {
+        let api: Api<Secret> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let params = ListParams::default().labels("owner=helm");
+        let list = api
+            .list(&params)
+            .await
+            .map_err(|e| KubeconfigError::ClientError {
+                reason: e.to_string(),
+            })?;
+        let releases = list
+            .items
+            .iter()
+            .filter(|s| s.type_.as_deref() == Some("helm.sh/release.v1"))
+            .filter_map(parse_release_secret)
+            .collect();
+        Ok(latest_releases(releases))
     }
 
     /// List events in `namespace`, or across all namespaces when `None`,

--- a/crates/cubelite-core/src/helm.rs
+++ b/crates/cubelite-core/src/helm.rs
@@ -1,0 +1,197 @@
+//! Helm v3 release discovery via release secrets.
+//!
+//! Helm stores each release revision in a Secret of type
+//! `helm.sh/release.v1` labelled `owner=helm`, with the payload in
+//! `data.release`: base64 text wrapping a gzip-compressed JSON document.
+//! [`parse_release_secret`] reads the cheap metadata from labels and
+//! decodes the payload for chart/app-version/updated details.
+
+use std::collections::BTreeMap;
+use std::io::Read;
+
+use base64::Engine;
+use k8s_openapi::api::core::v1::Secret;
+use serde::{Deserialize, Serialize};
+
+/// Lightweight representation of a Helm release (latest revision).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HelmReleaseInfo {
+    /// Release name.
+    pub name: String,
+    /// Namespace the release is installed into.
+    pub namespace: String,
+    /// Revision number.
+    pub revision: i32,
+    /// Release status (e.g. `"deployed"`, `"pending-upgrade"`, `"failed"`).
+    pub status: Option<String>,
+    /// Chart `name-version` (e.g. `"nginx-15.1.2"`), when decodable.
+    pub chart: Option<String>,
+    /// Chart appVersion, when decodable.
+    pub app_version: Option<String>,
+    /// RFC 3339 last-deployed timestamp (falls back to secret creation).
+    pub updated: Option<String>,
+}
+
+/// Decode the double-encoded Helm payload: base64 text → gzip → JSON.
+fn decode_release_payload(raw: &[u8]) -> Option<serde_json::Value> {
+    let compressed = base64::engine::general_purpose::STANDARD
+        .decode(raw.strip_suffix(b"\n").unwrap_or(raw))
+        .ok()?;
+    let mut json = String::new();
+    flate2::read::GzDecoder::new(compressed.as_slice())
+        .read_to_string(&mut json)
+        .ok()?;
+    serde_json::from_str(&json).ok()
+}
+
+/// Parse a Helm release secret into a [`HelmReleaseInfo`].
+///
+/// Returns `None` when the secret is not a Helm release secret (missing
+/// the `name` label or the `release` payload key).
+pub fn parse_release_secret(secret: &Secret) -> Option<HelmReleaseInfo> {
+    let labels: &BTreeMap<String, String> = secret.metadata.labels.as_ref()?;
+    let name = labels.get("name")?.clone();
+    let namespace = secret.metadata.namespace.clone().unwrap_or_default();
+    let revision = labels
+        .get("version")
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    let status = labels.get("status").cloned();
+
+    let payload = secret
+        .data
+        .as_ref()
+        .and_then(|d| d.get("release"))
+        .and_then(|bs| decode_release_payload(&bs.0));
+
+    let (chart, app_version, updated) = match &payload {
+        Some(doc) => {
+            let meta = &doc["chart"]["metadata"];
+            let chart = match (meta["name"].as_str(), meta["version"].as_str()) {
+                (Some(n), Some(v)) => Some(format!("{n}-{v}")),
+                (Some(n), None) => Some(n.to_string()),
+                _ => None,
+            };
+            let app_version = meta["appVersion"].as_str().map(str::to_string);
+            let updated = doc["info"]["last_deployed"].as_str().map(str::to_string);
+            (chart, app_version, updated)
+        }
+        None => (None, None, None),
+    };
+
+    let updated = updated.or_else(|| {
+        secret
+            .metadata
+            .creation_timestamp
+            .as_ref()
+            .map(|t| t.0.to_rfc3339())
+    });
+
+    Some(HelmReleaseInfo {
+        name,
+        namespace,
+        revision,
+        status,
+        chart,
+        app_version,
+        updated,
+    })
+}
+
+/// Keep only the latest revision per (namespace, release name), sorted by name.
+pub fn latest_releases(mut releases: Vec<HelmReleaseInfo>) -> Vec<HelmReleaseInfo> {
+    let mut latest: BTreeMap<(String, String), HelmReleaseInfo> = BTreeMap::new();
+    for release in releases.drain(..) {
+        let key = (release.namespace.clone(), release.name.clone());
+        match latest.get(&key) {
+            Some(existing) if existing.revision >= release.revision => {}
+            _ => {
+                latest.insert(key, release);
+            }
+        }
+    }
+    latest.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use k8s_openapi::ByteString;
+    use std::io::Write;
+
+    fn helm_secret(name: &str, revision: &str, status: &str, payload: Option<&str>) -> Secret {
+        let mut data = BTreeMap::new();
+        if let Some(json) = payload {
+            let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            gz.write_all(json.as_bytes()).expect("gzip write");
+            let compressed = gz.finish().expect("gzip finish");
+            let encoded = base64::engine::general_purpose::STANDARD.encode(compressed);
+            data.insert("release".to_string(), ByteString(encoded.into_bytes()));
+        }
+        Secret {
+            metadata: ObjectMeta {
+                name: Some(format!("sh.helm.release.v1.{name}.v{revision}")),
+                namespace: Some("default".to_string()),
+                labels: Some(BTreeMap::from([
+                    ("owner".to_string(), "helm".to_string()),
+                    ("name".to_string(), name.to_string()),
+                    ("version".to_string(), revision.to_string()),
+                    ("status".to_string(), status.to_string()),
+                ])),
+                ..Default::default()
+            },
+            type_: Some("helm.sh/release.v1".to_string()),
+            data: Some(data),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn parses_labels_and_decoded_payload() {
+        let payload = r#"{
+            "chart": { "metadata": { "name": "nginx", "version": "15.1.2", "appVersion": "1.27" } },
+            "info": { "last_deployed": "2026-07-10T09:00:00Z" }
+        }"#;
+        let secret = helm_secret("web", "3", "deployed", Some(payload));
+        let info = parse_release_secret(&secret).expect("parse");
+        assert_eq!(info.name, "web");
+        assert_eq!(info.revision, 3);
+        assert_eq!(info.status.as_deref(), Some("deployed"));
+        assert_eq!(info.chart.as_deref(), Some("nginx-15.1.2"));
+        assert_eq!(info.app_version.as_deref(), Some("1.27"));
+        assert_eq!(info.updated.as_deref(), Some("2026-07-10T09:00:00Z"));
+    }
+
+    #[test]
+    fn survives_undecodable_payload() {
+        let mut secret = helm_secret("web", "1", "failed", None);
+        secret.data = Some(BTreeMap::from([(
+            "release".to_string(),
+            ByteString(b"not-base64!!".to_vec()),
+        )]));
+        let info = parse_release_secret(&secret).expect("parse");
+        assert_eq!(info.status.as_deref(), Some("failed"));
+        assert!(info.chart.is_none());
+    }
+
+    #[test]
+    fn ignores_non_helm_secrets() {
+        let secret = Secret::default();
+        assert!(parse_release_secret(&secret).is_none());
+    }
+
+    #[test]
+    fn latest_releases_keeps_max_revision_per_release() {
+        let mk = |name: &str, rev: i32| HelmReleaseInfo {
+            name: name.to_string(),
+            namespace: "default".to_string(),
+            revision: rev,
+            ..Default::default()
+        };
+        let out = latest_releases(vec![mk("web", 1), mk("web", 3), mk("db", 2), mk("web", 2)]);
+        assert_eq!(out.len(), 2);
+        let web = out.iter().find(|r| r.name == "web").expect("web");
+        assert_eq!(web.revision, 3);
+    }
+}

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod client;
 pub mod context;
 pub mod error;
+pub mod helm;
 pub mod kubeconfig;
 pub mod logs;
 pub mod resources;
@@ -40,6 +41,7 @@ pub mod watcher;
 // Re-export the most commonly used items at the crate root.
 pub use client::KubeClient;
 pub use error::{ContextError, KubeconfigError};
+pub use helm::HelmReleaseInfo;
 pub use kubeconfig::KubeConfig;
 pub use logs::{LogLevel, LogLine};
 pub use resources::{


### PR DESCRIPTION
Closes #242 — first issue of **v0.2.0 — Desktop feature-complete**.

## Backend
- `cubelite_core::helm`: parses Helm v3 release secrets (`helm.sh/release.v1`, label `owner=helm`) — name/revision/status from labels; chart, appVersion and last-deployed decoded from the double-encoded payload (base64 text → gzip → JSON). Undecodable payloads degrade gracefully to label data.
- `latest_releases` dedupes to the max revision per `(namespace, release)`
- `KubeClient::list_helm_releases` (namespace optional) with `owner=helm` label selector
- New deps: `base64`, `flate2`

## Frontend
- `list_helm_releases` command + typed wrapper; `helm` joins the on-demand kinds in the resources store (stale-guard, refresh-while-open)
- **Helm Releases view** per design handoff: NAME / NAMESPACE / REV / STATUS / CHART / UPDATED, status pill mapping deployed→ok, pending-*→warn, failed→err
- Every view in the registry is now backed by real data — empty-state fallback removed

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace` (4 new helm tests incl. synthetic gzip payload round-trip)
- `pnpm --filter desktop lint / typecheck / test / build` — 138 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)