### PR TITLE
feat(core+desktop): kubeconfig exec/auth-provider plugin support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,6 +2033,7 @@ dependencies = [
  "bytes",
  "chrono",
  "either",
+ "form_urlencoded",
  "futures",
  "home",
  "http",

--- a/apps/desktop/src-tauri/src/env.rs
+++ b/apps/desktop/src-tauri/src/env.rs
@@ -1,0 +1,92 @@
+//! PATH repair for GUI-launched processes.
+//!
+//! Apps started from Finder/launchd (macOS) or a desktop launcher (Linux)
+//! inherit a minimal PATH, so kubeconfig `exec` credential plugins
+//! (`kubelogin`, `aws`, `gke-gcloud-auth-plugin`, krew plugins, …) spawned
+//! by kube-rs are not found. At startup we ask the user's login shell for
+//! its PATH and merge it into the process environment.
+
+use std::process::Command;
+
+/// Merge `extra` PATH entries after `current`, deduplicating while keeping
+/// order (current entries win).
+fn merge_paths(current: &str, extra: &str) -> String {
+    let mut seen = std::collections::HashSet::new();
+    let mut merged = Vec::new();
+    for entry in current.split(':').chain(extra.split(':')) {
+        if entry.is_empty() {
+            continue;
+        }
+        if seen.insert(entry.to_string()) {
+            merged.push(entry);
+        }
+    }
+    merged.join(":")
+}
+
+/// Well-known plugin locations appended even when the shell probe fails.
+fn fallback_entries() -> String {
+    let home = std::env::var("HOME").unwrap_or_default();
+    [
+        "/usr/local/bin".to_string(),
+        "/opt/homebrew/bin".to_string(),
+        format!("{home}/.krew/bin"),
+        format!("{home}/.local/bin"),
+    ]
+    .join(":")
+}
+
+/// Ask the user's login shell for its PATH (GUI processes get a minimal one).
+fn login_shell_path() -> Option<String> {
+    let shell = std::env::var("SHELL").ok()?;
+    let output = Command::new(shell)
+        .args(["-lc", "printf %s \"$PATH\""])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Repair PATH so kubeconfig exec credential plugins resolve.
+///
+/// No-op on Windows (GUI processes inherit the full user PATH there).
+pub fn fix_path() {
+    #[cfg(unix)]
+    {
+        let current = std::env::var("PATH").unwrap_or_default();
+        let shell_path = login_shell_path().unwrap_or_default();
+        let merged = merge_paths(&merge_paths(&current, &shell_path), &fallback_entries());
+        // Setting PATH for our own process before any threads spawn plugins.
+        std::env::set_var("PATH", merged);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_keeps_order_and_dedupes() {
+        let merged = merge_paths("/usr/bin:/bin", "/opt/homebrew/bin:/usr/bin");
+        assert_eq!(merged, "/usr/bin:/bin:/opt/homebrew/bin");
+    }
+
+    #[test]
+    fn merge_skips_empty_entries() {
+        let merged = merge_paths("", "/usr/local/bin::/bin");
+        assert_eq!(merged, "/usr/local/bin:/bin");
+    }
+
+    #[test]
+    fn fallbacks_include_krew() {
+        assert!(fallback_entries().contains(".krew/bin"));
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod env;
 
 use commands::kubernetes::{
     cluster_capacity, delete_pod, get_current_context, get_resource_yaml, list_configmaps,
@@ -11,6 +12,9 @@ use commands::kubernetes::{
 
 /// Entry point for the Tauri application.
 pub fn run() {
+    // Must run before anything can spawn kubeconfig exec plugins.
+    env::fix_path();
+
     if let Err(e) = tauri::Builder::default()
         .manage(WatchState::default())
         .manage(LogState::default())

--- a/crates/cubelite-core/Cargo.toml
+++ b/crates/cubelite-core/Cargo.toml
@@ -11,7 +11,7 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 dirs = "5"
-kube = { version = "0.97", features = ["runtime", "derive", "client"] }
+kube = { version = "0.97", features = ["runtime", "derive", "client", "oidc"] }
 serde_json = { workspace = true }
 k8s-openapi = { version = "0.23", features = ["v1_30"] }
 base64 = "0.22"

--- a/crates/cubelite-core/src/kubeconfig.rs
+++ b/crates/cubelite-core/src/kubeconfig.rs
@@ -191,10 +191,16 @@ impl KubeConfig {
     /// This mirrors how `kubectl` behaves when `KUBECONFIG` specifies multiple
     /// paths.
     ///
+    /// Only the `current-context` key of the primary file is patched: the
+    /// document is round-tripped as raw YAML so fields our typed model does
+    /// not know about (`exec` credential plugins, `auth-provider`,
+    /// extensions, …) are preserved verbatim, and a merged multi-file
+    /// KUBECONFIG is never flattened into the primary file.
+    ///
     /// # Errors
     ///
     /// Returns [`KubeconfigError::FileNotFound`] when no load path is known,
-    /// [`KubeconfigError::ParseError`] if serialisation fails, or
+    /// [`KubeconfigError::ParseError`] if (de)serialisation fails, or
     /// [`KubeconfigError::Io`] on write failure.
     pub fn save(&self) -> Result<(), KubeconfigError> {
         let primary = self
@@ -203,7 +209,20 @@ impl KubeConfig {
             .ok_or_else(|| KubeconfigError::FileNotFound {
                 path: "(no kubeconfig paths known — cannot save)".to_string(),
             })?;
-        let yaml = serde_yaml::to_string(&self.raw)?;
+
+        let content = std::fs::read_to_string(primary)?;
+        let mut doc: serde_yaml::Value = serde_yaml::from_str(&content)?;
+        let mapping = doc
+            .as_mapping_mut()
+            .ok_or_else(|| KubeconfigError::MergeError {
+                reason: format!("kubeconfig root is not a mapping: {}", primary.display()),
+            })?;
+        mapping.insert(
+            serde_yaml::Value::String("current-context".to_string()),
+            serde_yaml::Value::String(self.raw.current_context.clone().unwrap_or_default()),
+        );
+
+        let yaml = serde_yaml::to_string(&doc)?;
         std::fs::write(primary, yaml)?;
         Ok(())
     }
@@ -514,6 +533,52 @@ contexts:
     }
 
     // -- Persistence ---------------------------------------------------------
+
+    #[test]
+    fn save_preserves_exec_credential_plugins() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: aks
+contexts:
+  - name: aks
+    context: { cluster: aks, user: aks-user }
+  - name: kind
+    context: { cluster: kind, user: kind-user }
+clusters:
+  - name: aks
+    cluster: { server: "https://aks:443" }
+  - name: kind
+    cluster: { server: "https://127.0.0.1:6443" }
+users:
+  - name: aks-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: kubelogin
+        args: ["get-token", "--login", "azurecli"]
+        env: null
+        interactiveMode: IfAvailable
+        provideClusterInfo: false
+  - name: kind-user
+    user:
+      auth-provider:
+        name: oidc
+        config:
+          idp-issuer-url: https://issuer.example.com
+"#;
+        let f = write_temp(yaml);
+        let mut cfg = KubeConfig::load_from_paths(&[f.path().to_path_buf()]).expect("load");
+        cfg.set_active_context("kind").expect("switch");
+        cfg.save().expect("save");
+
+        let written = std::fs::read_to_string(f.path()).expect("read back");
+        assert!(written.contains("current-context: kind"));
+        assert!(written.contains("command: kubelogin"), "exec block dropped");
+        assert!(written.contains("interactiveMode: IfAvailable"));
+        assert!(written.contains("auth-provider"), "auth-provider dropped");
+        assert!(written.contains("idp-issuer-url"));
+    }
 
     #[test]
     fn save_persists_context_switch() {


### PR DESCRIPTION
Refs #108 — completes the core + desktop scope; the Swift-app remainder is re-milestoned to v0.3.0 (macOS unified UI).

## The critical fix
`KubeConfig::save` rewrote the primary kubeconfig through our typed model, which does not know `exec`, `auth-provider` or extension fields. **Every context switch from CubeLite silently stripped exec credential plugins** (kubelogin/AKS, aws/EKS, gke-gcloud-auth-plugin/GKE, krew) — and flattened a merged multi-file `KUBECONFIG` into the primary file. `save` now round-trips the raw YAML and patches only `current-context`; a regression test covers kubelogin `exec` and `oidc` `auth-provider` blocks surviving a switch.

## Making exec plugins actually work in a GUI app
kube-rs supports `exec` plugins natively, but GUI-launched processes (Finder/launchd) inherit a minimal `PATH`, so the plugin binaries are not found. `src-tauri/src/env.rs` now asks the login shell for its `PATH` at startup and merges it with well-known fallbacks (`/usr/local/bin`, `/opt/homebrew/bin`, `~/.krew/bin`, `~/.local/bin`). No-op on Windows. Merge logic unit-tested.

## Also
- kube `oidc` feature enabled (auth-provider oidc token refresh). Legacy GCP `auth-provider` remains unsupported upstream; its official replacement is the exec path, which now works.

## Verification (exit codes checked explicitly)
- `cargo fmt --check` · `cargo clippy --workspace --all-targets` (0 errors) · `cargo test --workspace` (new regression + PATH-merge tests)
- `pnpm --filter desktop lint / typecheck / test / build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)