### PR TITLE
feat(core+desktop): extended workloads — Jobs, CronJobs, StatefulSets, Nodes, PVCs

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -4,8 +4,8 @@ use cubelite_core::{
     logs::stream_pod_logs,
     metrics::{NodeCapacityInfo, PodMetricsInfo},
     resources::{
-        ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
-        ServiceInfo,
+        ConfigMapInfo, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo, JobInfo, NamespaceInfo,
+        NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo, StatefulSetInfo,
     },
     ResourceType, ResourceWatcher, WatchEvent,
 };
@@ -344,6 +344,87 @@ pub async fn probe_cluster(
             error: Some(e.to_string()),
         }),
     }
+}
+
+/// List jobs in the given namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_jobs(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<JobInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_jobs(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List cron jobs in the given namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_cronjobs(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<CronJobInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_cronjobs(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List stateful sets in the given namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_statefulsets(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<StatefulSetInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_statefulsets(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List persistent volume claims in the given namespace (all namespaces when `None`).
+#[tauri::command]
+pub async fn list_pvcs(
+    kubeconfig_path: String,
+    namespace: Option<String>,
+    context: Option<String>,
+) -> Result<Vec<PvcInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .list_pvcs(namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List cluster nodes (read-only inventory).
+#[tauri::command]
+pub async fn list_nodes(
+    kubeconfig_path: String,
+    context: Option<String>,
+) -> Result<Vec<NodeInfo>, String> {
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client.list_nodes().await.map_err(|e| e.to_string())
 }
 
 /// Delete a pod (the owning controller will recreate it).

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,10 +2,10 @@ pub mod commands;
 
 use commands::kubernetes::{
     cluster_capacity, delete_pod, get_current_context, list_configmaps, list_contexts,
-    list_deployments, list_events, list_helm_releases, list_ingresses, list_namespaces,
-    list_pod_metrics, list_pods, list_secrets, list_services, probe_cluster, restart_deployment,
-    scale_deployment, set_context, stop_logs, stream_logs, unwatch_resources, watch_resources,
-    LogState, WatchState,
+    list_cronjobs, list_deployments, list_events, list_helm_releases, list_ingresses, list_jobs,
+    list_namespaces, list_nodes, list_pod_metrics, list_pods, list_pvcs, list_secrets,
+    list_services, list_statefulsets, probe_cluster, restart_deployment, scale_deployment,
+    set_context, stop_logs, stream_logs, unwatch_resources, watch_resources, LogState, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -26,6 +26,11 @@ pub fn run() {
             list_pod_metrics,
             cluster_capacity,
             probe_cluster,
+            list_jobs,
+            list_cronjobs,
+            list_statefulsets,
+            list_nodes,
+            list_pvcs,
             watch_resources,
             unwatch_resources,
             stream_logs,

--- a/apps/desktop/src/lib/components/shell/Sidebar.svelte
+++ b/apps/desktop/src/lib/components/shell/Sidebar.svelte
@@ -14,13 +14,23 @@
 
 	// Group dot colors per spec: workloads blue, network violet, config amber, observe teal.
 	const sections: Section[] = [
-		{ label: 'Cluster', dot: 'var(--color-accent)', items: [{ view: 'overview', label: 'Overview' }] },
+		{
+			label: 'Cluster',
+			dot: 'var(--color-accent)',
+			items: [
+				{ view: 'overview', label: 'Overview' },
+				{ view: 'nodes', label: 'Nodes' }
+			]
+		},
 		{
 			label: 'Workloads',
 			dot: 'var(--color-cluster-blue)',
 			items: [
 				{ view: 'pods', label: 'Pods' },
 				{ view: 'deployments', label: 'Deployments' },
+				{ view: 'statefulsets', label: 'StatefulSets' },
+				{ view: 'jobs', label: 'Jobs' },
+				{ view: 'cronjobs', label: 'CronJobs' },
 				{ view: 'helm', label: 'Helm Releases' }
 			]
 		},
@@ -37,7 +47,8 @@
 			dot: 'var(--color-status-warn)',
 			items: [
 				{ view: 'configmaps', label: 'ConfigMaps' },
-				{ view: 'secrets', label: 'Secrets' }
+				{ view: 'secrets', label: 'Secrets' },
+				{ view: 'pvcs', label: 'PVCs' }
 			]
 		},
 		{

--- a/apps/desktop/src/lib/components/views/CronJobsView.svelte
+++ b/apps/desktop/src/lib/components/views/CronJobsView.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('cronjobs');
+	});
+
+	const grid = 'grid-template-columns: 2fr 1fr 0.7fr 0.5fr 0.8fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">CronJobs</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Schedule</span>
+				<span class="type-colhead">Suspend</span>
+				<span class="type-colhead">Active</span>
+				<span class="type-colhead">Last schedule</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.cronjobs.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No cron jobs found.</p>
+				{:else}
+					{#each resources.cronjobs as item (item.namespace + '/' + item.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+						<span class="type-data truncate text-text-data-bright">{item.name}</span>
+						<span class="type-data-sm text-text-secondary">{item.schedule}</span>
+						<span class="type-data-sm" style="color: {item.suspend ? 'var(--color-status-warn)' : 'var(--color-text-secondary)'};">{item.suspend ? 'True' : 'False'}</span>
+						<span class="type-data-sm text-text-secondary">{item.active}</span>
+						<span class="type-data-sm text-text-secondary">{formatAge(item.last_schedule)}</span>
+						<span class="type-data-sm text-text-secondary">{formatAge(item.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/JobsView.svelte
+++ b/apps/desktop/src/lib/components/views/JobsView.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('jobs');
+	});
+
+	const grid = 'grid-template-columns: 2.4fr 0.9fr 0.6fr 0.6fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">Jobs</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Completions</span>
+				<span class="type-colhead">Active</span>
+				<span class="type-colhead">Failed</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.jobs.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No jobs found.</p>
+				{:else}
+					{#each resources.jobs as item (item.namespace + '/' + item.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+						<span class="type-data truncate text-text-data-bright">{item.name}</span>
+						<span class="type-data-sm text-text-secondary">{item.succeeded}/{item.completions}</span>
+						<span class="type-data-sm text-text-secondary">{item.active}</span>
+						<span class="type-data-sm" style="color: {item.failed > 0 ? 'var(--color-status-err)' : 'var(--color-text-secondary)'};">{item.failed}</span>
+						<span class="type-data-sm text-text-secondary">{formatAge(item.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/NodesView.svelte
+++ b/apps/desktop/src/lib/components/views/NodesView.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('nodes');
+	});
+
+	const grid = 'grid-template-columns: 2.2fr 0.8fr 1.4fr 0.9fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">Nodes</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Status</span>
+				<span class="type-colhead">Roles</span>
+				<span class="type-colhead">Version</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.nodeInventory.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No nodes found.</p>
+				{:else}
+					{#each resources.nodeInventory as item (item.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+						<span class="type-data truncate text-text-data-bright">{item.name}</span>
+						<span class="type-data-sm" style="color: {item.status === 'Ready' ? 'var(--color-status-ok)' : 'var(--color-status-err)'};">{item.status}</span>
+						<span class="type-data-sm truncate text-text-secondary">{item.roles.join(', ') || '—'}</span>
+						<span class="type-data-sm text-text-secondary">{item.version ?? '—'}</span>
+						<span class="type-data-sm text-text-secondary">{formatAge(item.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/PvcsView.svelte
+++ b/apps/desktop/src/lib/components/views/PvcsView.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('pvcs');
+	});
+
+	const grid = 'grid-template-columns: 2fr 0.7fr 1.4fr 0.7fr 0.9fr 0.9fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">PersistentVolumeClaims</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Status</span>
+				<span class="type-colhead">Volume</span>
+				<span class="type-colhead">Capacity</span>
+				<span class="type-colhead">Access modes</span>
+				<span class="type-colhead">StorageClass</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.pvcs.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No persistent volume claims found.</p>
+				{:else}
+					{#each resources.pvcs as item (item.namespace + '/' + item.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+						<span class="type-data truncate text-text-data-bright">{item.name}</span>
+						<span class="type-data-sm" style="color: {item.status === 'Bound' ? 'var(--color-status-ok)' : item.status === 'Lost' ? 'var(--color-status-err)' : 'var(--color-status-warn)'};">{item.status ?? '—'}</span>
+						<span class="type-data-sm truncate text-text-secondary">{item.volume ?? '—'}</span>
+						<span class="type-data-sm text-text-secondary">{item.capacity ?? '—'}</span>
+						<span class="type-data-sm truncate text-text-secondary">{item.access_modes.join(', ') || '—'}</span>
+						<span class="type-data-sm truncate text-text-secondary">{item.storage_class ?? '—'}</span>
+						<span class="type-data-sm text-text-secondary">{formatAge(item.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/StatefulSetsView.svelte
+++ b/apps/desktop/src/lib/components/views/StatefulSetsView.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { formatAge } from '$lib/age';
+	import { app } from '$lib/stores/app.svelte';
+	import { resources } from '$lib/stores/resources.svelte';
+
+	$effect(() => {
+		void [app.namespace, app.activeCluster];
+		void resources.loadKind('statefulsets');
+	});
+
+	const grid = 'grid-template-columns: 2.6fr 0.7fr 0.9fr 0.55fr;';
+</script>
+
+<div class="flex flex-col gap-3 p-4">
+	<h1 class="type-title">StatefulSets</h1>
+
+	{#if resources.extraError}
+		<p class="py-8 text-center text-xs text-status-err">{resources.extraError}</p>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-border-default">
+			<div class="grid gap-x-3 border-b border-border-default bg-surface-surface px-3 py-2" style={grid}>
+				<span class="type-colhead">Name</span>
+				<span class="type-colhead">Ready</span>
+				<span class="type-colhead">Status</span>
+				<span class="type-colhead">Age</span>
+			</div>
+			<div class="bg-surface-panel">
+				{#if resources.statefulsets.length === 0}
+					<p class="py-8 text-center text-xs text-text-disabled">No stateful sets found.</p>
+				{:else}
+					{#each resources.statefulsets as item (item.namespace + '/' + item.name)}
+						<div
+							class="grid items-center gap-x-3 border-b border-border-faint px-3 last:border-b-0 hover:bg-surface-row-hover"
+							style="{grid} padding-top: var(--row-pad-default); padding-bottom: var(--row-pad-default);"
+						>
+						<span class="type-data truncate text-text-data-bright">{item.name}</span>
+						<span class="type-data-sm text-text-secondary">{item.ready_replicas}/{item.replicas}</span>
+						<span class="type-data-sm" style="color: {item.replicas > 0 && item.ready_replicas >= item.replicas ? 'var(--color-status-ok)' : 'var(--color-status-warn)'};">{item.replicas > 0 && item.ready_replicas >= item.replicas ? 'Available' : 'Progressing'}</span>
+						<span class="type-data-sm text-text-secondary">{formatAge(item.creation_timestamp)}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/desktop/src/lib/components/views/index.ts
+++ b/apps/desktop/src/lib/components/views/index.ts
@@ -4,15 +4,20 @@ import type { Component } from "svelte";
 import type { View } from "$lib/stores/app.svelte";
 import AllClustersView from "./AllClustersView.svelte";
 import ConfigMapsView from "./ConfigMapsView.svelte";
+import CronJobsView from "./CronJobsView.svelte";
 import DeploymentsView from "./DeploymentsView.svelte";
 import EventsView from "./EventsView.svelte";
 import HelmView from "./HelmView.svelte";
 import IngressesView from "./IngressesView.svelte";
+import JobsView from "./JobsView.svelte";
 import LogsView from "./LogsView.svelte";
+import NodesView from "./NodesView.svelte";
 import OverviewView from "./OverviewView.svelte";
 import PodsView from "./PodsView.svelte";
+import PvcsView from "./PvcsView.svelte";
 import SecretsView from "./SecretsView.svelte";
 import ServicesView from "./ServicesView.svelte";
+import StatefulSetsView from "./StatefulSetsView.svelte";
 
 export interface ViewEntry {
   component: Component<Record<string, unknown>>;
@@ -32,11 +37,16 @@ export const viewRegistry: Record<View, ViewEntry> = {
   overview: asEntry(OverviewView),
   pods: asEntry(PodsView),
   deployments: asEntry(DeploymentsView),
+  statefulsets: asEntry(StatefulSetsView),
+  jobs: asEntry(JobsView),
+  cronjobs: asEntry(CronJobsView),
   helm: asEntry(HelmView),
   services: asEntry(ServicesView),
   ingresses: asEntry(IngressesView),
   configmaps: asEntry(ConfigMapsView),
   secrets: asEntry(SecretsView),
+  pvcs: asEntry(PvcsView),
   events: asEntry(EventsView),
   logs: asEntry(LogsView),
+  nodes: asEntry(NodesView),
 };

--- a/apps/desktop/src/lib/components/views/kind-views.test.ts
+++ b/apps/desktop/src/lib/components/views/kind-views.test.ts
@@ -19,6 +19,11 @@ vi.mock("$lib/tauri", () => ({
   listConfigMaps: vi.fn(async () => []),
   listSecrets: vi.fn(async () => []),
   listHelmReleases: vi.fn(async () => []),
+  listJobs: vi.fn(async () => []),
+  listCronJobs: vi.fn(async () => []),
+  listStatefulSets: vi.fn(async () => []),
+  listPvcs: vi.fn(async () => []),
+  listNodes: vi.fn(async () => []),
   watchResources: vi.fn(),
   unwatchResources: vi.fn(),
 }));
@@ -175,5 +180,59 @@ describe("HelmView", () => {
     const { default: HelmView } = await import("./HelmView.svelte");
     render(HelmView);
     expect(screen.getByText("No Helm releases found.")).toBeInTheDocument();
+  });
+});
+
+describe("workload views", () => {
+  it("JobsView renders completions and failed highlighting", async () => {
+    const { default: JobsView } = await import("./JobsView.svelte");
+    resources.jobs = [
+      { name: "migrate", namespace: "default", completions: 2, succeeded: 1, active: 1, failed: 1, creation_timestamp: null },
+    ];
+    render(JobsView);
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+    expect(screen.getByText("migrate")).toBeInTheDocument();
+  });
+
+  it("CronJobsView renders schedule and suspend", async () => {
+    const { default: CronJobsView } = await import("./CronJobsView.svelte");
+    resources.cronjobs = [
+      { name: "backup", namespace: "ops", schedule: "0 3 * * *", suspend: true, active: 0, last_schedule: null, creation_timestamp: null },
+    ];
+    render(CronJobsView);
+    expect(screen.getByText("0 3 * * *")).toBeInTheDocument();
+    expect(screen.getByText("True")).toBeInTheDocument();
+  });
+
+  it("StatefulSetsView derives status", async () => {
+    const { default: StatefulSetsView } = await import("./StatefulSetsView.svelte");
+    resources.statefulsets = [
+      { name: "db", namespace: "default", replicas: 3, ready_replicas: 2, creation_timestamp: null },
+    ];
+    render(StatefulSetsView);
+    expect(screen.getByText("2/3")).toBeInTheDocument();
+    expect(screen.getByText("Progressing")).toBeInTheDocument();
+  });
+
+  it("NodesView renders status, roles and version", async () => {
+    const { default: NodesView } = await import("./NodesView.svelte");
+    resources.nodeInventory = [
+      { name: "node-1", status: "Ready", roles: ["control-plane"], version: "v1.30.2", creation_timestamp: null },
+    ];
+    render(NodesView);
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("control-plane")).toBeInTheDocument();
+    expect(screen.getByText("v1.30.2")).toBeInTheDocument();
+  });
+
+  it("PvcsView renders bound claim details", async () => {
+    const { default: PvcsView } = await import("./PvcsView.svelte");
+    resources.pvcs = [
+      { name: "data", namespace: "default", status: "Bound", volume: "pv-1", capacity: "10Gi", access_modes: ["ReadWriteOnce"], storage_class: "fast", creation_timestamp: null },
+    ];
+    render(PvcsView);
+    expect(screen.getByText("Bound")).toBeInTheDocument();
+    expect(screen.getByText("10Gi")).toBeInTheDocument();
+    expect(screen.getByText("fast")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/lib/stores/app.svelte.ts
+++ b/apps/desktop/src/lib/stores/app.svelte.ts
@@ -9,13 +9,18 @@ export const VIEWS = [
   "overview",
   "pods",
   "deployments",
+  "statefulsets",
+  "jobs",
+  "cronjobs",
   "helm",
   "services",
   "ingresses",
   "configmaps",
   "secrets",
+  "pvcs",
   "events",
   "logs",
+  "nodes",
 ] as const;
 
 export type View = (typeof VIEWS)[number];

--- a/apps/desktop/src/lib/stores/resources.svelte.ts
+++ b/apps/desktop/src/lib/stores/resources.svelte.ts
@@ -8,27 +8,37 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   clusterCapacity,
   listConfigMaps,
+  listCronJobs,
   listDeployments,
   listEvents,
   listHelmReleases,
   listIngresses,
+  listJobs,
   listNamespaces,
+  listNodes,
   listPods,
   listPodMetrics,
+  listPvcs,
   listSecrets,
   listServices,
+  listStatefulSets,
   unwatchResources,
   watchResources,
   type ConfigMapInfo,
+  type CronJobInfo,
   type DeploymentInfo,
   type EventInfo,
   type HelmReleaseInfo,
   type IngressInfo,
+  type JobInfo,
   type NamespaceInfo,
   type NodeCapacityInfo,
+  type NodeInfo,
   type PodInfo,
   type PodMetricsInfo,
+  type PvcInfo,
   type SecretInfo,
+  type StatefulSetInfo,
   type ServiceInfo,
 } from "$lib/tauri";
 import { errorMessage } from "$lib/errors";
@@ -38,7 +48,17 @@ import { settings } from "./settings.svelte";
 const RELOAD_DEBOUNCE_MS = 300;
 
 /** Resource kinds loaded on demand when their view is opened. */
-export type ExtraKind = "services" | "ingresses" | "configmaps" | "secrets" | "helm";
+export type ExtraKind =
+  | "services"
+  | "ingresses"
+  | "configmaps"
+  | "secrets"
+  | "helm"
+  | "statefulsets"
+  | "jobs"
+  | "cronjobs"
+  | "pvcs"
+  | "nodes";
 
 const EXTRA_KINDS: readonly ExtraKind[] = [
   "services",
@@ -46,6 +66,11 @@ const EXTRA_KINDS: readonly ExtraKind[] = [
   "configmaps",
   "secrets",
   "helm",
+  "statefulsets",
+  "jobs",
+  "cronjobs",
+  "pvcs",
+  "nodes",
 ];
 
 export function isExtraKind(v: unknown): v is ExtraKind {
@@ -62,6 +87,11 @@ class ResourcesStore {
   configmaps = $state<ConfigMapInfo[]>([]);
   secrets = $state<SecretInfo[]>([]);
   helmReleases = $state<HelmReleaseInfo[]>([]);
+  statefulsets = $state<StatefulSetInfo[]>([]);
+  jobs = $state<JobInfo[]>([]);
+  cronjobs = $state<CronJobInfo[]>([]);
+  pvcs = $state<PvcInfo[]>([]);
+  nodeInventory = $state<NodeInfo[]>([]);
   /** ns/name → usage; null until metrics-server answers, {} when it 404s. */
   podMetrics = $state<Record<string, PodMetricsInfo>>({});
   nodes = $state<NodeCapacityInfo[]>([]);
@@ -239,6 +269,31 @@ class ResourcesStore {
           if (seq === this.#extraSeq) this.helmReleases = list;
           break;
         }
+        case "statefulsets": {
+          const list = await listStatefulSets(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.statefulsets = list;
+          break;
+        }
+        case "jobs": {
+          const list = await listJobs(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.jobs = list;
+          break;
+        }
+        case "cronjobs": {
+          const list = await listCronJobs(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.cronjobs = list;
+          break;
+        }
+        case "pvcs": {
+          const list = await listPvcs(kc, ns, cluster);
+          if (seq === this.#extraSeq) this.pvcs = list;
+          break;
+        }
+        case "nodes": {
+          const list = await listNodes(kc, cluster);
+          if (seq === this.#extraSeq) this.nodeInventory = list;
+          break;
+        }
       }
     } catch (e) {
       if (seq === this.#extraSeq) this.extraError = errorMessage(e);
@@ -260,6 +315,11 @@ class ResourcesStore {
     this.configmaps = [];
     this.secrets = [];
     this.helmReleases = [];
+    this.statefulsets = [];
+    this.jobs = [];
+    this.cronjobs = [];
+    this.pvcs = [];
+    this.nodeInventory = [];
     this.podMetrics = {};
     this.nodes = [];
     this.metricsAvailable = false;

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -233,6 +233,53 @@ export type NodeCapacityInfo = {
   memory_allocatable_bytes: number;
 };
 
+export type JobInfo = {
+  name: string;
+  namespace: string;
+  completions: number;
+  succeeded: number;
+  active: number;
+  failed: number;
+  creation_timestamp: string | null;
+};
+
+export type CronJobInfo = {
+  name: string;
+  namespace: string;
+  schedule: string;
+  suspend: boolean;
+  active: number;
+  last_schedule: string | null;
+  creation_timestamp: string | null;
+};
+
+export type StatefulSetInfo = {
+  name: string;
+  namespace: string;
+  replicas: number;
+  ready_replicas: number;
+  creation_timestamp: string | null;
+};
+
+export type NodeInfo = {
+  name: string;
+  status: string;
+  roles: string[];
+  version: string | null;
+  creation_timestamp: string | null;
+};
+
+export type PvcInfo = {
+  name: string;
+  namespace: string;
+  status: string | null;
+  volume: string | null;
+  capacity: string | null;
+  access_modes: string[];
+  storage_class: string | null;
+  creation_timestamp: string | null;
+};
+
 export type ClusterHealthInfo = {
   context: string;
   reachable: boolean;
@@ -285,6 +332,64 @@ export function clusterCapacity(
   context?: string,
 ): Promise<NodeCapacityInfo[]> {
   return invoke<NodeCapacityInfo[]>("cluster_capacity", {
+    kubeconfigPath,
+    context: context ?? null,
+  });
+}
+
+export function listJobs(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<JobInfo[]> {
+  return invoke<JobInfo[]>("list_jobs", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listCronJobs(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<CronJobInfo[]> {
+  return invoke<CronJobInfo[]>("list_cronjobs", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listStatefulSets(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<StatefulSetInfo[]> {
+  return invoke<StatefulSetInfo[]>("list_statefulsets", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listPvcs(
+  kubeconfigPath: string,
+  namespace?: string,
+  context?: string,
+): Promise<PvcInfo[]> {
+  return invoke<PvcInfo[]>("list_pvcs", {
+    kubeconfigPath,
+    namespace: namespace ?? null,
+    context: context ?? null,
+  });
+}
+
+export function listNodes(
+  kubeconfigPath: string,
+  context?: string,
+): Promise<NodeInfo[]> {
+  return invoke<NodeInfo[]>("list_nodes", {
     kubeconfigPath,
     context: context ?? null,
   });

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -3,8 +3,11 @@
 //! [`KubeClient`] wraps a configured `kube::Client` and exposes high-level
 //! methods for listing the most common Kubernetes resources.
 
-use k8s_openapi::api::apps::v1::Deployment;
-use k8s_openapi::api::core::v1::{ConfigMap, Event, Namespace, Node, Pod, Secret, Service};
+use k8s_openapi::api::apps::v1::{Deployment, StatefulSet};
+use k8s_openapi::api::batch::v1::{CronJob, Job};
+use k8s_openapi::api::core::v1::{
+    ConfigMap, Event, Namespace, Node, PersistentVolumeClaim, Pod, Secret, Service,
+};
 use k8s_openapi::api::networking::v1::Ingress;
 use kube::{
     api::{DeleteParams, ListParams, Patch, PatchParams},
@@ -22,12 +25,13 @@ use crate::{
         PodMetricsInfo,
     },
     resources::{
-        ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
-        ServiceInfo,
+        ConfigMapInfo, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo, JobInfo, NamespaceInfo,
+        NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo, StatefulSetInfo,
     },
     watcher::{
-        configmap_to_info, deployment_to_info, ingress_to_info, namespace_to_info, pod_to_info,
-        secret_to_info, service_to_info,
+        configmap_to_info, cronjob_to_info, deployment_to_info, ingress_to_info, job_to_info,
+        namespace_to_info, node_to_info, pod_to_info, pvc_to_info, secret_to_info, service_to_info,
+        statefulset_to_info,
     },
 };
 
@@ -429,6 +433,114 @@ impl KubeClient {
             .map_err(|e| KubeconfigError::ClientError {
                 reason: e.to_string(),
             })
+    }
+
+    /// List jobs in `namespace`, or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_jobs(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<JobInfo>, KubeconfigError> {
+        let api: Api<Job> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.into_iter().filter_map(job_to_info).collect())
+    }
+
+    /// List cron jobs in `namespace`, or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_cronjobs(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<CronJobInfo>, KubeconfigError> {
+        let api: Api<CronJob> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.into_iter().filter_map(cronjob_to_info).collect())
+    }
+
+    /// List stateful sets in `namespace`, or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_statefulsets(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<StatefulSetInfo>, KubeconfigError> {
+        let api: Api<StatefulSet> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list
+            .items
+            .into_iter()
+            .filter_map(statefulset_to_info)
+            .collect())
+    }
+
+    /// List persistent volume claims in `namespace`, or across all namespaces when `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_pvcs(
+        &self,
+        namespace: Option<&str>,
+    ) -> Result<Vec<PvcInfo>, KubeconfigError> {
+        let api: Api<PersistentVolumeClaim> = match namespace {
+            Some(ns) => Api::namespaced(self.inner.clone(), ns),
+            None => Api::all(self.inner.clone()),
+        };
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.into_iter().filter_map(pvc_to_info).collect())
+    }
+
+    /// List nodes (read-only inventory).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn list_nodes(&self) -> Result<Vec<NodeInfo>, KubeconfigError> {
+        let api: Api<Node> = Api::all(self.inner.clone());
+        let list =
+            api.list(&Default::default())
+                .await
+                .map_err(|e| KubeconfigError::ClientError {
+                    reason: e.to_string(),
+                })?;
+        Ok(list.items.into_iter().filter_map(node_to_info).collect())
     }
 
     /// List events in `namespace`, or across all namespaces when `None`,

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -47,8 +47,8 @@ pub use kubeconfig::KubeConfig;
 pub use logs::{LogLevel, LogLine};
 pub use metrics::{NodeCapacityInfo, PodMetricsInfo};
 pub use resources::{
-    ConfigMapInfo, DeploymentInfo, EventInfo, IngressInfo, NamespaceInfo, PodInfo, SecretInfo,
-    ServiceInfo,
+    ConfigMapInfo, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo, JobInfo, NamespaceInfo,
+    NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo, StatefulSetInfo,
 };
 pub use types::{
     ClusterDetails, ContextDetails, ContextInfo, KubeConfigFile, NamedCluster, NamedContext,

--- a/crates/cubelite-core/src/resources.rs
+++ b/crates/cubelite-core/src/resources.rs
@@ -192,3 +192,92 @@ pub struct SecretInfo {
     /// RFC 3339 creation timestamp, when reported by the API server.
     pub creation_timestamp: Option<String>,
 }
+
+/// Lightweight representation of a Kubernetes Job.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct JobInfo {
+    /// The job name.
+    pub name: String,
+    /// The namespace the job belongs to.
+    pub namespace: String,
+    /// Desired completions (spec.completions, defaults to 1).
+    pub completions: i32,
+    /// Pods that completed successfully.
+    pub succeeded: i32,
+    /// Pods currently running.
+    pub active: i32,
+    /// Pods that failed.
+    pub failed: i32,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes CronJob.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CronJobInfo {
+    /// The cron job name.
+    pub name: String,
+    /// The namespace the cron job belongs to.
+    pub namespace: String,
+    /// Cron schedule expression.
+    pub schedule: String,
+    /// `true` when the cron job is suspended.
+    pub suspend: bool,
+    /// Number of currently active jobs.
+    pub active: i32,
+    /// RFC 3339 timestamp of the last scheduled run.
+    pub last_schedule: Option<String>,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes StatefulSet.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StatefulSetInfo {
+    /// The stateful set name.
+    pub name: String,
+    /// The namespace the stateful set belongs to.
+    pub namespace: String,
+    /// Desired number of replicas.
+    pub replicas: i32,
+    /// Replicas currently reporting ready.
+    pub ready_replicas: i32,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes Node (read-only inventory).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NodeInfo {
+    /// The node name.
+    pub name: String,
+    /// `"Ready"` / `"NotReady"` from the Ready condition.
+    pub status: String,
+    /// Roles from `node-role.kubernetes.io/*` labels.
+    pub roles: Vec<String>,
+    /// Kubelet version.
+    pub version: Option<String>,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}
+
+/// Lightweight representation of a Kubernetes PersistentVolumeClaim.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PvcInfo {
+    /// The claim name.
+    pub name: String,
+    /// The namespace the claim belongs to.
+    pub namespace: String,
+    /// Claim phase (`"Bound"`, `"Pending"`, `"Lost"`).
+    pub status: Option<String>,
+    /// Bound volume name, when bound.
+    pub volume: Option<String>,
+    /// Requested/actual storage capacity (e.g. `"10Gi"`).
+    pub capacity: Option<String>,
+    /// Access modes (e.g. `"RWO"`, `"ROX"`, `"RWX"`).
+    pub access_modes: Vec<String>,
+    /// Storage class name, when set.
+    pub storage_class: Option<String>,
+    /// RFC 3339 creation timestamp, when reported by the API server.
+    pub creation_timestamp: Option<String>,
+}

--- a/crates/cubelite-core/src/watcher.rs
+++ b/crates/cubelite-core/src/watcher.rs
@@ -22,16 +22,18 @@ use std::pin::Pin;
 
 use futures::{Stream, StreamExt};
 use k8s_openapi::api::{
-    apps::v1::Deployment,
-    core::v1::{ConfigMap, Namespace, Pod, Secret, Service},
+    apps::v1::{Deployment, StatefulSet},
+    batch::v1::{CronJob, Job},
+    core::v1::{ConfigMap, Namespace, Node, PersistentVolumeClaim, Pod, Secret, Service},
     networking::v1::Ingress,
 };
 use kube::{runtime::watcher, Api, Client};
 use serde::{Deserialize, Serialize};
 
 use crate::resources::{
-    ConfigMapInfo, ContainerInfo, DeploymentConditionInfo, DeploymentInfo, IngressInfo,
-    NamespaceInfo, PodInfo, SecretInfo, ServiceInfo,
+    ConfigMapInfo, ContainerInfo, CronJobInfo, DeploymentConditionInfo, DeploymentInfo,
+    IngressInfo, JobInfo, NamespaceInfo, NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo,
+    StatefulSetInfo,
 };
 
 /// Selects which Kubernetes resource type to watch.
@@ -462,6 +464,154 @@ pub(crate) fn deployment_to_info(d: Deployment) -> Option<DeploymentInfo> {
     })
 }
 
+/// Convert a raw [`Job`] object into a [`JobInfo`], returning `None` if
+/// there is no name.
+pub(crate) fn job_to_info(j: Job) -> Option<JobInfo> {
+    let name = j.metadata.name.clone()?;
+    let namespace = j.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&j.metadata);
+    let completions = j.spec.as_ref().and_then(|s| s.completions).unwrap_or(1);
+    let (succeeded, active, failed) = j
+        .status
+        .map(|st| {
+            (
+                st.succeeded.unwrap_or(0),
+                st.active.unwrap_or(0),
+                st.failed.unwrap_or(0),
+            )
+        })
+        .unwrap_or((0, 0, 0));
+    Some(JobInfo {
+        name,
+        namespace,
+        completions,
+        succeeded,
+        active,
+        failed,
+        creation_timestamp: creation,
+    })
+}
+
+/// Convert a raw [`CronJob`] object into a [`CronJobInfo`], returning `None`
+/// if there is no name.
+pub(crate) fn cronjob_to_info(cj: CronJob) -> Option<CronJobInfo> {
+    let name = cj.metadata.name.clone()?;
+    let namespace = cj.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&cj.metadata);
+    let (schedule, suspend) = cj
+        .spec
+        .map(|s| (s.schedule, s.suspend.unwrap_or(false)))
+        .unwrap_or_default();
+    let (active, last_schedule) = cj
+        .status
+        .map(|st| {
+            (
+                st.active.map(|a| a.len() as i32).unwrap_or(0),
+                st.last_schedule_time.map(|t| t.0.to_rfc3339()),
+            )
+        })
+        .unwrap_or((0, None));
+    Some(CronJobInfo {
+        name,
+        namespace,
+        schedule,
+        suspend,
+        active,
+        last_schedule,
+        creation_timestamp: creation,
+    })
+}
+
+/// Convert a raw [`StatefulSet`] object into a [`StatefulSetInfo`],
+/// returning `None` if there is no name.
+pub(crate) fn statefulset_to_info(ss: StatefulSet) -> Option<StatefulSetInfo> {
+    let name = ss.metadata.name.clone()?;
+    let namespace = ss.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&ss.metadata);
+    let replicas = ss.spec.as_ref().and_then(|s| s.replicas).unwrap_or(0);
+    let ready_replicas = ss
+        .status
+        .as_ref()
+        .and_then(|s| s.ready_replicas)
+        .unwrap_or(0);
+    Some(StatefulSetInfo {
+        name,
+        namespace,
+        replicas,
+        ready_replicas,
+        creation_timestamp: creation,
+    })
+}
+
+/// Convert a raw [`Node`] object into a [`NodeInfo`], returning `None` if
+/// there is no name.
+pub(crate) fn node_to_info(n: Node) -> Option<NodeInfo> {
+    let name = n.metadata.name.clone()?;
+    let creation = creation_timestamp(&n.metadata);
+    let roles = n
+        .metadata
+        .labels
+        .as_ref()
+        .map(|labels| {
+            labels
+                .keys()
+                .filter_map(|k| k.strip_prefix("node-role.kubernetes.io/"))
+                .filter(|r| !r.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let ready = n
+        .status
+        .as_ref()
+        .and_then(|s| s.conditions.as_ref())
+        .and_then(|conds| conds.iter().find(|c| c.type_ == "Ready"))
+        .map(|c| c.status == "True")
+        .unwrap_or(false);
+    let version = n
+        .status
+        .and_then(|s| s.node_info)
+        .map(|ni| ni.kubelet_version);
+    Some(NodeInfo {
+        name,
+        status: if ready { "Ready" } else { "NotReady" }.to_string(),
+        roles,
+        version,
+        creation_timestamp: creation,
+    })
+}
+
+/// Convert a raw [`PersistentVolumeClaim`] into a [`PvcInfo`], returning
+/// `None` if there is no name.
+pub(crate) fn pvc_to_info(pvc: PersistentVolumeClaim) -> Option<PvcInfo> {
+    let name = pvc.metadata.name.clone()?;
+    let namespace = pvc.metadata.namespace.clone().unwrap_or_default();
+    let creation = creation_timestamp(&pvc.metadata);
+    let storage_class = pvc.spec.as_ref().and_then(|s| s.storage_class_name.clone());
+    let volume = pvc.spec.as_ref().and_then(|s| s.volume_name.clone());
+    let (status, capacity, access_modes) = pvc
+        .status
+        .map(|st| {
+            let capacity = st
+                .capacity
+                .as_ref()
+                .and_then(|c| c.get("storage"))
+                .map(|q| q.0.clone());
+            (st.phase, capacity, st.access_modes.unwrap_or_default())
+        })
+        .unwrap_or((None, None, Vec::new()));
+    Some(PvcInfo {
+        name,
+        namespace,
+        status,
+        volume,
+        capacity,
+        access_modes,
+        storage_class,
+        creation_timestamp: creation,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -746,6 +896,155 @@ mod tests {
             Some("hunter2")
         );
         assert_eq!(info.data.get("cert").map(String::as_str), Some("(binary)"));
+    }
+
+    #[test]
+    fn job_to_info_conversion() {
+        use k8s_openapi::api::batch::v1::{Job, JobSpec, JobStatus};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let j = Job {
+            metadata: ObjectMeta {
+                name: Some("migrate".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: Some(JobSpec {
+                completions: Some(2),
+                ..Default::default()
+            }),
+            status: Some(JobStatus {
+                succeeded: Some(1),
+                active: Some(1),
+                ..Default::default()
+            }),
+        };
+        let info = job_to_info(j).unwrap();
+        assert_eq!(info.completions, 2);
+        assert_eq!(info.succeeded, 1);
+        assert_eq!(info.active, 1);
+        assert_eq!(info.failed, 0);
+    }
+
+    #[test]
+    fn cronjob_to_info_conversion() {
+        use k8s_openapi::api::batch::v1::{CronJob, CronJobSpec, CronJobStatus};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let cj = CronJob {
+            metadata: ObjectMeta {
+                name: Some("backup".to_string()),
+                namespace: Some("ops".to_string()),
+                ..Default::default()
+            },
+            spec: Some(CronJobSpec {
+                schedule: "0 3 * * *".to_string(),
+                suspend: Some(true),
+                ..Default::default()
+            }),
+            status: Some(CronJobStatus::default()),
+        };
+        let info = cronjob_to_info(cj).unwrap();
+        assert_eq!(info.schedule, "0 3 * * *");
+        assert!(info.suspend);
+        assert_eq!(info.active, 0);
+    }
+
+    #[test]
+    fn statefulset_to_info_conversion() {
+        use k8s_openapi::api::apps::v1::{StatefulSet, StatefulSetSpec, StatefulSetStatus};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let ss = StatefulSet {
+            metadata: ObjectMeta {
+                name: Some("db".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: Some(StatefulSetSpec {
+                replicas: Some(3),
+                ..Default::default()
+            }),
+            status: Some(StatefulSetStatus {
+                ready_replicas: Some(2),
+                ..Default::default()
+            }),
+        };
+        let info = statefulset_to_info(ss).unwrap();
+        assert_eq!(info.replicas, 3);
+        assert_eq!(info.ready_replicas, 2);
+    }
+
+    #[test]
+    fn node_to_info_conversion() {
+        use k8s_openapi::api::core::v1::{Node, NodeCondition, NodeStatus, NodeSystemInfo};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+        use std::collections::BTreeMap;
+
+        let n = Node {
+            metadata: ObjectMeta {
+                name: Some("node-1".to_string()),
+                labels: Some(BTreeMap::from([(
+                    "node-role.kubernetes.io/control-plane".to_string(),
+                    "".to_string(),
+                )])),
+                ..Default::default()
+            },
+            status: Some(NodeStatus {
+                conditions: Some(vec![NodeCondition {
+                    type_: "Ready".to_string(),
+                    status: "True".to_string(),
+                    ..Default::default()
+                }]),
+                node_info: Some(NodeSystemInfo {
+                    kubelet_version: "v1.30.2".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let info = node_to_info(n).unwrap();
+        assert_eq!(info.status, "Ready");
+        assert_eq!(info.roles, vec!["control-plane"]);
+        assert_eq!(info.version.as_deref(), Some("v1.30.2"));
+    }
+
+    #[test]
+    fn pvc_to_info_conversion() {
+        use k8s_openapi::api::core::v1::{
+            PersistentVolumeClaim, PersistentVolumeClaimSpec, PersistentVolumeClaimStatus,
+        };
+        use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+        use std::collections::BTreeMap;
+
+        let pvc = PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some("data".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            spec: Some(PersistentVolumeClaimSpec {
+                storage_class_name: Some("fast".to_string()),
+                volume_name: Some("pv-1".to_string()),
+                ..Default::default()
+            }),
+            status: Some(PersistentVolumeClaimStatus {
+                phase: Some("Bound".to_string()),
+                access_modes: Some(vec!["ReadWriteOnce".to_string()]),
+                capacity: Some(BTreeMap::from([(
+                    "storage".to_string(),
+                    Quantity("10Gi".to_string()),
+                )])),
+                ..Default::default()
+            }),
+        };
+        let info = pvc_to_info(pvc).unwrap();
+        assert_eq!(info.status.as_deref(), Some("Bound"));
+        assert_eq!(info.capacity.as_deref(), Some("10Gi"));
+        assert_eq!(info.access_modes, vec!["ReadWriteOnce"]);
+        assert_eq!(info.storage_class.as_deref(), Some("fast"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #246 — desktop counterpart of the macOS umbrella #77.

## Backend
- `JobInfo` / `CronJobInfo` / `StatefulSetInfo` / `NodeInfo` / `PvcInfo` with converters and unit tests (Ready condition + `node-role.kubernetes.io/*` labels for nodes; storage capacity/access-modes for claims)
- `KubeClient::list_jobs / list_cronjobs / list_statefulsets / list_pvcs` (namespace optional) and `list_nodes` (cluster-scoped)
- Five Tauri commands + typed wrappers

## Frontend
- View enum + on-demand kinds in the resources store (same stale-guard/lazy-load pattern as #237)
- Sidebar: **Workloads** gains StatefulSets / Jobs / CronJobs, **Cluster** gains Nodes, **Config** gains PVCs
- kubectl-convention tables per the established design patterns, with status coloring: failed jobs err, suspended cronjobs warn, NotReady nodes err, Bound/Pending/Lost claims ok/warn/err

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace` (5 new converter tests)
- `pnpm --filter desktop lint / typecheck / test / build` — 151 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)