### PR TITLE
feat(design+desktop): light theme

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -11,40 +11,44 @@
   --font-sans: "Geist", system-ui, sans-serif;
   --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  --color-surface-window: #0b0b0d;
-  --color-surface-sunken: #0d0d10;
-  --color-surface-panel: #101013;
-  --color-surface-surface: #131316;
-  --color-surface-raised: #1a1a1f;
-  --color-surface-overlay: #161619;
-  --color-surface-row-hover: #16161a;
+  --color-surface-window: var(--cl-color-surface-window);
+  --color-surface-sunken: var(--cl-color-surface-sunken);
+  --color-surface-panel: var(--cl-color-surface-panel);
+  --color-surface-surface: var(--cl-color-surface-surface);
+  --color-surface-raised: var(--cl-color-surface-raised);
+  --color-surface-overlay: var(--cl-color-surface-overlay);
+  --color-surface-row-hover: var(--cl-color-surface-row-hover);
 
-  --color-border-default: #26262b;
-  --color-border-strong: #34343b;
-  --color-border-faint: #1e1e23;
+  --color-border-default: var(--cl-color-border-default);
+  --color-border-strong: var(--cl-color-border-strong);
+  --color-border-faint: var(--cl-color-border-faint);
 
-  --color-text-primary: #f4f4f5;
-  --color-text-secondary: #9c9ca6;
-  --color-text-tertiary: #71717a;
-  --color-text-disabled: #5c5c66;
-  --color-text-data-bright: #e4e4e7;
-  --color-text-log: #c8c8d0;
+  --color-text-primary: var(--cl-color-text-primary);
+  --color-text-secondary: var(--cl-color-text-secondary);
+  --color-text-tertiary: var(--cl-color-text-tertiary);
+  --color-text-disabled: var(--cl-color-text-disabled);
+  --color-text-data-bright: var(--cl-color-text-data-bright);
+  --color-text-log: var(--cl-color-text-log);
 
-  --color-accent: #6e9bf5;
-  --color-accent-alt-violet: #a78bfa;
-  --color-accent-alt-teal: #2dd4bf;
+  --color-status-ok: var(--cl-color-status-ok);
+  --color-status-warn: var(--cl-color-status-warn);
+  --color-status-err: var(--cl-color-status-err);
+  --color-status-err-solid: var(--cl-color-status-err-solid);
+  --color-status-info: var(--cl-color-status-info);
 
-  --color-status-ok: #34d399;
-  --color-status-warn: #fbbf24;
-  --color-status-err: #f87171;
-  --color-status-err-solid: #dc4646;
-  --color-status-info: #7dd3fc;
+  --color-cluster-blue: var(--cl-color-cluster-blue);
+  --color-cluster-amber: var(--cl-color-cluster-amber);
+  --color-cluster-pink: var(--cl-color-cluster-pink);
+  --color-cluster-violet: var(--cl-color-cluster-violet);
+  --color-cluster-teal: var(--cl-color-cluster-teal);
 
-  --color-cluster-blue: #60a5fa;
-  --color-cluster-amber: #f59e0b;
-  --color-cluster-pink: #f472b6;
-  --color-cluster-violet: #a78bfa;
-  --color-cluster-teal: #2dd4bf;
+  --shadow-overlay: var(--cl-shadow-overlay);
+  --shadow-drawer: var(--cl-shadow-drawer);
+  --shadow-toast: var(--cl-shadow-toast);
+
+  --color-accent: var(--cl-color-accent);
+  --color-accent-alt-violet: var(--cl-color-accent-alt-violet);
+  --color-accent-alt-teal: var(--cl-color-accent-alt-teal);
 
   --spacing-1: 4px;
   --spacing-2: 8px;
@@ -60,16 +64,45 @@
   --radius-xl: 10px;
   --radius-2xl: 12px;
   --radius-full: 9999px;
-
-  --shadow-overlay: 0 24px 80px rgba(0,0,0,.7);
-  --shadow-drawer: -16px 0 40px rgba(0,0,0,.45);
-  --shadow-toast: 0 10px 34px rgba(0,0,0,.5);
 }
 /* @generated:theme-end */
 
 /* @generated:layer-start */
 @layer base {
   :root {
+    --cl-color-surface-window: #fafafa;
+    --cl-color-surface-sunken: #f1f1f4;
+    --cl-color-surface-panel: #f5f5f7;
+    --cl-color-surface-surface: #ffffff;
+    --cl-color-surface-raised: #ececef;
+    --cl-color-surface-overlay: #ffffff;
+    --cl-color-surface-row-hover: #efeff2;
+    --cl-color-border-default: #e1e1e6;
+    --cl-color-border-strong: #c9c9d2;
+    --cl-color-border-faint: #ececf1;
+    --cl-color-text-primary: #18181b;
+    --cl-color-text-secondary: #52525b;
+    --cl-color-text-tertiary: #6e6e78;
+    --cl-color-text-disabled: #a0a0ab;
+    --cl-color-text-data-bright: #27272a;
+    --cl-color-text-log: #3a3a44;
+    --cl-color-status-ok: #0a9a6b;
+    --cl-color-status-warn: #c47b09;
+    --cl-color-status-err: #dc3f3f;
+    --cl-color-status-err-solid: #c93535;
+    --cl-color-status-info: #0f7fbd;
+    --cl-color-cluster-blue: #3b82f6;
+    --cl-color-cluster-amber: #d97706;
+    --cl-color-cluster-pink: #db2777;
+    --cl-color-cluster-violet: #7c3aed;
+    --cl-color-cluster-teal: #0d9488;
+    --cl-shadow-overlay: 0 24px 80px rgba(20,20,30,.16);
+    --cl-shadow-drawer: -16px 0 40px rgba(20,20,30,.12);
+    --cl-shadow-toast: 0 10px 34px rgba(20,20,30,.14);
+    --cl-color-accent: #4e77e5;
+    --cl-color-accent-alt-violet: #7c5ce8;
+    --cl-color-accent-alt-teal: #0f9e8e;
+
     --alpha-selection-bg: color-mix(in srgb, var(--color-accent) 10%, transparent);
     --alpha-active-nav-bg: color-mix(in srgb, var(--color-accent) 14%, transparent);
     --alpha-pill-ok: color-mix(in srgb, var(--color-status-ok) 10%, transparent);
@@ -89,35 +122,68 @@
     --motion-drawer: 160ms ease;
     --motion-toast: 180ms ease;
 
-    --background: 240 8.3% 4.7%;
-    --foreground: 240 4.8% 95.9%;
-    --card: 240 7.3% 8%;
-    --card-foreground: 240 4.8% 95.9%;
-    --popover: 240 6.4% 9.2%;
-    --popover-foreground: 240 4.8% 95.9%;
-    --primary: 220 87.1% 69.6%;
-    --primary-foreground: 240 8.3% 4.7%;
-    --secondary: 240 8.8% 11.2%;
-    --secondary-foreground: 240 4.8% 95.9%;
-    --muted: 240 8.8% 11.2%;
-    --muted-foreground: 240 5.3% 63.1%;
-    --accent: 240 8.8% 11.2%;
-    --accent-foreground: 240 4.8% 95.9%;
-    --destructive: 0 68.2% 56.9%;
-    --destructive-foreground: 240 4.8% 95.9%;
-    --border: 240 6.2% 15.9%;
-    --input: 240 6.2% 15.9%;
-    --ring: 220 87.1% 69.6%;
-    --sidebar-background: 240 8.6% 6.9%;
-    --sidebar-foreground: 240 5.3% 63.1%;
-    --sidebar-primary: 220 87.1% 69.6%;
-    --sidebar-primary-foreground: 240 8.3% 4.7%;
-    --sidebar-accent: 240 8.8% 11.2%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 7.7% 12.7%;
-    --sidebar-ring: 220 87.1% 69.6%;
+    --background: 0 0% 98%;
+    --foreground: 240 5.9% 10%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 5.9% 10%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 5.9% 10%;
+    --primary: 223.7 74.4% 60.2%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 8.6% 93.1%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 8.6% 93.1%;
+    --muted-foreground: 240 5.2% 33.9%;
+    --accent: 240 8.6% 93.1%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 58.3% 49.8%;
+    --destructive-foreground: 240 5.9% 10%;
+    --border: 240 9.1% 89.2%;
+    --input: 240 9.1% 89.2%;
+    --ring: 223.7 74.4% 60.2%;
+    --sidebar-background: 240 11.1% 96.5%;
+    --sidebar-foreground: 240 5.2% 33.9%;
+    --sidebar-primary: 223.7 74.4% 60.2%;
+    --sidebar-primary-foreground: 0 0% 98%;
+    --sidebar-accent: 240 8.6% 93.1%;
+    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-border: 240 15.2% 93.5%;
+    --sidebar-ring: 223.7 74.4% 60.2%;
   }
   .dark {
+    --cl-color-surface-window: #0b0b0d;
+    --cl-color-surface-sunken: #0d0d10;
+    --cl-color-surface-panel: #101013;
+    --cl-color-surface-surface: #131316;
+    --cl-color-surface-raised: #1a1a1f;
+    --cl-color-surface-overlay: #161619;
+    --cl-color-surface-row-hover: #16161a;
+    --cl-color-border-default: #26262b;
+    --cl-color-border-strong: #34343b;
+    --cl-color-border-faint: #1e1e23;
+    --cl-color-text-primary: #f4f4f5;
+    --cl-color-text-secondary: #9c9ca6;
+    --cl-color-text-tertiary: #71717a;
+    --cl-color-text-disabled: #5c5c66;
+    --cl-color-text-data-bright: #e4e4e7;
+    --cl-color-text-log: #c8c8d0;
+    --cl-color-status-ok: #34d399;
+    --cl-color-status-warn: #fbbf24;
+    --cl-color-status-err: #f87171;
+    --cl-color-status-err-solid: #dc4646;
+    --cl-color-status-info: #7dd3fc;
+    --cl-color-cluster-blue: #60a5fa;
+    --cl-color-cluster-amber: #f59e0b;
+    --cl-color-cluster-pink: #f472b6;
+    --cl-color-cluster-violet: #a78bfa;
+    --cl-color-cluster-teal: #2dd4bf;
+    --cl-shadow-overlay: 0 24px 80px rgba(0,0,0,.7);
+    --cl-shadow-drawer: -16px 0 40px rgba(0,0,0,.45);
+    --cl-shadow-toast: 0 10px 34px rgba(0,0,0,.5);
+    --cl-color-accent: #6e9bf5;
+    --cl-color-accent-alt-violet: #a78bfa;
+    --cl-color-accent-alt-teal: #2dd4bf;
+
     --background: 240 8.3% 4.7%;
     --foreground: 240 4.8% 95.9%;
     --card: 240 7.3% 8%;

--- a/apps/desktop/src/lib/components/PreferencesModal.svelte
+++ b/apps/desktop/src/lib/components/PreferencesModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { setMode } from 'mode-watcher';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
 	import { app } from '$lib/stores/app.svelte';
@@ -10,10 +11,10 @@
 		app.preferencesOpen = false;
 	}
 
-	const themeSegments: { value: Theme; label: string; disabled?: boolean; title?: string }[] = [
-		{ value: 'light', label: 'Light', disabled: true, title: 'Coming soon — dark is final in v1' },
+	const themeSegments: { value: Theme; label: string }[] = [
+		{ value: 'light', label: 'Light' },
 		{ value: 'dark', label: 'Dark' },
-		{ value: 'system', label: 'System', disabled: true, title: 'Coming soon — dark is final in v1' }
+		{ value: 'system', label: 'System' }
 	];
 
 	const refreshSegments: { value: RefreshInterval; label: string }[] = [
@@ -29,9 +30,13 @@
 		<section class="flex items-center justify-between gap-4">
 			<div>
 				<div class="type-body text-text-primary">Appearance</div>
-				<p class="type-caption mt-0.5 text-text-tertiary">Light and System arrive with the light theme.</p>
+				<p class="type-caption mt-0.5 text-text-tertiary">System follows the OS preference.</p>
 			</div>
-			<SegmentedControl segments={themeSegments} bind:value={settings.theme.value} />
+			<SegmentedControl
+				segments={themeSegments}
+				bind:value={settings.theme.value}
+				onChange={(value) => setMode(value)}
+			/>
 		</section>
 
 		<section class="flex items-center justify-between gap-4">

--- a/apps/desktop/src/lib/components/overlays.test.ts
+++ b/apps/desktop/src/lib/components/overlays.test.ts
@@ -20,7 +20,11 @@ vi.mock("$lib/tauri", () => ({
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(async () => () => {}),
 }));
+vi.mock("mode-watcher", () => ({
+  setMode: vi.fn(),
+}));
 
+import { setMode } from "mode-watcher";
 import Toaster from "./ui/Toaster.svelte";
 import DeletePodDialog from "./DeletePodDialog.svelte";
 import PreferencesModal from "./PreferencesModal.svelte";
@@ -92,12 +96,16 @@ describe("DeletePodDialog", () => {
 });
 
 describe("PreferencesModal", () => {
-  it("disables Light and System and keeps Dark active", () => {
+  it("offers all three appearance modes and applies the choice", async () => {
     app.preferencesOpen = true;
     render(PreferencesModal);
-    expect(screen.getByText("Light")).toBeDisabled();
-    expect(screen.getByText("System")).toBeDisabled();
     expect(screen.getByText("Dark")).not.toBeDisabled();
+    await fireEvent.click(screen.getByText("Light"));
+    expect(settings.theme.value).toBe("light");
+    expect(setMode).toHaveBeenCalledWith("light");
+    await fireEvent.click(screen.getByText("System"));
+    expect(settings.theme.value).toBe("system");
+    expect(setMode).toHaveBeenCalledWith("system");
   });
 
   it("persists the auto-refresh choice", async () => {

--- a/apps/desktop/src/routes/+page.svelte
+++ b/apps/desktop/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { setMode } from 'mode-watcher';
 	import { homeDir } from '@tauri-apps/api/path';
 	import Titlebar from '$lib/components/shell/Titlebar.svelte';
 	import ClusterRail from '$lib/components/shell/ClusterRail.svelte';
@@ -24,6 +25,7 @@
 	const Current = $derived(entry.component);
 
 	onMount(() => {
+		setMode(settings.theme.value);
 		void (async () => {
 			const dir = await homeDir();
 			app.kubeconfigPath = `${dir}/.kube/config`;

--- a/design/export-tokens.ts
+++ b/design/export-tokens.ts
@@ -24,6 +24,8 @@ import { fileURLToPath } from "node:url";
 
 interface Token {
   $value: string;
+  /** Light-theme counterpart; falls back to $value when omitted. */
+  $light?: string;
   $type?: string;
   $description?: string;
 }
@@ -49,10 +51,29 @@ interface DesignTokensV2 {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Entries of a token group, skipping `$description` and other meta keys. */
-function entries(group: TokenGroup): [string, string][] {
+function entries(group: TokenGroup, theme: "dark" | "light" = "dark"): [string, string][] {
   return Object.entries(group)
     .filter(([k]) => !k.startsWith("$"))
-    .map(([k, t]) => [k, t.$value]);
+    .map(([k, t]) => [k, theme === "light" ? (t.$light ?? t.$value) : t.$value]);
+}
+
+/** `--prefix-key: var(--cl-prefix-key);` aliases for theme-switchable groups. */
+function aliasLines(group: TokenGroup, prefix: string, indent: string): string {
+  return entries(group)
+    .map(([k]) => `${indent}--${prefix}${k}: var(--cl-${prefix}${k});`)
+    .join("\n");
+}
+
+/** `--cl-prefix-key: <value>;` concrete values for one theme. */
+function themedLines(
+  group: TokenGroup,
+  prefix: string,
+  indent: string,
+  theme: "dark" | "light",
+): string {
+  return entries(group, theme)
+    .map(([k, v]) => `${indent}--cl-${prefix}${k}: ${v};`)
+    .join("\n");
 }
 
 function lines(
@@ -134,43 +155,44 @@ const cssFile = resolve(root, "apps", "desktop", "src", "app.css");
 
 const tk = JSON.parse(readFileSync(tokensFile, "utf-8")) as DesignTokensV2;
 
-const tval = (group: TokenGroup, key: string): string => {
+const tval = (group: TokenGroup, key: string, theme: "dark" | "light" = "dark"): string => {
   const t = group[key];
   if (!t) throw new Error(`Missing token: ${key}`);
-  return t.$value;
+  return theme === "light" ? (t.$light ?? t.$value) : t.$value;
 };
+
+/** Color groups whose values switch between light and dark. */
+const SWITCHABLE: [TokenGroup, string][] = [
+  [tk.surface, "color-surface-"],
+  [tk.border, "color-border-"],
+  [tk.text, "color-text-"],
+  [tk.status, "color-status-"],
+  [tk["cluster-identity"], "color-cluster-"],
+  [tk.shadow, "shadow-"],
+];
 
 // ── Build @theme block ────────────────────────────────────────────────────────
 
 // accent.default → --color-accent; other accent keys keep their name suffix.
-const accentLines = entries(tk.accent)
-  .map(([k, v]) =>
-    k === "default" ? `  --color-accent: ${v};` : `  --color-accent-${k}: ${v};`,
-  )
-  .join("\n");
+const accentAlias = (k: string): string =>
+  k === "default" ? "color-accent" : `color-accent-${k}`;
 
+// Colors and shadows are aliases into theme-switchable --cl-* custom
+// properties defined per :root (light) / .dark below; everything that uses
+// a utility or an inline var(--color-*) follows the active theme.
 const themeContent = [
   "@theme {",
   `  --font-sans: ${tval(tk.font.family, "sans")};`,
   `  --font-mono: ${tval(tk.font.family, "mono")};`,
   "",
-  lines(tk.surface, "color-surface-", "  "),
-  "",
-  lines(tk.border, "color-border-", "  "),
-  "",
-  lines(tk.text, "color-text-", "  "),
-  "",
-  accentLines,
-  "",
-  lines(tk.status, "color-status-", "  "),
-  "",
-  lines(tk["cluster-identity"], "color-cluster-", "  "),
+  ...SWITCHABLE.map(([group, prefix]) => aliasLines(group, prefix, "  ") + "\n"),
+  entries(tk.accent)
+    .map(([k]) => `  --${accentAlias(k)}: var(--cl-${accentAlias(k)});`)
+    .join("\n"),
   "",
   lines(tk.spacing, "spacing-", "  "),
   "",
   lines(tk.radius, "radius-", "  "),
-  "",
-  lines(tk.shadow, "shadow-", "  "),
   "}",
 ].join("\n");
 
@@ -192,55 +214,68 @@ const alphaLines = [
 const densityLines = lines(tk.density, "", "    ");
 const motionLines = lines(tk.motion, "motion-", "    ", motionValue);
 
-// shadcn-svelte compat bridge: HSL triples derived from the v2 dark palette.
+// shadcn-svelte compat bridge: HSL triples derived from the active palette.
 // Existing/future shadcn-styled components read hsl(var(--background)) etc.
-// The app is dark-only in v1, so :root and .dark get identical values.
-const bridge: [string, string][] = [
-  ["background", tval(tk.surface, "window")],
-  ["foreground", tval(tk.text, "primary")],
-  ["card", tval(tk.surface, "surface")],
-  ["card-foreground", tval(tk.text, "primary")],
-  ["popover", tval(tk.surface, "overlay")],
-  ["popover-foreground", tval(tk.text, "primary")],
-  ["primary", tval(tk.accent, "default")],
-  ["primary-foreground", tval(tk.surface, "window")],
-  ["secondary", tval(tk.surface, "raised")],
-  ["secondary-foreground", tval(tk.text, "primary")],
-  ["muted", tval(tk.surface, "raised")],
-  ["muted-foreground", tval(tk.text, "secondary")],
-  ["accent", tval(tk.surface, "raised")],
-  ["accent-foreground", tval(tk.text, "primary")],
-  ["destructive", tval(tk.status, "err-solid")],
-  ["destructive-foreground", tval(tk.text, "primary")],
-  ["border", tval(tk.border, "default")],
-  ["input", tval(tk.border, "default")],
-  ["ring", tval(tk.accent, "default")],
-  ["sidebar-background", tval(tk.surface, "panel")],
-  ["sidebar-foreground", tval(tk.text, "secondary")],
-  ["sidebar-primary", tval(tk.accent, "default")],
-  ["sidebar-primary-foreground", tval(tk.surface, "window")],
-  ["sidebar-accent", tval(tk.surface, "raised")],
-  ["sidebar-accent-foreground", tval(tk.text, "primary")],
-  ["sidebar-border", tval(tk.border, "faint")],
-  ["sidebar-ring", tval(tk.accent, "default")],
+const bridgeFor = (theme: "dark" | "light"): [string, string][] => [
+  ["background", tval(tk.surface, "window", theme)],
+  ["foreground", tval(tk.text, "primary", theme)],
+  ["card", tval(tk.surface, "surface", theme)],
+  ["card-foreground", tval(tk.text, "primary", theme)],
+  ["popover", tval(tk.surface, "overlay", theme)],
+  ["popover-foreground", tval(tk.text, "primary", theme)],
+  ["primary", tval(tk.accent, "default", theme)],
+  ["primary-foreground", tval(tk.surface, "window", theme)],
+  ["secondary", tval(tk.surface, "raised", theme)],
+  ["secondary-foreground", tval(tk.text, "primary", theme)],
+  ["muted", tval(tk.surface, "raised", theme)],
+  ["muted-foreground", tval(tk.text, "secondary", theme)],
+  ["accent", tval(tk.surface, "raised", theme)],
+  ["accent-foreground", tval(tk.text, "primary", theme)],
+  ["destructive", tval(tk.status, "err-solid", theme)],
+  ["destructive-foreground", tval(tk.text, "primary", theme)],
+  ["border", tval(tk.border, "default", theme)],
+  ["input", tval(tk.border, "default", theme)],
+  ["ring", tval(tk.accent, "default", theme)],
+  ["sidebar-background", tval(tk.surface, "panel", theme)],
+  ["sidebar-foreground", tval(tk.text, "secondary", theme)],
+  ["sidebar-primary", tval(tk.accent, "default", theme)],
+  ["sidebar-primary-foreground", tval(tk.surface, "window", theme)],
+  ["sidebar-accent", tval(tk.surface, "raised", theme)],
+  ["sidebar-accent-foreground", tval(tk.text, "primary", theme)],
+  ["sidebar-border", tval(tk.border, "faint", theme)],
+  ["sidebar-ring", tval(tk.accent, "default", theme)],
 ];
 
-const bridgeLines = (indent: string): string =>
-  bridge.map(([k, v]) => `${indent}--${k}: ${hexToHslTriple(v)};`).join("\n");
+const bridgeLines = (indent: string, theme: "dark" | "light"): string =>
+  bridgeFor(theme)
+    .map(([k, v]) => `${indent}--${k}: ${hexToHslTriple(v)};`)
+    .join("\n");
+
+const themedBlock = (theme: "dark" | "light"): string =>
+  [
+    ...SWITCHABLE.map(([group, prefix]) => themedLines(group, prefix, "    ", theme)),
+    entries(tk.accent, theme)
+      .map(([k, v]) => `    --cl-${accentAlias(k)}: ${v};`)
+      .join("\n"),
+  ].join("\n");
 
 const layerContent = [
   "@layer base {",
   "  :root {",
+  themedBlock("light"),
+  "",
   alphaLines,
   "",
   densityLines,
   "",
   motionLines,
   "",
-  bridgeLines("    "),
+  bridgeLines("    ", "light"),
   "  }",
   "  .dark {",
-  bridgeLines("    "),
+  themedBlock("dark"),
+  "",
+  bridgeLines("    ", "dark"),
   "  }",
   "}",
 ].join("\n");

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -1,120 +1,386 @@
 {
-  "$description": "CubeLite design tokens v2 — unified cross-platform dark-first identity (Design System v1). Dark complete; light theme TODO. Hex values (not HSL triples).",
-
+  "$description": "CubeLite design tokens v2 — unified cross-platform identity (Design System v1). $value = dark, $light = light counterpart. Hex values (not HSL triples).",
   "surface": {
-    "window":  { "$value": "#0b0b0d", "$type": "color", "$description": "Window background" },
-    "sunken":  { "$value": "#0d0d10", "$type": "color", "$description": "Log viewer, code" },
-    "panel":   { "$value": "#101013", "$type": "color", "$description": "Sidebar, table bodies" },
-    "surface": { "$value": "#131316", "$type": "color", "$description": "Cards, table headers, titlebar" },
-    "raised":  { "$value": "#1a1a1f", "$type": "color", "$description": "Controls, hover fills" },
-    "overlay": { "$value": "#161619", "$type": "color", "$description": "Modals, palette, toasts" },
-    "row-hover": { "$value": "#16161a", "$type": "color" }
-  },
-
-  "border": {
-    "default": { "$value": "#26262b", "$type": "color" },
-    "strong":  { "$value": "#34343b", "$type": "color", "$description": "Overlay borders" },
-    "faint":   { "$value": "#1e1e23", "$type": "color", "$description": "Row separators" }
-  },
-
-  "text": {
-    "primary":    { "$value": "#f4f4f5", "$type": "color" },
-    "secondary":  { "$value": "#9c9ca6", "$type": "color" },
-    "tertiary":   { "$value": "#71717a", "$type": "color", "$description": "Column headers, meta" },
-    "disabled":   { "$value": "#5c5c66", "$type": "color", "$description": "Placeholders, kbd" },
-    "data-bright":{ "$value": "#e4e4e7", "$type": "color", "$description": "Mono resource names" },
-    "log":        { "$value": "#c8c8d0", "$type": "color" }
-  },
-
-  "accent": {
-    "default": { "$value": "#6e9bf5", "$type": "color", "$description": "Selection, focus, primary actions" },
-    "alt-violet": { "$value": "#a78bfa", "$type": "color" },
-    "alt-teal":   { "$value": "#2dd4bf", "$type": "color" }
-  },
-
-  "status": {
-    "ok":   { "$value": "#34d399", "$type": "color", "$description": "Running/Available/Succeeded/deployed" },
-    "warn": { "$value": "#fbbf24", "$type": "color", "$description": "Pending/Progressing/pending-upgrade" },
-    "err":  { "$value": "#f87171", "$type": "color", "$description": "CrashLoop/failed/unreachable" },
-    "err-solid": { "$value": "#dc4646", "$type": "color", "$description": "Destructive confirm button fill" },
-    "info": { "$value": "#7dd3fc", "$type": "color", "$description": "INFO log level" }
-  },
-
-  "alpha": {
-    "$description": "Tint recipes: color-mix(color a%, transparent)",
-    "selection-bg":   { "$value": "accent 10%", "$type": "recipe" },
-    "active-nav-bg":  { "$value": "accent 14%", "$type": "recipe" },
-    "active-rail-bg": { "$value": "identity 20%", "$type": "recipe" },
-    "pill-bg":        { "$value": "status 10%", "$type": "recipe" },
-    "log-error-row":  { "$value": "err 7%", "$type": "recipe" },
-    "log-warn-row":   { "$value": "warn 4.5%", "$type": "recipe" },
-    "focus-ring":     { "$value": "accent 15% · 3px", "$type": "recipe" }
-  },
-
-  "cluster-identity": {
-    "$description": "Assigned at context discovery, stable, user-overridable. Never used to convey health.",
-    "blue":   { "$value": "#60a5fa", "$type": "color" },
-    "amber":  { "$value": "#f59e0b", "$type": "color" },
-    "pink":   { "$value": "#f472b6", "$type": "color" },
-    "violet": { "$value": "#a78bfa", "$type": "color" },
-    "teal":   { "$value": "#2dd4bf", "$type": "color" }
-  },
-
-  "spacing": {
-    "1": { "$value": "4px", "$type": "spacing" },
-    "2": { "$value": "8px", "$type": "spacing" },
-    "3": { "$value": "12px", "$type": "spacing" },
-    "4": { "$value": "16px", "$type": "spacing" },
-    "5": { "$value": "20px", "$type": "spacing" },
-    "6": { "$value": "24px", "$type": "spacing" },
-    "8": { "$value": "32px", "$type": "spacing" }
-  },
-
-  "radius": {
-    "sm":  { "$value": "4px",  "$type": "dimension", "$description": "Chips, kbd" },
-    "md":  { "$value": "6px",  "$type": "dimension", "$description": "Buttons, inputs, controls" },
-    "lg":  { "$value": "8px",  "$type": "dimension", "$description": "Tables, log panel" },
-    "xl":  { "$value": "10px", "$type": "dimension", "$description": "Cards, rail avatars" },
-    "2xl": { "$value": "12px", "$type": "dimension", "$description": "Modals, palette" },
-    "full":{ "$value": "9999px", "$type": "dimension", "$description": "Pills" }
-  },
-
-  "shadow": {
-    "overlay": { "$value": "0 24px 80px rgba(0,0,0,.7)",  "$type": "shadow" },
-    "drawer":  { "$value": "-16px 0 40px rgba(0,0,0,.45)", "$type": "shadow" },
-    "toast":   { "$value": "0 10px 34px rgba(0,0,0,.5)",  "$type": "shadow" }
-  },
-
-  "font": {
-    "family": {
-      "sans": { "$value": "\"Geist\", system-ui, sans-serif", "$type": "fontFamily", "$description": "UI, navigation, buttons" },
-      "mono": { "$value": "\"Geist Mono\", ui-monospace, SFMono-Regular, Menlo, monospace", "$type": "fontFamily", "$description": "All data: names, metrics, IPs, logs" }
+    "window": {
+      "$value": "#0b0b0d",
+      "$type": "color",
+      "$description": "Window background",
+      "$light": "#fafafa"
     },
-    "style": {
-      "display":  { "$value": "600 28px sans", "$type": "typography", "$description": "Onboarding hero only" },
-      "title":    { "$value": "600 16px sans", "$type": "typography", "$description": "View titles" },
-      "subtitle": { "$value": "600 13px sans", "$type": "typography", "$description": "Modal titles, titlebar cluster name" },
-      "body":     { "$value": "500 12.5px sans", "$type": "typography", "$description": "Nav, buttons, rows" },
-      "caption":  { "$value": "400 11px sans", "$type": "typography" },
-      "section":  { "$value": "600 9.5px sans · uppercase · ls .07em", "$type": "typography" },
-      "colhead":  { "$value": "600 10.5px sans · uppercase", "$type": "typography" },
-      "data":     { "$value": "500 12px mono", "$type": "typography", "$description": "Resource names" },
-      "data-sm":  { "$value": "400 11.5px mono", "$type": "typography", "$description": "Cells, metrics" },
-      "log":      { "$value": "400 11px mono", "$type": "typography" }
+    "sunken": {
+      "$value": "#0d0d10",
+      "$type": "color",
+      "$description": "Log viewer, code",
+      "$light": "#f1f1f4"
+    },
+    "panel": {
+      "$value": "#101013",
+      "$type": "color",
+      "$description": "Sidebar, table bodies",
+      "$light": "#f5f5f7"
+    },
+    "surface": {
+      "$value": "#131316",
+      "$type": "color",
+      "$description": "Cards, table headers, titlebar",
+      "$light": "#ffffff"
+    },
+    "raised": {
+      "$value": "#1a1a1f",
+      "$type": "color",
+      "$description": "Controls, hover fills",
+      "$light": "#ececef"
+    },
+    "overlay": {
+      "$value": "#161619",
+      "$type": "color",
+      "$description": "Modals, palette, toasts",
+      "$light": "#ffffff"
+    },
+    "row-hover": {
+      "$value": "#16161a",
+      "$type": "color",
+      "$light": "#efeff2"
     }
   },
-
-  "density": {
-    "row-pad-default": { "$value": "9px", "$type": "spacing" },
-    "row-pad-compact": { "$value": "5px", "$type": "spacing" },
-    "control-height":  { "$value": "28px", "$type": "dimension" },
-    "min-hit-target":  { "$value": "28px", "$type": "dimension" }
+  "border": {
+    "default": {
+      "$value": "#26262b",
+      "$type": "color",
+      "$light": "#e1e1e6"
+    },
+    "strong": {
+      "$value": "#34343b",
+      "$type": "color",
+      "$description": "Overlay borders",
+      "$light": "#c9c9d2"
+    },
+    "faint": {
+      "$value": "#1e1e23",
+      "$type": "color",
+      "$description": "Row separators",
+      "$light": "#ececf1"
+    }
   },
-
+  "text": {
+    "primary": {
+      "$value": "#f4f4f5",
+      "$type": "color",
+      "$light": "#18181b"
+    },
+    "secondary": {
+      "$value": "#9c9ca6",
+      "$type": "color",
+      "$light": "#52525b"
+    },
+    "tertiary": {
+      "$value": "#71717a",
+      "$type": "color",
+      "$description": "Column headers, meta",
+      "$light": "#6e6e78"
+    },
+    "disabled": {
+      "$value": "#5c5c66",
+      "$type": "color",
+      "$description": "Placeholders, kbd",
+      "$light": "#a0a0ab"
+    },
+    "data-bright": {
+      "$value": "#e4e4e7",
+      "$type": "color",
+      "$description": "Mono resource names",
+      "$light": "#27272a"
+    },
+    "log": {
+      "$value": "#c8c8d0",
+      "$type": "color",
+      "$light": "#3a3a44"
+    }
+  },
+  "accent": {
+    "default": {
+      "$value": "#6e9bf5",
+      "$type": "color",
+      "$description": "Selection, focus, primary actions",
+      "$light": "#4e77e5"
+    },
+    "alt-violet": {
+      "$value": "#a78bfa",
+      "$type": "color",
+      "$light": "#7c5ce8"
+    },
+    "alt-teal": {
+      "$value": "#2dd4bf",
+      "$type": "color",
+      "$light": "#0f9e8e"
+    }
+  },
+  "status": {
+    "ok": {
+      "$value": "#34d399",
+      "$type": "color",
+      "$description": "Running/Available/Succeeded/deployed",
+      "$light": "#0a9a6b"
+    },
+    "warn": {
+      "$value": "#fbbf24",
+      "$type": "color",
+      "$description": "Pending/Progressing/pending-upgrade",
+      "$light": "#c47b09"
+    },
+    "err": {
+      "$value": "#f87171",
+      "$type": "color",
+      "$description": "CrashLoop/failed/unreachable",
+      "$light": "#dc3f3f"
+    },
+    "err-solid": {
+      "$value": "#dc4646",
+      "$type": "color",
+      "$description": "Destructive confirm button fill",
+      "$light": "#c93535"
+    },
+    "info": {
+      "$value": "#7dd3fc",
+      "$type": "color",
+      "$description": "INFO log level",
+      "$light": "#0f7fbd"
+    }
+  },
+  "alpha": {
+    "$description": "Tint recipes: color-mix(color a%, transparent)",
+    "selection-bg": {
+      "$value": "accent 10%",
+      "$type": "recipe"
+    },
+    "active-nav-bg": {
+      "$value": "accent 14%",
+      "$type": "recipe"
+    },
+    "active-rail-bg": {
+      "$value": "identity 20%",
+      "$type": "recipe"
+    },
+    "pill-bg": {
+      "$value": "status 10%",
+      "$type": "recipe"
+    },
+    "log-error-row": {
+      "$value": "err 7%",
+      "$type": "recipe"
+    },
+    "log-warn-row": {
+      "$value": "warn 4.5%",
+      "$type": "recipe"
+    },
+    "focus-ring": {
+      "$value": "accent 15% · 3px",
+      "$type": "recipe"
+    }
+  },
+  "cluster-identity": {
+    "$description": "Assigned at context discovery, stable, user-overridable. Never used to convey health.",
+    "blue": {
+      "$value": "#60a5fa",
+      "$type": "color",
+      "$light": "#3b82f6"
+    },
+    "amber": {
+      "$value": "#f59e0b",
+      "$type": "color",
+      "$light": "#d97706"
+    },
+    "pink": {
+      "$value": "#f472b6",
+      "$type": "color",
+      "$light": "#db2777"
+    },
+    "violet": {
+      "$value": "#a78bfa",
+      "$type": "color",
+      "$light": "#7c3aed"
+    },
+    "teal": {
+      "$value": "#2dd4bf",
+      "$type": "color",
+      "$light": "#0d9488"
+    }
+  },
+  "spacing": {
+    "1": {
+      "$value": "4px",
+      "$type": "spacing"
+    },
+    "2": {
+      "$value": "8px",
+      "$type": "spacing"
+    },
+    "3": {
+      "$value": "12px",
+      "$type": "spacing"
+    },
+    "4": {
+      "$value": "16px",
+      "$type": "spacing"
+    },
+    "5": {
+      "$value": "20px",
+      "$type": "spacing"
+    },
+    "6": {
+      "$value": "24px",
+      "$type": "spacing"
+    },
+    "8": {
+      "$value": "32px",
+      "$type": "spacing"
+    }
+  },
+  "radius": {
+    "sm": {
+      "$value": "4px",
+      "$type": "dimension",
+      "$description": "Chips, kbd"
+    },
+    "md": {
+      "$value": "6px",
+      "$type": "dimension",
+      "$description": "Buttons, inputs, controls"
+    },
+    "lg": {
+      "$value": "8px",
+      "$type": "dimension",
+      "$description": "Tables, log panel"
+    },
+    "xl": {
+      "$value": "10px",
+      "$type": "dimension",
+      "$description": "Cards, rail avatars"
+    },
+    "2xl": {
+      "$value": "12px",
+      "$type": "dimension",
+      "$description": "Modals, palette"
+    },
+    "full": {
+      "$value": "9999px",
+      "$type": "dimension",
+      "$description": "Pills"
+    }
+  },
+  "shadow": {
+    "overlay": {
+      "$value": "0 24px 80px rgba(0,0,0,.7)",
+      "$type": "shadow",
+      "$light": "0 24px 80px rgba(20,20,30,.16)"
+    },
+    "drawer": {
+      "$value": "-16px 0 40px rgba(0,0,0,.45)",
+      "$type": "shadow",
+      "$light": "-16px 0 40px rgba(20,20,30,.12)"
+    },
+    "toast": {
+      "$value": "0 10px 34px rgba(0,0,0,.5)",
+      "$type": "shadow",
+      "$light": "0 10px 34px rgba(20,20,30,.14)"
+    }
+  },
+  "font": {
+    "family": {
+      "sans": {
+        "$value": "\"Geist\", system-ui, sans-serif",
+        "$type": "fontFamily",
+        "$description": "UI, navigation, buttons"
+      },
+      "mono": {
+        "$value": "\"Geist Mono\", ui-monospace, SFMono-Regular, Menlo, monospace",
+        "$type": "fontFamily",
+        "$description": "All data: names, metrics, IPs, logs"
+      }
+    },
+    "style": {
+      "display": {
+        "$value": "600 28px sans",
+        "$type": "typography",
+        "$description": "Onboarding hero only"
+      },
+      "title": {
+        "$value": "600 16px sans",
+        "$type": "typography",
+        "$description": "View titles"
+      },
+      "subtitle": {
+        "$value": "600 13px sans",
+        "$type": "typography",
+        "$description": "Modal titles, titlebar cluster name"
+      },
+      "body": {
+        "$value": "500 12.5px sans",
+        "$type": "typography",
+        "$description": "Nav, buttons, rows"
+      },
+      "caption": {
+        "$value": "400 11px sans",
+        "$type": "typography"
+      },
+      "section": {
+        "$value": "600 9.5px sans · uppercase · ls .07em",
+        "$type": "typography"
+      },
+      "colhead": {
+        "$value": "600 10.5px sans · uppercase",
+        "$type": "typography"
+      },
+      "data": {
+        "$value": "500 12px mono",
+        "$type": "typography",
+        "$description": "Resource names"
+      },
+      "data-sm": {
+        "$value": "400 11.5px mono",
+        "$type": "typography",
+        "$description": "Cells, metrics"
+      },
+      "log": {
+        "$value": "400 11px mono",
+        "$type": "typography"
+      }
+    }
+  },
+  "density": {
+    "row-pad-default": {
+      "$value": "9px",
+      "$type": "spacing"
+    },
+    "row-pad-compact": {
+      "$value": "5px",
+      "$type": "spacing"
+    },
+    "control-height": {
+      "$value": "28px",
+      "$type": "dimension"
+    },
+    "min-hit-target": {
+      "$value": "28px",
+      "$type": "dimension"
+    }
+  },
   "motion": {
-    "fadein": { "$value": "100ms ease", "$type": "duration" },
-    "popin":  { "$value": "140ms ease · translateY(6px) scale(.98) → none", "$type": "duration" },
-    "drawer": { "$value": "160ms ease · translateX(30px) → none", "$type": "duration" },
-    "toast":  { "$value": "180ms ease", "$type": "duration" }
+    "fadein": {
+      "$value": "100ms ease",
+      "$type": "duration"
+    },
+    "popin": {
+      "$value": "140ms ease · translateY(6px) scale(.98) → none",
+      "$type": "duration"
+    },
+    "drawer": {
+      "$value": "160ms ease · translateX(30px) → none",
+      "$type": "duration"
+    },
+    "toast": {
+      "$value": "180ms ease",
+      "$type": "duration"
+    }
   }
 }


### PR DESCRIPTION
Closes #245

## Tokens
- `design/tokens.json`: every color and shadow token gains a `$light` counterpart — light surfaces (#fafafa window / #ffffff cards), darker text ramp, contrast-adjusted accent/status/identity palettes, softened shadows
- `design/export-tokens.ts`: `@theme` colors/shadows are now **aliases** into theme-switchable `--cl-*` custom properties emitted per `:root` (light) and `.dark` (dark). Tailwind utilities *and* the many inline `var(--color-*)` style references all switch automatically; the shadcn HSL bridge is derived per theme.

## Desktop
- Preferences → Appearance segmented control fully enabled: **Light / Dark / System** apply immediately (`mode-watcher` `setMode`) and persist across restarts
- Persisted theme applied at startup; first-launch default remains dark

## Verification (exit codes checked explicitly)
- `pnpm design:tokens` idempotent (second run produces no diff)
- `pnpm --filter desktop lint / typecheck / test / build` — 146 tests, 0 unhandled errors
- No Rust changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)