### PR TITLE
feat(core+desktop): read-only YAML viewer for resources

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -427,6 +427,30 @@ pub async fn list_nodes(
     client.list_nodes().await.map_err(|e| e.to_string())
 }
 
+/// Render one resource as cleaned YAML (managedFields stripped).
+///
+/// `resource_type` accepts the same lowercase names as `watch_resources`.
+#[tauri::command]
+pub async fn get_resource_yaml(
+    kubeconfig_path: String,
+    resource_type: String,
+    namespace: String,
+    name: String,
+    context: Option<String>,
+) -> Result<String, String> {
+    let rt: ResourceType = serde_json::from_value(serde_json::Value::String(resource_type))
+        .map_err(|e| format!("invalid resource_type: {e}"))?;
+
+    let client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .get_resource_yaml(rt, &namespace, &name)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Delete a pod (the owning controller will recreate it).
 #[tauri::command]
 pub async fn delete_pod(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,11 +1,12 @@
 pub mod commands;
 
 use commands::kubernetes::{
-    cluster_capacity, delete_pod, get_current_context, list_configmaps, list_contexts,
-    list_cronjobs, list_deployments, list_events, list_helm_releases, list_ingresses, list_jobs,
-    list_namespaces, list_nodes, list_pod_metrics, list_pods, list_pvcs, list_secrets,
-    list_services, list_statefulsets, probe_cluster, restart_deployment, scale_deployment,
-    set_context, stop_logs, stream_logs, unwatch_resources, watch_resources, LogState, WatchState,
+    cluster_capacity, delete_pod, get_current_context, get_resource_yaml, list_configmaps,
+    list_contexts, list_cronjobs, list_deployments, list_events, list_helm_releases,
+    list_ingresses, list_jobs, list_namespaces, list_nodes, list_pod_metrics, list_pods, list_pvcs,
+    list_secrets, list_services, list_statefulsets, probe_cluster, restart_deployment,
+    scale_deployment, set_context, stop_logs, stream_logs, unwatch_resources, watch_resources,
+    LogState, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -31,6 +32,7 @@ pub fn run() {
             list_statefulsets,
             list_nodes,
             list_pvcs,
+            get_resource_yaml,
             watch_resources,
             unwatch_resources,
             stream_logs,

--- a/apps/desktop/src/lib/components/YamlModal.svelte
+++ b/apps/desktop/src/lib/components/YamlModal.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import Check from '@lucide/svelte/icons/check';
+	import Copy from '@lucide/svelte/icons/copy';
+	import Modal from '$lib/components/ui/Modal.svelte';
+	import { errorMessage } from '$lib/errors';
+	import { app } from '$lib/stores/app.svelte';
+	import { getResourceYaml, type YamlResourceType } from '$lib/tauri';
+
+	let {
+		resourceType,
+		namespace,
+		name,
+		onClose
+	}: {
+		resourceType: YamlResourceType;
+		namespace: string;
+		name: string;
+		onClose: () => void;
+	} = $props();
+
+	let yaml = $state<string | null>(null);
+	let error = $state<string | null>(null);
+	let copied = $state(false);
+
+	$effect(() => {
+		yaml = null;
+		error = null;
+		const kc = app.kubeconfigPath;
+		const cluster = app.activeCluster;
+		if (!kc || !cluster) return;
+		getResourceYaml(kc, resourceType, namespace, name, cluster)
+			.then((text) => (yaml = text))
+			.catch((e: unknown) => (error = errorMessage(e)));
+	});
+
+	async function copy() {
+		if (!yaml) return;
+		try {
+			await navigator.clipboard.writeText(yaml);
+			copied = true;
+			setTimeout(() => (copied = false), 1500);
+		} catch {
+			// Clipboard may be unavailable; the selection still works.
+		}
+	}
+</script>
+
+<Modal title="{name}.yaml" width={720} {onClose}>
+	<div class="flex flex-col gap-2">
+		<div class="flex justify-end">
+			<button
+				type="button"
+				disabled={!yaml}
+				class="focus-ring type-caption flex h-7 items-center gap-1.5 rounded-md border border-border-default bg-surface-raised px-2.5 text-text-secondary hover:brightness-110 disabled:opacity-45"
+				onclick={() => void copy()}
+			>
+				{#if copied}
+					<Check class="h-3 w-3 text-status-ok" />
+					Copied
+				{:else}
+					<Copy class="h-3 w-3" />
+					Copy
+				{/if}
+			</button>
+		</div>
+
+		{#if error}
+			<p class="py-8 text-center text-xs text-status-err">{error}</p>
+		{:else if yaml === null}
+			<p class="py-8 text-center text-xs text-text-disabled">Loading…</p>
+		{:else}
+			<pre
+				class="type-log max-h-[60vh] overflow-auto rounded-lg border border-border-faint bg-surface-sunken p-3 text-text-log">{yaml}</pre>
+		{/if}
+	</div>
+</Modal>

--- a/apps/desktop/src/lib/components/deployments/DeploymentDrawer.svelte
+++ b/apps/desktop/src/lib/components/deployments/DeploymentDrawer.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+	import FileCode from '@lucide/svelte/icons/file-code';
 	import FileText from '@lucide/svelte/icons/file-text';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import RotateCw from '@lucide/svelte/icons/rotate-cw';
 	import { formatAge } from '$lib/age';
 	import { matchesSelector } from '$lib/k8s-match';
 	import Drawer from '$lib/components/ui/Drawer.svelte';
+	import YamlModal from '$lib/components/YamlModal.svelte';
 	import StatusPill from '$lib/components/ui/StatusPill.svelte';
 	import { deploymentStatus, podStatusLabel, podTone, toneColor } from '$lib/status';
 	import { app } from '$lib/stores/app.svelte';
@@ -17,6 +19,7 @@
 
 	const status = $derived(deploymentStatus(deployment));
 	const restarting = $derived(mutations.isRestarting(deployment.namespace, deployment.name));
+	let yamlOpen = $state(false);
 	const selectorLabel = $derived(
 		Object.entries(deployment.selector)
 			.map(([k, v]) => `${k}=${v}`)
@@ -132,6 +135,15 @@
 		</button>
 		<button
 			type="button"
+			aria-label="YAML"
+			title="View YAML"
+			class="focus-ring type-body flex h-7 items-center justify-center gap-1.5 rounded-md border border-border-default bg-surface-raised px-2.5 text-text-secondary hover:brightness-110"
+			onclick={() => (yamlOpen = true)}
+		>
+			<FileCode class="h-3 w-3" />
+		</button>
+		<button
+			type="button"
 			disabled={restarting}
 			class="focus-ring type-body flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border border-border-default bg-surface-raised text-text-secondary hover:brightness-110 disabled:opacity-45"
 			onclick={() => void mutations.restartDeployment(deployment.namespace, deployment.name)}
@@ -145,3 +157,12 @@
 		</button>
 	{/snippet}
 </Drawer>
+
+{#if yamlOpen}
+	<YamlModal
+		resourceType="deployment"
+		namespace={deployment.namespace}
+		name={deployment.name}
+		onClose={() => (yamlOpen = false)}
+	/>
+{/if}

--- a/apps/desktop/src/lib/components/pods/PodDrawer.svelte
+++ b/apps/desktop/src/lib/components/pods/PodDrawer.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+	import FileCode from '@lucide/svelte/icons/file-code';
 	import FileText from '@lucide/svelte/icons/file-text';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import RotateCw from '@lucide/svelte/icons/rotate-cw';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import { formatAge } from '$lib/age';
 	import Drawer from '$lib/components/ui/Drawer.svelte';
+	import YamlModal from '$lib/components/YamlModal.svelte';
 	import MeterBar from '$lib/components/ui/MeterBar.svelte';
 	import StatusPill from '$lib/components/ui/StatusPill.svelte';
 	import { podStatusLabel, podTone } from '$lib/status';
@@ -22,6 +24,7 @@
 	}: { pod: PodInfo; onClose: () => void; onDelete?: (pod: PodInfo) => void } = $props();
 
 	const restarting = $derived(mutations.isDeleting(pod.namespace, pod.name));
+	let yamlOpen = $state(false);
 
 	async function restart() {
 		// A pod "restart" is a delete; the owning controller recreates it.
@@ -126,6 +129,15 @@
 		</button>
 		<button
 			type="button"
+			aria-label="YAML"
+			title="View YAML"
+			class="focus-ring type-body flex h-7 items-center justify-center gap-1.5 rounded-md border border-border-default bg-surface-raised px-2.5 text-text-secondary hover:brightness-110"
+			onclick={() => (yamlOpen = true)}
+		>
+			<FileCode class="h-3 w-3" />
+		</button>
+		<button
+			type="button"
 			disabled={restarting}
 			class="focus-ring type-body flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border border-border-default bg-surface-raised text-text-secondary hover:brightness-110 disabled:opacity-45"
 			onclick={() => void restart()}
@@ -148,3 +160,12 @@
 		</button>
 	{/snippet}
 </Drawer>
+
+{#if yamlOpen}
+	<YamlModal
+		resourceType="pod"
+		namespace={pod.namespace}
+		name={pod.name}
+		onClose={() => (yamlOpen = false)}
+	/>
+{/if}

--- a/apps/desktop/src/lib/components/yaml-modal.test.ts
+++ b/apps/desktop/src/lib/components/yaml-modal.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/svelte";
+
+vi.mock("$lib/tauri", () => ({
+  getResourceYaml: vi.fn(),
+  listContexts: vi.fn(),
+  setContext: vi.fn(),
+  listPods: vi.fn(),
+  listNamespaces: vi.fn(),
+  listDeployments: vi.fn(),
+  listEvents: vi.fn(async () => []),
+  listPodMetrics: vi.fn(async () => []),
+  clusterCapacity: vi.fn(async () => []),
+  watchResources: vi.fn(),
+  unwatchResources: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+import YamlModal from "./YamlModal.svelte";
+import { getResourceYaml } from "$lib/tauri";
+import { app } from "$lib/stores/app.svelte";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  app.kubeconfigPath = "/home/u/.kube/config";
+  app.activeCluster = "prod";
+});
+
+describe("YamlModal", () => {
+  it("fetches and renders the resource YAML", async () => {
+    vi.mocked(getResourceYaml).mockResolvedValue("kind: Pod\nmetadata:\n  name: api-0\n");
+    render(YamlModal, {
+      props: { resourceType: "pod", namespace: "default", name: "api-0", onClose: vi.fn() },
+    });
+    expect(getResourceYaml).toHaveBeenCalledWith(
+      "/home/u/.kube/config",
+      "pod",
+      "default",
+      "api-0",
+      "prod",
+    );
+    expect(await screen.findByText(/kind: Pod/)).toBeInTheDocument();
+    expect(screen.getByText("api-0.yaml")).toBeInTheDocument();
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+  });
+
+  it("shows the fetch error", async () => {
+    vi.mocked(getResourceYaml).mockRejectedValue(new Error("not found"));
+    render(YamlModal, {
+      props: { resourceType: "pod", namespace: "default", name: "gone", onClose: vi.fn() },
+    });
+    expect(await screen.findByText("not found")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -395,6 +395,30 @@ export function listNodes(
   });
 }
 
+export type YamlResourceType =
+  | "pod"
+  | "deployment"
+  | "service"
+  | "configmap"
+  | "secret"
+  | "ingress";
+
+export function getResourceYaml(
+  kubeconfigPath: string,
+  resourceType: YamlResourceType,
+  namespace: string,
+  name: string,
+  context?: string,
+): Promise<string> {
+  return invoke<string>("get_resource_yaml", {
+    kubeconfigPath,
+    resourceType,
+    namespace,
+    name,
+    context: context ?? null,
+  });
+}
+
 export function probeCluster(
   kubeconfigPath: string,
   context: string,

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -28,6 +28,7 @@ use crate::{
         ConfigMapInfo, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo, JobInfo, NamespaceInfo,
         NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo, StatefulSetInfo,
     },
+    watcher::ResourceType,
     watcher::{
         configmap_to_info, cronjob_to_info, deployment_to_info, ingress_to_info, job_to_info,
         namespace_to_info, node_to_info, pod_to_info, pvc_to_info, secret_to_info, service_to_info,
@@ -543,6 +544,33 @@ impl KubeClient {
         Ok(list.items.into_iter().filter_map(node_to_info).collect())
     }
 
+    /// Fetch one resource and render it as cleaned YAML (managedFields
+    /// stripped, like `kubectl get -o yaml`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails or
+    /// the resource kind does not support YAML rendering.
+    pub async fn get_resource_yaml(
+        &self,
+        resource_type: ResourceType,
+        namespace: &str,
+        name: &str,
+    ) -> Result<String, KubeconfigError> {
+        let client = self.inner.clone();
+        match resource_type {
+            ResourceType::Pod => fetch_yaml::<Pod>(client, namespace, name).await,
+            ResourceType::Deployment => fetch_yaml::<Deployment>(client, namespace, name).await,
+            ResourceType::Service => fetch_yaml::<Service>(client, namespace, name).await,
+            ResourceType::ConfigMap => fetch_yaml::<ConfigMap>(client, namespace, name).await,
+            ResourceType::Secret => fetch_yaml::<Secret>(client, namespace, name).await,
+            ResourceType::Ingress => fetch_yaml::<Ingress>(client, namespace, name).await,
+            ResourceType::Namespace => Err(KubeconfigError::ClientError {
+                reason: "YAML view is not supported for namespaces".to_string(),
+            }),
+        }
+    }
+
     /// List events in `namespace`, or across all namespaces when `None`,
     /// sorted most-recent first.
     ///
@@ -638,6 +666,44 @@ impl KubeClient {
     }
 }
 
+/// Fetch one namespaced object and serialize it as cleaned YAML.
+async fn fetch_yaml<K>(
+    client: Client,
+    namespace: &str,
+    name: &str,
+) -> Result<String, KubeconfigError>
+where
+    K: kube::Resource<Scope = k8s_openapi::NamespaceResourceScope>
+        + Clone
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + std::fmt::Debug,
+    <K as kube::Resource>::DynamicType: Default,
+{
+    let api: Api<K> = Api::namespaced(client, namespace);
+    let obj = api
+        .get(name)
+        .await
+        .map_err(|e| KubeconfigError::ClientError {
+            reason: e.to_string(),
+        })?;
+    to_clean_yaml(&obj)
+}
+
+/// Serialize an API object to YAML with noisy server-side bookkeeping
+/// (`metadata.managedFields`) stripped, like `kubectl get -o yaml`.
+fn to_clean_yaml<T: serde::Serialize>(obj: &T) -> Result<String, KubeconfigError> {
+    let mut value = serde_json::to_value(obj).map_err(|e| KubeconfigError::ClientError {
+        reason: e.to_string(),
+    })?;
+    if let Some(meta) = value.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+        meta.remove("managedFields");
+    }
+    serde_yaml::to_string(&value).map_err(|e| KubeconfigError::ClientError {
+        reason: e.to_string(),
+    })
+}
+
 /// Convert a raw [`Event`] object into an [`EventInfo`].
 fn event_to_info(e: Event) -> EventInfo {
     let object = match (&e.involved_object.kind, &e.involved_object.name) {
@@ -669,6 +735,23 @@ mod tests {
     use super::*;
     use k8s_openapi::api::core::v1::{EventSource, ObjectReference};
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, Time};
+
+    #[test]
+    fn to_clean_yaml_strips_managed_fields() {
+        let obj = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "api-0",
+                "managedFields": [{ "manager": "kubectl" }]
+            },
+            "spec": { "containers": [] }
+        });
+        let yaml = to_clean_yaml(&obj).expect("yaml");
+        assert!(yaml.contains("name: api-0"));
+        assert!(!yaml.contains("managedFields"));
+        assert!(yaml.contains("kind: Pod"));
+    }
 
     #[test]
     fn event_to_info_full() {


### PR DESCRIPTION
Closes #248

## Backend
- `KubeClient::get_resource_yaml` for pods, deployments, services, configmaps, secrets, ingresses — output cleaned like `kubectl get -o yaml` (`metadata.managedFields` stripped via a tested helper); generic over namespaced kinds
- `get_resource_yaml` command reusing the lowercase `ResourceType` names from `watch_resources`

## Frontend
- **YamlModal** (720px): mono `bg/sunken` pre per the design tokens, loading/error states, Copy button with confirmation tick
- **YAML** button in the Pod and Deployment drawer footers

Read-only per the issue; edit/apply follows once mutations are proven out.

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace`
- `pnpm --filter desktop lint / typecheck / test / build` — 153 tests, 0 unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)