### PR TITLE
feat(core+desktop): per-cluster health probe

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -10,7 +10,7 @@ use cubelite_core::{
     ResourceType, ResourceWatcher, WatchEvent,
 };
 use futures::StreamExt;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -288,6 +288,62 @@ pub async fn cluster_capacity(
         .map_err(|e| e.to_string())?;
 
     client.cluster_capacity().await.map_err(|e| e.to_string())
+}
+
+/// Result of a cluster reachability probe.
+#[derive(Debug, Serialize)]
+pub struct ClusterHealthInfo {
+    /// Context name that was probed.
+    pub context: String,
+    /// `true` when the API server answered /version.
+    pub reachable: bool,
+    /// Kubernetes server version, when reachable.
+    pub version: Option<String>,
+    /// Node count, when the caller may list nodes.
+    pub node_count: Option<usize>,
+    /// Failure reason, when unreachable.
+    pub error: Option<String>,
+}
+
+/// Probe one context with short timeouts: /version + best-effort node count.
+#[tauri::command]
+pub async fn probe_cluster(
+    kubeconfig_path: String,
+    context: String,
+) -> Result<ClusterHealthInfo, String> {
+    let client = match KubeClient::new_probe(Path::new(&kubeconfig_path), Some(&context)).await {
+        Ok(c) => c,
+        Err(e) => {
+            return Ok(ClusterHealthInfo {
+                context,
+                reachable: false,
+                version: None,
+                node_count: None,
+                error: Some(e.to_string()),
+            });
+        }
+    };
+
+    match client.server_version().await {
+        Ok(version) => {
+            // Node listing may be forbidden; the probe still counts as healthy.
+            let node_count = client.node_count().await.ok();
+            Ok(ClusterHealthInfo {
+                context,
+                reachable: true,
+                version: Some(version),
+                node_count,
+                error: None,
+            })
+        }
+        Err(e) => Ok(ClusterHealthInfo {
+            context,
+            reachable: false,
+            version: None,
+            node_count: None,
+            error: Some(e.to_string()),
+        }),
+    }
 }
 
 /// Delete a pod (the owning controller will recreate it).

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,8 +3,9 @@ pub mod commands;
 use commands::kubernetes::{
     cluster_capacity, delete_pod, get_current_context, list_configmaps, list_contexts,
     list_deployments, list_events, list_helm_releases, list_ingresses, list_namespaces,
-    list_pod_metrics, list_pods, list_secrets, list_services, restart_deployment, scale_deployment,
-    set_context, stop_logs, stream_logs, unwatch_resources, watch_resources, LogState, WatchState,
+    list_pod_metrics, list_pods, list_secrets, list_services, probe_cluster, restart_deployment,
+    scale_deployment, set_context, stop_logs, stream_logs, unwatch_resources, watch_resources,
+    LogState, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -24,6 +25,7 @@ pub fn run() {
             list_helm_releases,
             list_pod_metrics,
             cluster_capacity,
+            probe_cluster,
             watch_resources,
             unwatch_resources,
             stream_logs,

--- a/apps/desktop/src/lib/components/CommandPalette.svelte
+++ b/apps/desktop/src/lib/components/CommandPalette.svelte
@@ -8,6 +8,7 @@
 	import Kbd from '$lib/components/ui/Kbd.svelte';
 	import { app, type View } from '$lib/stores/app.svelte';
 	import { clusters } from '$lib/stores/clusters.svelte';
+	import { health } from '$lib/stores/health.svelte';
 	import { modLabel } from '$lib/platform';
 	import { providerOf } from '$lib/provider';
 	import type { Component } from 'svelte';
@@ -93,16 +94,17 @@
 									>
 										{providerOf(ctx.name, ctx.cluster_server)}
 									</span>
-									{#if ctx.name === app.activeCluster}
-										<span
-											class="h-1.5 w-1.5 rounded-full"
-											style="background: {clusters.connectionState === 'connected'
-												? 'var(--color-status-ok)'
-												: clusters.connectionState === 'unreachable'
-													? 'var(--color-status-err)'
-													: 'var(--color-text-tertiary)'};"
-										></span>
-									{/if}
+									{@const state = ctx.name === app.activeCluster
+										? clusters.connectionState
+										: health.for(ctx.name).state}
+									<span
+										class="h-1.5 w-1.5 rounded-full"
+										style="background: {state === 'connected'
+											? 'var(--color-status-ok)'
+											: state === 'unreachable'
+												? 'var(--color-status-err)'
+												: 'var(--color-text-tertiary)'};"
+									></span>
 									{#if i < 5}
 										<Kbd label="{modLabel}{i + 1}" />
 									{/if}

--- a/apps/desktop/src/lib/components/shell/ClusterRail.svelte
+++ b/apps/desktop/src/lib/components/shell/ClusterRail.svelte
@@ -4,6 +4,7 @@
 	import IdentityAvatar from '$lib/components/ui/IdentityAvatar.svelte';
 	import { app } from '$lib/stores/app.svelte';
 	import { clusters } from '$lib/stores/clusters.svelte';
+	import { health } from '$lib/stores/health.svelte';
 
 	function clickCluster(name: string) {
 		if (name === app.activeCluster) {
@@ -45,7 +46,7 @@
 				name={ctx.name}
 				color={clusters.identityFor(ctx.name)}
 				active={isActive}
-				health={isActive ? clusters.connectionState : 'unknown'}
+				health={isActive ? clusters.connectionState : health.for(ctx.name).state}
 			/>
 		</button>
 	{/each}

--- a/apps/desktop/src/lib/components/shell/StatusBar.svelte
+++ b/apps/desktop/src/lib/components/shell/StatusBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { app } from '$lib/stores/app.svelte';
 	import { clusters } from '$lib/stores/clusters.svelte';
+	import { health } from '$lib/stores/health.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
 	import { settings } from '$lib/stores/settings.svelte';
 
@@ -8,6 +9,7 @@
 		clusters.contexts.find((c) => c.name === app.activeCluster)?.cluster_server ?? null
 	);
 	const warningCount = $derived(resources.warningEvents.length);
+	const version = $derived(app.activeCluster ? health.for(app.activeCluster).version : null);
 	const refreshLabel = $derived(
 		settings.refreshInterval.value === 0
 			? 'refresh off'
@@ -22,6 +24,9 @@
 >
 	{#if server}
 		<span class="truncate">{server}</span>
+	{/if}
+	{#if version}
+		<span>k8s {version}</span>
 	{/if}
 	<span>{refreshLabel}</span>
 	<span class="flex-1"></span>

--- a/apps/desktop/src/lib/components/views/AllClustersView.svelte
+++ b/apps/desktop/src/lib/components/views/AllClustersView.svelte
@@ -5,7 +5,9 @@
 	import StatusPill from '$lib/components/ui/StatusPill.svelte';
 	import { app } from '$lib/stores/app.svelte';
 	import { clusters } from '$lib/stores/clusters.svelte';
+	import { health } from '$lib/stores/health.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
+	import { formatAge } from '$lib/age';
 	import { percentOf } from '$lib/units';
 
 	const issues = $derived(resources.issuePods.length);
@@ -19,20 +21,33 @@
 		void clusters.switchCluster(name);
 	}
 
+	function stateFor(name: string): 'connected' | 'unreachable' | 'unknown' {
+		if (name === app.activeCluster && clusters.connectionState !== 'unknown') {
+			return clusters.connectionState;
+		}
+		return health.for(name).state;
+	}
+
 	function pillFor(name: string): { label: string; tone: 'ok' | 'err' | 'neutral' } {
-		if (name !== app.activeCluster) return { label: 'Unknown', tone: 'neutral' };
-		if (clusters.connectionState === 'connected') return { label: 'Healthy', tone: 'ok' };
-		if (clusters.connectionState === 'unreachable') return { label: 'Unreachable', tone: 'err' };
+		const state = stateFor(name);
+		if (state === 'connected') return { label: 'Healthy', tone: 'ok' };
+		if (state === 'unreachable') return { label: 'Unreachable', tone: 'err' };
 		return { label: 'Unknown', tone: 'neutral' };
 	}
 
-	// Backend has no probe for inactive clusters; only the active one has data.
 	function statsFor(name: string): [string, string][] {
+		const h = health.for(name);
 		const active = name === app.activeCluster && clusters.connectionState === 'connected';
+		const nodes =
+			h.nodeCount !== null
+				? String(h.nodeCount)
+				: active && resources.metricsAvailable
+					? String(resources.nodes.length)
+					: '—';
 		return [
-			['Nodes', active && resources.metricsAvailable ? String(resources.nodes.length) : '—'],
+			['Nodes', nodes],
 			['Pods', active ? String(resources.pods.length) : '—'],
-			['Version', '—'],
+			['Version', h.version ?? '—'],
 			['Warnings', active ? String(issues) : '—']
 		];
 	}
@@ -104,9 +119,13 @@
 					</div>
 				{/if}
 
-				{#if ctx.name === app.activeCluster && clusters.connectionState === 'unreachable'}
+				{#if stateFor(ctx.name) === 'unreachable'}
+					{@const h = health.for(ctx.name)}
 					<p class="type-caption text-status-err">
-						{clusters.unreachableReason ?? 'connection failed'}
+						{h.lastSeen ? `Last seen ${formatAge(h.lastSeen)} ago — ` : ''}{(ctx.name ===
+							app.activeCluster && clusters.unreachableReason) ||
+							h.reason ||
+							'connection failed'}
 					</p>
 				{/if}
 			</button>

--- a/apps/desktop/src/lib/stores/health.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/health.svelte.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("$lib/tauri", () => ({
+  probeCluster: vi.fn(),
+  listContexts: vi.fn(),
+  setContext: vi.fn(),
+  listPods: vi.fn(),
+  listNamespaces: vi.fn(),
+  listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
+  listPodMetrics: vi.fn(async () => []),
+  clusterCapacity: vi.fn(async () => []),
+  watchResources: vi.fn(),
+  unwatchResources: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+import { probeCluster } from "$lib/tauri";
+import { health } from "./health.svelte";
+import { app } from "./app.svelte";
+import { clusters } from "./clusters.svelte";
+import { settings } from "./settings.svelte";
+import { installLocalStorageMock } from "./storage-mock";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  installLocalStorageMock();
+  settings.lastSeen.value = {};
+  health.byContext = {};
+  app.kubeconfigPath = "/home/u/.kube/config";
+  clusters.contexts = [
+    { name: "prod", cluster_server: "https://prod:6443", namespace: "default", is_active: true },
+    { name: "staging", cluster_server: "https://staging:6443", namespace: "default", is_active: false },
+  ];
+});
+
+describe("health.probeAll", () => {
+  it("records reachable clusters with version/node count and persists lastSeen", async () => {
+    vi.mocked(probeCluster).mockImplementation(async (_kc, context) =>
+      context === "prod"
+        ? { context, reachable: true, version: "v1.30.2", node_count: 3, error: null }
+        : { context, reachable: false, version: null, node_count: null, error: "connection timed out" },
+    );
+
+    await health.probeAll();
+
+    expect(health.for("prod")).toMatchObject({
+      state: "connected",
+      version: "v1.30.2",
+      nodeCount: 3,
+    });
+    expect(health.for("prod").lastSeen).not.toBeNull();
+    expect(settings.lastSeen.value.prod).toBeDefined();
+
+    expect(health.for("staging")).toMatchObject({
+      state: "unreachable",
+      reason: "connection timed out",
+      lastSeen: null,
+    });
+  });
+
+  it("keeps the previous lastSeen when a cluster goes down", async () => {
+    settings.lastSeen.value = { staging: "2026-07-10T08:00:00Z" };
+    vi.mocked(probeCluster).mockResolvedValue({
+      context: "staging",
+      reachable: false,
+      version: null,
+      node_count: null,
+      error: "timeout",
+    });
+    clusters.contexts = [
+      { name: "staging", cluster_server: null, namespace: "default", is_active: false },
+    ];
+
+    await health.probeAll();
+
+    expect(health.for("staging").lastSeen).toBe("2026-07-10T08:00:00Z");
+  });
+
+  it("falls back to unknown with persisted lastSeen before any probe", () => {
+    settings.lastSeen.value = { prod: "2026-07-09T00:00:00Z" };
+    expect(health.for("prod")).toMatchObject({
+      state: "unknown",
+      lastSeen: "2026-07-09T00:00:00Z",
+    });
+  });
+});

--- a/apps/desktop/src/lib/stores/health.svelte.ts
+++ b/apps/desktop/src/lib/stores/health.svelte.ts
@@ -1,0 +1,92 @@
+/**
+ * Background reachability probes for every kube context, so the rail
+ * badges and the All-Clusters dashboard show real health instead of
+ * "unknown" for inactive clusters.
+ */
+
+import { probeCluster } from "$lib/tauri";
+import { app } from "./app.svelte";
+import { clusters } from "./clusters.svelte";
+import { settings } from "./settings.svelte";
+
+const PROBE_INTERVAL_MS = 60_000;
+
+export interface ClusterHealth {
+  state: "connected" | "unreachable" | "unknown";
+  version: string | null;
+  nodeCount: number | null;
+  reason: string | null;
+  /** RFC 3339 of the last successful probe (persisted across restarts). */
+  lastSeen: string | null;
+}
+
+class HealthStore {
+  byContext = $state<Record<string, ClusterHealth>>({});
+
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #probing = false;
+
+  for(contextName: string): ClusterHealth {
+    return (
+      this.byContext[contextName] ?? {
+        state: "unknown",
+        version: null,
+        nodeCount: null,
+        reason: null,
+        lastSeen: settings.lastSeen.value[contextName] ?? null,
+      }
+    );
+  }
+
+  /** Probe every discovered context in parallel (skips if already running). */
+  async probeAll(): Promise<void> {
+    const kc = app.kubeconfigPath;
+    if (!kc || this.#probing) return;
+    this.#probing = true;
+    try {
+      const results = await Promise.all(
+        clusters.contexts.map((c) =>
+          probeCluster(kc, c.name).catch((e: unknown) => ({
+            context: c.name,
+            reachable: false,
+            version: null,
+            node_count: null,
+            error: e instanceof Error ? e.message : String(e),
+          })),
+        ),
+      );
+
+      const now = new Date().toISOString();
+      const next: Record<string, ClusterHealth> = {};
+      const seen = { ...settings.lastSeen.value };
+      for (const r of results) {
+        if (r.reachable) seen[r.context] = now;
+        next[r.context] = {
+          state: r.reachable ? "connected" : "unreachable",
+          version: r.version,
+          nodeCount: r.node_count,
+          reason: r.error,
+          lastSeen: seen[r.context] ?? null,
+        };
+      }
+      this.byContext = next;
+      settings.lastSeen.value = seen;
+    } finally {
+      this.#probing = false;
+    }
+  }
+
+  /** Start periodic probing (immediate first run). */
+  start(): void {
+    this.stop();
+    void this.probeAll();
+    this.#timer = setInterval(() => void this.probeAll(), PROBE_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.#timer) clearInterval(this.#timer);
+    this.#timer = null;
+  }
+}
+
+export const health = new HealthStore();

--- a/apps/desktop/src/lib/stores/settings.svelte.ts
+++ b/apps/desktop/src/lib/stores/settings.svelte.ts
@@ -84,4 +84,6 @@ export const settings = {
   onboardingSeen: persisted<boolean>("onboardingSeen", false, isBoolean),
   /** contextName → identity color key; written back on context discovery. */
   identityColors: persisted<Record<string, string>>("identityColors", {}, isStringRecord),
+  /** contextName → RFC 3339 of the last successful reachability probe. */
+  lastSeen: persisted<Record<string, string>>("lastSeen", {}, isStringRecord),
 };

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -233,6 +233,14 @@ export type NodeCapacityInfo = {
   memory_allocatable_bytes: number;
 };
 
+export type ClusterHealthInfo = {
+  context: string;
+  reachable: boolean;
+  version: string | null;
+  node_count: number | null;
+  error: string | null;
+};
+
 export type LogLevel = "info" | "warn" | "error";
 
 export type LogLine = {
@@ -280,6 +288,13 @@ export function clusterCapacity(
     kubeconfigPath,
     context: context ?? null,
   });
+}
+
+export function probeCluster(
+  kubeconfigPath: string,
+  context: string,
+): Promise<ClusterHealthInfo> {
+  return invoke<ClusterHealthInfo>("probe_cluster", { kubeconfigPath, context });
 }
 
 export function streamLogs(

--- a/apps/desktop/src/routes/+page.svelte
+++ b/apps/desktop/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 	import { isMac } from '$lib/platform';
 	import { app } from '$lib/stores/app.svelte';
 	import { clusters } from '$lib/stores/clusters.svelte';
+	import { health } from '$lib/stores/health.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
 	import { settings } from '$lib/stores/settings.svelte';
 
@@ -37,11 +38,13 @@
 			if (!settings.onboardingSeen.value) {
 				app.onboardingOpen = true;
 			}
+			health.start();
 		})();
 
 		return () => {
 			void resources.stopWatching();
 			resources.stopAutoRefresh();
+			health.stop();
 		};
 	});
 

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -12,6 +12,7 @@ use kube::{
     Api, Client, Config,
 };
 use std::path::Path;
+use std::time::Duration;
 
 use crate::{
     error::KubeconfigError,
@@ -58,6 +59,25 @@ impl KubeClient {
     /// Returns [`KubeconfigError`] when the file cannot be read, parsed, or
     /// when the client cannot be initialised from the resulting config.
     pub async fn new(path: &Path, context: Option<&str>) -> Result<Self, KubeconfigError> {
+        Self::build(path, context, None).await
+    }
+
+    /// Like [`KubeClient::new`] but with short connect/read timeouts —
+    /// intended for reachability probes that must fail fast.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError`] when the kubeconfig cannot be loaded or
+    /// the client cannot be initialised.
+    pub async fn new_probe(path: &Path, context: Option<&str>) -> Result<Self, KubeconfigError> {
+        Self::build(path, context, Some((3, 5))).await
+    }
+
+    async fn build(
+        path: &Path,
+        context: Option<&str>,
+        timeouts_secs: Option<(u64, u64)>,
+    ) -> Result<Self, KubeconfigError> {
         let raw = tokio::fs::read_to_string(path)
             .await
             .map_err(|source| KubeconfigError::Io { source })?;
@@ -70,17 +90,53 @@ impl KubeClient {
             ..Default::default()
         };
 
-        let config = Config::from_custom_kubeconfig(kubeconfig, &options)
+        let mut config = Config::from_custom_kubeconfig(kubeconfig, &options)
             .await
             .map_err(|e| KubeconfigError::MergeError {
                 reason: e.to_string(),
             })?;
+
+        if let Some((connect, read)) = timeouts_secs {
+            config.connect_timeout = Some(Duration::from_secs(connect));
+            config.read_timeout = Some(Duration::from_secs(read));
+        }
 
         let inner = Client::try_from(config).map_err(|e| KubeconfigError::ClientError {
             reason: e.to_string(),
         })?;
 
         Ok(Self { inner })
+    }
+
+    /// Kubernetes server version (`gitVersion` from `/version`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn server_version(&self) -> Result<String, KubeconfigError> {
+        let doc = self.raw_get("/version").await?;
+        doc["gitVersion"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| KubeconfigError::ClientError {
+                reason: "missing gitVersion in /version response".to_string(),
+            })
+    }
+
+    /// Number of nodes in the cluster (best used by reachability probes).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn node_count(&self) -> Result<usize, KubeconfigError> {
+        let api: Api<Node> = Api::all(self.inner.clone());
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.len())
     }
 
     /// List pods in `namespace`, or across all namespaces when `namespace` is


### PR DESCRIPTION
Closes #244

## Backend
- `KubeClient::new_probe` — short connect/read timeouts (3s/5s) so probes fail fast instead of hanging on dead clusters
- `server_version` (`/version` gitVersion) and `node_count` helpers
- `probe_cluster` command: probes one context and returns reachability **as data** (`ClusterHealthInfo { reachable, version, node_count, error }`) — a down cluster is a result, not an error

## Frontend
- `health` store: probes every discovered context in parallel on startup and every 60s; `lastSeen` persisted across restarts
- **Cluster rail** badges and **command palette** dots now show real health for inactive clusters (was the honest gray "unknown")
- **All Clusters dashboard**: real Healthy/Unreachable pills for every cluster, NODES and VERSION mini-stats from the probe, offline cards per spec: "Last seen 3h ago — connection timed out"
- **Status bar** shows the active cluster's k8s version

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace`
- `pnpm --filter desktop lint / typecheck / test / build` — 146 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)