### PR TITLE
test(desktop): Playwright e2e suite with mocked Tauri IPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ apps/desktop/src-tauri/gen/
 # rules on throwaway prototype markup). The bundle README + tokens-v2
 # remain tracked.
 design/design_handoff_cubelite_ui/*.dc.html
+
+# Playwright
+apps/desktop/test-results/
+apps/desktop/playwright-report/

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,9 +11,12 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src --max-warnings 0",
-    "typecheck": "svelte-check --tsconfig ./tsconfig.json"
+    "typecheck": "svelte-check --tsconfig ./tsconfig.json",
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.60.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * E2E suite: the production bundle served by `vite preview` with the Tauri
+ * IPC layer mocked in the browser (tests/e2e/tauri-mock.ts). No Rust backend
+ * or cluster is required.
+ */
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm build && pnpm preview --port 4173 --strictPort",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apps/desktop/tests/e2e/app.spec.ts
+++ b/apps/desktop/tests/e2e/app.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMockScript } from "./tauri-mock";
+
+async function boot(page: Page, opts: { onboardingSeen?: boolean } = {}) {
+  await page.addInitScript(tauriMockScript());
+  const seen = opts.onboardingSeen ?? true;
+  await page.addInitScript(
+    ([seenValue]) => {
+      window.localStorage.setItem("cubelite.onboardingSeen", seenValue);
+      window.localStorage.setItem("cubelite.theme", '"dark"');
+    },
+    [String(seen)],
+  );
+  await page.goto("/");
+}
+
+test("shell renders titlebar, rail, sidebar and status bar", async ({ page }) => {
+  await boot(page);
+  await expect(page.getByText("prod-aks").first()).toBeVisible();
+  await expect(page.getByText("AKS", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("All Clusters")).toBeVisible();
+  await expect(page.getByText("Workloads")).toBeVisible();
+  await expect(page.getByText("https://prod.azmk8s.io:443")).toBeVisible();
+});
+
+test("first launch shows onboarding and completes", async ({ page }) => {
+  await boot(page, { onboardingSeen: false });
+  await expect(page.getByText("Welcome to CubeLite")).toBeVisible();
+  await expect(page.getByText("2 contexts found")).toBeVisible();
+  await page.getByText("Continue").click();
+  await page.getByText("Continue").click();
+  await page.getByText("Start using CubeLite").click();
+  await expect(page.getByText("Welcome to CubeLite")).not.toBeVisible();
+  // The init script would reset the flag on reload; assert persistence directly.
+  const seen = await page.evaluate(() => window.localStorage.getItem("cubelite.onboardingSeen"));
+  expect(seen).toBe("true");
+});
+
+test("pods view lists fixtures and opens the detail drawer, Esc closes", async ({ page }) => {
+  await boot(page);
+  await page.getByText("Pods", { exact: true }).click();
+  await expect(page.getByText("api-0")).toBeVisible();
+  await expect(page.getByText("Pending", { exact: true })).toBeVisible();
+  await page.getByText("api-0").click();
+  await expect(page.getByRole("dialog", { name: "api-0" })).toBeVisible();
+  await expect(page.getByText("Burstable")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog", { name: "api-0" })).not.toBeVisible();
+});
+
+test("command palette navigates views", async ({ page }) => {
+  await boot(page);
+  await page.getByText("Search & switch…").click();
+  await expect(page.getByPlaceholder("Search clusters, views, actions…")).toBeVisible();
+  await page.getByText("Go to Deployments").click();
+  await expect(page.getByText("Replicas · Actions")).toBeVisible();
+});
+
+test("cluster switch from the rail lands on the new cluster", async ({ page }) => {
+  await boot(page);
+  await page.getByTitle("staging").click();
+  await expect(page.getByText("staging").first()).toBeVisible();
+  await expect(page.getByLabel("All Clusters")).toBeVisible();
+});
+
+test("preferences persist the refresh interval across reloads", async ({ page }) => {
+  await boot(page);
+  await page.getByLabel("Preferences").click();
+  await page.getByRole("radio", { name: "1m" }).click();
+  await page.keyboard.press("Escape");
+  await page.reload();
+  await expect(page.getByText("refresh 1m")).toBeVisible();
+});

--- a/apps/desktop/tests/e2e/tauri-mock.ts
+++ b/apps/desktop/tests/e2e/tauri-mock.ts
@@ -1,0 +1,124 @@
+/**
+ * Browser-side mock of the Tauri v2 IPC layer (`window.__TAURI_INTERNALS__`)
+ * with deterministic cluster fixtures. Injected via `page.addInitScript`
+ * before the app boots, so `@tauri-apps/api` calls resolve without a Rust
+ * backend.
+ */
+
+export const FIXTURES = {
+  contexts: [
+    { name: "prod-aks", cluster_server: "https://prod.azmk8s.io:443", namespace: "default", is_active: true },
+    { name: "staging", cluster_server: "https://staging:6443", namespace: "default", is_active: false },
+  ],
+  pods: [
+    {
+      name: "api-0",
+      namespace: "default",
+      phase: "Running",
+      ready: true,
+      restarts: 0,
+      ready_containers: 1,
+      total_containers: 1,
+      node: "node-1",
+      pod_ip: "10.0.0.5",
+      qos_class: "Burstable",
+      containers: [{ name: "api", image: "ghcr.io/x/api:2.1", ready: true }],
+      labels: { app: "api" },
+      creation_timestamp: "2026-07-10T09:00:00Z",
+    },
+    {
+      name: "worker-0",
+      namespace: "default",
+      phase: "Pending",
+      ready: false,
+      restarts: 5,
+      ready_containers: 0,
+      total_containers: 1,
+      node: null,
+      pod_ip: null,
+      qos_class: null,
+      containers: [{ name: "worker", image: "ghcr.io/x/worker:2.1", ready: false }],
+      labels: { app: "worker" },
+      creation_timestamp: "2026-07-11T08:00:00Z",
+    },
+  ],
+  namespaces: [
+    { name: "default", phase: "Active" },
+    { name: "kube-system", phase: "Active" },
+  ],
+  deployments: [
+    {
+      name: "api",
+      namespace: "default",
+      replicas: 2,
+      ready_replicas: 2,
+      images: ["ghcr.io/x/api:2.1"],
+      selector: { app: "api" },
+      strategy: "RollingUpdate",
+      conditions: [{ condition_type: "Available", status: "True", reason: "MinimumReplicasAvailable" }],
+      creation_timestamp: "2026-07-01T09:00:00Z",
+    },
+  ],
+};
+
+/** Serializable init script installing the IPC mock. */
+export function tauriMockScript(): string {
+  const fixtures = JSON.stringify(FIXTURES);
+  return `
+(() => {
+  const fixtures = ${fixtures};
+  let callbackId = 1;
+
+  const responses = (cmd, args) => {
+    switch (cmd) {
+      case "list_contexts": return fixtures.contexts;
+      case "get_current_context": return "prod-aks";
+      case "set_context": {
+        fixtures.contexts = fixtures.contexts.map((c) => ({ ...c, is_active: c.name === args.contextName }));
+        return null;
+      }
+      case "list_pods": return args.namespace && args.namespace !== "default" ? [] : fixtures.pods;
+      case "list_namespaces": return fixtures.namespaces;
+      case "list_deployments": return args.namespace === "default" ? fixtures.deployments : [];
+      case "list_events": return [];
+      case "list_pod_metrics": return [];
+      case "cluster_capacity": return [];
+      case "list_services":
+      case "list_ingresses":
+      case "list_configmaps":
+      case "list_secrets":
+      case "list_helm_releases":
+      case "list_jobs":
+      case "list_cronjobs":
+      case "list_statefulsets":
+      case "list_pvcs":
+      case "list_nodes":
+        return [];
+      case "probe_cluster":
+        return { context: args.context, reachable: args.context !== "staging", version: "v1.30.2", node_count: 3, error: args.context === "staging" ? "connection timed out" : null };
+      case "watch_resources": return "w1";
+      case "unwatch_resources": return null;
+      case "stream_logs": return "l1";
+      case "stop_logs": return null;
+      case "get_resource_yaml": return "kind: Pod\\nmetadata:\\n  name: " + args.name + "\\n";
+      default: return null;
+    }
+  };
+
+  window.__TAURI_INTERNALS__ = {
+    metadata: { currentWindow: { label: "main" }, currentWebview: { label: "main" } },
+    plugins: {},
+    transformCallback(callback) {
+      const id = callbackId++;
+      window["_" + id] = callback;
+      return id;
+    },
+    async invoke(cmd, args) {
+      if (cmd.startsWith("plugin:path|")) return "/home/test";
+      if (cmd.startsWith("plugin:event|")) return callbackId++;
+      return responses(cmd, args ?? {});
+    },
+  };
+})();
+`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^2.6.0
         version: 2.6.1
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
         version: 3.0.10(@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7(@typescript-eslint/types@8.58.1))(vite@6.4.3(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))(svelte@5.55.7(@typescript-eslint/types@8.58.1))(typescript@5.9.3)(vite@6.4.3(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
@@ -582,6 +585,11 @@ packages:
     resolution: {integrity: sha512-yXwewA7ANQ5hfaSDrvsecosWjZn5RglzeXUZRSnxeANBskpNwblOkEJTqD0ujDdNKIKL8E9eVc2U/P3ziJr7OA==}
     peerDependencies:
       svelte: ^5
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1383,6 +1391,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1681,6 +1694,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -2395,6 +2418,10 @@ snapshots:
   '@lucide/svelte@1.24.0(svelte@5.55.7(@typescript-eslint/types@8.58.1))':
     dependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.58.1)
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -3194,6 +3221,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3436,6 +3466,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@3.1.4(postcss@8.5.14):
     dependencies:


### PR DESCRIPTION
Closes #247 — makes the `pnpm --filter desktop test:e2e` gate referenced by AGENTS.md real.

## Setup
- `playwright.config.ts`: chromium against the **production bundle** (`pnpm build && vite preview`, port 4173)
- `tests/e2e/tauri-mock.ts`: browser-side `__TAURI_INTERNALS__` mock with deterministic fixtures — no Rust backend or live cluster required; namespace-aware list responses, event/path plugins stubbed

## Flows covered (6)
1. Shell composition: titlebar identity + provider chip, rail, sidebar groups, status bar server
2. First-launch onboarding: 3 steps, completion persists `onboardingSeen`
3. Pods table → detail drawer (QoS from fixtures) → Esc closes
4. Command palette → navigate to Deployments
5. Cluster switch from the rail
6. Preferences: refresh interval persists across reload

## Verification (exit codes checked explicitly)
- `pnpm --filter desktop test:e2e` — 6/6 passed
- `pnpm --filter desktop lint / typecheck / test / build` — 153 unit tests, 0 unhandled errors
- No Rust changes

Note: e2e runs locally (chromium via `playwright install`); adding it to CI is a workflow change owned by devops (`.github/**`) and can follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)