### PR TITLE
design(macos): unified shell — rail, header, sidebar, status bar

### DIFF
--- a/apps/macos/cubelite/cubelite/CubeliteApp.swift
+++ b/apps/macos/cubelite/cubelite/CubeliteApp.swift
@@ -65,6 +65,7 @@ struct CubeliteApp: App {
                 )
             }
         }
+        .windowStyle(.hiddenTitleBar)
         .defaultSize(
             width: hasCompletedOnboarding ? 1200 : 600,
             height: hasCompletedOnboarding ? 700 : 400

--- a/apps/macos/cubelite/cubelite/Views/MainView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView.swift
@@ -113,28 +113,87 @@ struct MainView: View {
         )
     }
 
+    // MARK: - Actions
+
+    /// Refresh everything relevant to the current mode (used by the header).
+    func refreshAll() {
+        Task {
+            await loadKubeconfig()
+            if showAllClusters {
+                await loadCrossClusterData()
+            } else {
+                if let ctx = selectedContext {
+                    await loadNamespaces(for: ctx)
+                }
+                if let sel = sidebarSelection {
+                    await loadResources(context: sel.context, namespace: sel.namespace)
+                }
+            }
+        }
+    }
+
     // MARK: - Body
 
     var body: some View {
-        NavigationSplitView(columnVisibility: $columnVisibility) {
-            sidebar
-                .navigationSplitViewColumnWidth(
-                    min: 52,
-                    ideal: isSidebarCollapsed ? 52 : 240,
-                    max: isSidebarCollapsed ? 60 : 300
+        VStack(spacing: 0) {
+            UnifiedHeaderView(
+                contexts: clusterState.contexts,
+                selectedContext: showAllClusters ? nil : selectedContext,
+                clusterReachable: clusterState.clusterReachable,
+                namespaces: clusterState.namespaces,
+                selectedNamespace: sidebarSelection?.namespace,
+                isLoading: clusterState.isLoading || clusterState.isLoadingResources
+                    || isLoadingNamespaces,
+                unreadErrorCount: logStore.unreadErrorCount,
+                onSelectNamespace: { namespace in
+                    if let context = selectedContext {
+                        sidebarSelection = SidebarSelection(context: context, namespace: namespace)
+                    }
+                },
+                onRefresh: { refreshAll() },
+                onShowLogs: { showingLogs = true }
+            )
+            HStack(spacing: 0) {
+                ClusterRailView(
+                    contexts: clusterState.contexts,
+                    selectedContext: selectedContext,
+                    showAllClusters: showAllClusters,
+                    onSelectAllClusters: {
+                        showAllClusters = true
+                        selectedContext = nil
+                        Task { await loadCrossClusterData() }
+                    },
+                    onSelectContext: { context in
+                        showAllClusters = false
+                        if selectedContext == context {
+                            selectedResourceType = .dashboard
+                        } else {
+                            selectedContext = context
+                        }
+                    }
                 )
-        } content: {
-            resourceTypeList
-                .navigationTitle("Resources")
-                .navigationSplitViewColumnWidth(min: 160, ideal: 180, max: 220)
-        } detail: {
-            VStack(spacing: 0) {
-                errorBannerInset
-                detailArea
+                if !showAllClusters {
+                    UnifiedSidebarView(
+                        selection: $selectedResourceType,
+                        podCount: clusterState.pods.count,
+                        deploymentCount: clusterState.deployments.count
+                    )
+                    Rectangle().fill(DesignTokens.borderFaint).frame(width: 1)
+                }
+                VStack(spacing: 0) {
+                    errorBannerInset
+                    detailArea
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+                .background(DesignTokens.surfaceWindow)
             }
+            StatusBarView(
+                autoRefreshInterval: appSettings.autoRefreshInterval,
+                unreadErrorCount: logStore.unreadErrorCount,
+                onShowLogs: { showingLogs = true }
+            )
         }
         .frame(minWidth: 900, minHeight: 550)
-        .toolbar { toolbarContent }
         .sheet(isPresented: $showingLogs) {
             LogsView()
                 .environment(logStore)
@@ -186,12 +245,6 @@ struct MainView: View {
             selectedHelmReleaseID = nil
             if let sel = newValue {
                 Task { await loadResources(context: sel.context, namespace: sel.namespace) }
-            }
-        }
-        .onChange(of: columnVisibility) { _, newValue in
-            if newValue != .all {
-                columnVisibility = .all
-                isSidebarCollapsed.toggle()
             }
         }
     }

--- a/apps/macos/cubelite/cubelite/Views/Shell/ClusterRailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/ClusterRailView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// Persistent 58pt vertical rail of cluster avatars (Design System v1):
+/// All-Clusters home on top, one identity avatar per kubeconfig context,
+/// Preferences gear at the bottom.
+struct ClusterRailView: View {
+
+    let contexts: [String]
+    let selectedContext: String?
+    let showAllClusters: Bool
+    let onSelectAllClusters: () -> Void
+    let onSelectContext: (String) -> Void
+
+    @Environment(\.openSettings) private var openSettings
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Button(action: onSelectAllClusters) {
+                Image(systemName: "house")
+                    .font(.system(size: 14, weight: .medium))
+                    .frame(width: 38, height: 38)
+                    .background(
+                        showAllClusters
+                            ? AnyShapeStyle(DesignTokens.accentDefault.opacity(0.14))
+                            : AnyShapeStyle(DesignTokens.surfaceRaised),
+                        in: RoundedRectangle(cornerRadius: DesignTokens.radiusXl)
+                    )
+                    .foregroundStyle(
+                        showAllClusters ? DesignTokens.textPrimary : DesignTokens.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .help("All Clusters")
+
+            Rectangle()
+                .fill(DesignTokens.borderFaint)
+                .frame(width: 28, height: 1)
+
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 8) {
+                    ForEach(contexts, id: \.self) { context in
+                        avatar(for: context)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                openSettings()
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 14))
+                    .frame(width: 38, height: 38)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .buttonStyle(.plain)
+            .help("Preferences")
+        }
+        .padding(.vertical, 10)
+        .frame(width: 58)
+        .background(DesignTokens.surfaceWindow)
+        .overlay(alignment: .trailing) {
+            Rectangle().fill(DesignTokens.borderFaint).frame(width: 1)
+        }
+    }
+
+    private func avatar(for context: String) -> some View {
+        let identity = ClusterIdentity.color(for: context, in: contexts)
+        let isActive = context == selectedContext && !showAllClusters
+        return Button {
+            onSelectContext(context)
+        } label: {
+            Text(ClusterIdentity.initials(for: context))
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: 38, height: 38)
+                .background(
+                    isActive
+                        ? AnyShapeStyle(identity.opacity(0.2))
+                        : AnyShapeStyle(DesignTokens.surfaceRaised),
+                    in: RoundedRectangle(cornerRadius: DesignTokens.radiusXl)
+                )
+                .foregroundStyle(isActive ? DesignTokens.textPrimary : DesignTokens.textSecondary)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignTokens.radiusXl)
+                        .strokeBorder(identity, lineWidth: isActive ? 2 : 0)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(context)
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/Shell/IdentityHelpers.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/IdentityHelpers.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+// MARK: - Cluster Identity (Design System v1)
+//
+// Stable per-cluster identity color and avatar initials, mirroring the
+// desktop app's cluster-identity assignment (first-appearance order over
+// the five-color palette). Identity ≠ health: health is always a separate
+// dot/badge.
+
+enum ClusterIdentity {
+
+    /// The identity palette from the design tokens, in assignment order.
+    static let palette: [Color] = [
+        DesignTokens.clusterBlue,
+        DesignTokens.clusterAmber,
+        DesignTokens.clusterPink,
+        DesignTokens.clusterViolet,
+        DesignTokens.clusterTeal,
+    ]
+
+    /// Identity color for `context`, assigned by first-appearance order in
+    /// `contexts` and cycling when the palette is exhausted.
+    static func color(for context: String, in contexts: [String]) -> Color {
+        guard let index = contexts.firstIndex(of: context) else {
+            return palette[0]
+        }
+        return palette[index % palette.count]
+    }
+
+    /// Two-character avatar initials (e.g. `"prod-eu-1"` → `"PE"`).
+    static func initials(for name: String) -> String {
+        let parts = name.split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        if parts.count >= 2, let a = parts[0].first, let b = parts[1].first {
+            return String([a, b]).uppercased()
+        }
+        if let first = parts.first {
+            return String(first.prefix(2)).uppercased()
+        }
+        return "?"
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/Shell/StatusBarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/StatusBarView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// 27pt status bar (Design System v1): auto-refresh interval on the left,
+/// clickable unread-error count on the right.
+struct StatusBarView: View {
+
+    let autoRefreshInterval: Int
+    let unreadErrorCount: Int
+    let onShowLogs: () -> Void
+
+    private var refreshLabel: String {
+        switch autoRefreshInterval {
+        case 0: "refresh off"
+        case 60: "refresh 1m"
+        default: "refresh \(autoRefreshInterval)s"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Text(refreshLabel)
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundStyle(DesignTokens.textTertiary)
+            Spacer(minLength: 0)
+            if unreadErrorCount > 0 {
+                Button(action: onShowLogs) {
+                    Text("\(unreadErrorCount) error\(unreadErrorCount == 1 ? "" : "s")")
+                        .font(.system(size: 10.5, design: .monospaced))
+                        .foregroundStyle(DesignTokens.statusWarn)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 27)
+        .background(DesignTokens.surfacePanel)
+        .overlay(alignment: .top) {
+            Rectangle().fill(DesignTokens.borderFaint).frame(height: 1)
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedHeaderView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedHeaderView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// 42pt unified header bar (Design System v1): active-cluster identity dot +
+/// name + connection state on the left; namespace picker, refresh and logs
+/// on the right. Replaces the native toolbar of the old layout.
+struct UnifiedHeaderView: View {
+
+    let contexts: [String]
+    let selectedContext: String?
+    let clusterReachable: Bool?
+    let namespaces: [NamespaceInfo]
+    let selectedNamespace: String?
+    let isLoading: Bool
+    let unreadErrorCount: Int
+    let onSelectNamespace: (String?) -> Void
+    let onRefresh: () -> Void
+    let onShowLogs: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if let context = selectedContext {
+                let identity = ClusterIdentity.color(for: context, in: contexts)
+                HStack(spacing: 8) {
+                    Circle().fill(identity).frame(width: 8, height: 8)
+                    Text(context)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(DesignTokens.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    connectionBadge
+                }
+            } else {
+                Text("All Clusters")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(DesignTokens.textPrimary)
+            }
+
+            Spacer(minLength: 8)
+
+            if selectedContext != nil {
+                namespaceMenu
+            }
+
+            Button(action: onRefresh) {
+                if isLoading {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .foregroundStyle(DesignTokens.textSecondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .help("Refresh all")
+            .disabled(isLoading)
+
+            Button(action: onShowLogs) {
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: "bell")
+                        .foregroundStyle(DesignTokens.textSecondary)
+                    if unreadErrorCount > 0 {
+                        Text(unreadErrorCount < 100 ? "\(unreadErrorCount)" : "99+")
+                            .font(.system(size: 7, weight: .bold))
+                            .foregroundStyle(.white)
+                            .padding(2)
+                            .background(DesignTokens.statusErr, in: Circle())
+                            .offset(x: 5, y: -5)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .help("View logs and errors")
+        }
+        // Inset for the macOS traffic lights (hidden-title-bar window).
+        .padding(.leading, 78)
+        .padding(.trailing, 12)
+        .frame(height: 42)
+        .background(DesignTokens.surfaceSurface)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(DesignTokens.borderDefault).frame(height: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var connectionBadge: some View {
+        let (color, label): (Color, String) =
+            switch clusterReachable {
+            case .some(true): (DesignTokens.statusOk, "Connected")
+            case .some(false): (DesignTokens.statusErr, "Unreachable")
+            case .none: (DesignTokens.textTertiary, "—")
+            }
+        HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(DesignTokens.textTertiary)
+        }
+    }
+
+    private var namespaceMenu: some View {
+        Menu {
+            Button("All Namespaces") { onSelectNamespace(nil) }
+            if !namespaces.isEmpty {
+                Divider()
+                ForEach(namespaces) { ns in
+                    Button(ns.name) { onSelectNamespace(ns.name) }
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Text("namespace:")
+                    .font(.system(size: 11))
+                    .foregroundStyle(DesignTokens.textSecondary)
+                Text(selectedNamespace ?? "all")
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundStyle(DesignTokens.textPrimary)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8))
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 28)
+            .background(
+                DesignTokens.surfaceRaised,
+                in: RoundedRectangle(cornerRadius: DesignTokens.radiusMd))
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// 198pt grouped navigation sidebar (Design System v1): sections with
+/// group-color dots and live counts, replacing the middle resource-type
+/// column of the old three-pane layout.
+struct UnifiedSidebarView: View {
+
+    @Binding var selection: ResourceType?
+    let podCount: Int
+    let deploymentCount: Int
+
+    private struct Section {
+        let label: String
+        let dot: Color
+        let items: [ResourceType]
+    }
+
+    private var sections: [Section] {
+        [
+            Section(label: "Cluster", dot: DesignTokens.accentDefault, items: [.dashboard]),
+            Section(
+                label: "Workloads", dot: DesignTokens.clusterBlue,
+                items: [.pods, .deployments, .helmReleases]),
+            Section(
+                label: "Network", dot: DesignTokens.clusterViolet,
+                items: [.services, .ingresses]),
+            Section(
+                label: "Config", dot: DesignTokens.statusWarn,
+                items: [.configMaps, .secrets]),
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ForEach(sections, id: \.label) { section in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(section.label.uppercased())
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .kerning(0.7)
+                        .foregroundStyle(DesignTokens.textTertiary)
+                        .padding(.horizontal, 10)
+                        .padding(.bottom, 2)
+                    ForEach(section.items) { item in
+                        row(for: item, dot: section.dot)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 12)
+        .frame(width: 198)
+        .background(DesignTokens.surfacePanel)
+    }
+
+    private func count(for item: ResourceType) -> Int? {
+        switch item {
+        case .pods: podCount
+        case .deployments: deploymentCount
+        default: nil
+        }
+    }
+
+    private func row(for item: ResourceType, dot: Color) -> some View {
+        let isActive = selection == item
+        return Button {
+            selection = item
+        } label: {
+            HStack(spacing: 8) {
+                Circle().fill(dot).frame(width: 6, height: 6)
+                Text(item.rawValue)
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(
+                        isActive ? DesignTokens.textPrimary : DesignTokens.textSecondary)
+                Spacer(minLength: 0)
+                if let count = count(for: item) {
+                    Text("\(count)")
+                        .font(.system(size: 10.5, design: .monospaced))
+                        .foregroundStyle(DesignTokens.textTertiary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                isActive
+                    ? AnyShapeStyle(DesignTokens.accentDefault.opacity(0.14))
+                    : AnyShapeStyle(.clear),
+                in: RoundedRectangle(cornerRadius: DesignTokens.radiusMd)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}


### PR DESCRIPTION
Refs #249 — second brick of the macOS unified-UI port (after the token bridge in #264).

## What
Replaces the three-column `NavigationSplitView` with the unified Design System v1 chrome, entirely on the generated `DesignTokens` colors:

- **ClusterRailView** (58pt): All-Clusters home, identity avatars (initials + stable palette color by first-appearance order — same assignment rule as the desktop app), Preferences gear
- **UnifiedHeaderView** (42pt, `.hiddenTitleBar` window with 78pt traffic-light inset): identity dot + context name + Connected/Unreachable badge, `namespace:` menu, refresh, logs bell with unread-error badge
- **UnifiedSidebarView** (198pt): grouped navigation (Cluster / Workloads / Network / Config) with group-color dots and live pod/deployment counts
- **StatusBarView** (27pt): auto-refresh interval + clickable error count

## What did NOT change
All loaders, watchers, auto-refresh, selection state and the entire detail area are reused unchanged — only the composition root moved. The old NavigationSplitView-specific extensions stay for the namespace-input (403) edge case and will be retired in the views brick.

## Verification
- `xcodebuild build-for-testing` — **TEST BUILD SUCCEEDED**
- `xcodebuild test-without-building` (unit tests, UITests skipped per gate) — all passed
- No desktop/Rust changes

## Next bricks under #249
Views/drawers restyle on `KubeAPIService` data → Cmd+K palette + Cmd+1–5 shortcuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)