### PR TITLE
design(macos): unified list states and status palette

### DIFF
--- a/apps/macos/cubelite/cubelite/Helpers/K8sFormatters.swift
+++ b/apps/macos/cubelite/cubelite/Helpers/K8sFormatters.swift
@@ -34,37 +34,39 @@ extension Optional where Wrapped == String {
 // MARK: - Pod Phase Color
 
 extension Color {
-    /// Returns the display colour for a given Kubernetes pod phase string.
+    /// Returns the display colour for a given Kubernetes pod phase string,
+    /// mapped onto the Design System v1 status palette.
     ///
-    /// | Phase       | Color        |
-    /// |-------------|--------------|
-    /// | `Running`   | `.green`     |
-    /// | `Pending`   | `.orange`    |
-    /// | `Succeeded` | `.blue`      |
-    /// | `Failed`    | `.red`       |
-    /// | *(other)*   | `.secondary` |
+    /// | Phase       | Token             |
+    /// |-------------|-------------------|
+    /// | `Running`   | `statusOk`        |
+    /// | `Pending`   | `statusWarn`      |
+    /// | `Succeeded` | `statusInfo`      |
+    /// | `Failed`    | `statusErr`       |
+    /// | *(other)*   | `textTertiary`    |
     static func podPhase(_ phase: String?) -> Color {
         switch phase {
-        case "Running":   return .green
-        case "Pending":   return .orange
-        case "Succeeded": return .blue
-        case "Failed":    return .red
-        default:          return .secondary
+        case "Running":   return DesignTokens.statusOk
+        case "Pending":   return DesignTokens.statusWarn
+        case "Succeeded": return DesignTokens.statusInfo
+        case "Failed":    return DesignTokens.statusErr
+        default:          return DesignTokens.textTertiary
         }
     }
 
-    /// Returns the display colour for a Kubernetes deployment condition status string.
+    /// Returns the display colour for a Kubernetes deployment condition
+    /// status string, mapped onto the Design System v1 status palette.
     ///
-    /// | Status    | Color     |
-    /// |-----------|-----------|
-    /// | `True`    | `.green`  |
-    /// | `False`   | `.red`    |
-    /// | *(other)* | `.orange` |
+    /// | Status    | Token        |
+    /// |-----------|--------------|
+    /// | `True`    | `statusOk`   |
+    /// | `False`   | `statusErr`  |
+    /// | *(other)* | `statusWarn` |
     static func conditionStatus(_ status: String) -> Color {
         switch status {
-        case "True":  return .green
-        case "False": return .red
-        default:      return .orange
+        case "True":  return DesignTokens.statusOk
+        case "False": return DesignTokens.statusErr
+        default:      return DesignTokens.statusWarn
         }
     }
 }

--- a/apps/macos/cubelite/cubelite/Views/ConfigMapListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ConfigMapListView.swift
@@ -26,41 +26,15 @@ struct ConfigMapListView: View {
     // MARK: - States
 
     private var loadingView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading config maps…")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
+        UnifiedLoadingState(label: "Loading config maps…")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
-                .foregroundStyle(.orange)
-            Text("Failed to load config maps")
-                .font(.headline)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-        }
+        UnifiedErrorState(title: "Failed to load config maps", message: message)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "doc.text")
-                .font(.system(size: 36))
-                .foregroundStyle(.quinary)
-            Text("No config maps found")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("There are no config maps in this namespace.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
+        UnifiedEmptyState(message: "There are no config maps in this namespace.")
     }
 
     // MARK: - Table
@@ -96,6 +70,7 @@ struct ConfigMapListView: View {
             }
             .width(ideal: 60)
         }
+        .unifiedTableBackground()
     }
 }
 

--- a/apps/macos/cubelite/cubelite/Views/DeploymentListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/DeploymentListView.swift
@@ -27,41 +27,15 @@ struct DeploymentListView: View {
     // MARK: - States
 
     private var loadingView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading deployments…")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
+        UnifiedLoadingState(label: "Loading deployments…")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
-                .foregroundStyle(.orange)
-            Text("Failed to load deployments")
-                .font(.headline)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-        }
+        UnifiedErrorState(title: "Failed to load deployments", message: message)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "arrow.triangle.2.circlepath")
-                .font(.system(size: 36))
-                .foregroundStyle(.quinary)
-            Text("No deployments found")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("There are no deployments in this namespace.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
+        UnifiedEmptyState(message: "There are no deployments in this namespace.")
     }
 
     // MARK: - Table
@@ -94,6 +68,7 @@ struct DeploymentListView: View {
             .width(ideal: 80)
 
         }
+        .unifiedTableBackground()
     }
 
     // MARK: - Helpers

--- a/apps/macos/cubelite/cubelite/Views/HelmReleaseListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/HelmReleaseListView.swift
@@ -28,41 +28,15 @@ struct HelmReleaseListView: View {
     // MARK: - States
 
     private var loadingView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading Helm releases\u{2026}")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
+        UnifiedLoadingState(label: "Loading Helm releases\u{2026}")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
-                .foregroundStyle(.orange)
-            Text("Failed to load Helm releases")
-                .font(.headline)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-        }
+        UnifiedErrorState(title: "Failed to load Helm releases", message: message)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "shippingbox")
-                .font(.system(size: 36))
-                .foregroundStyle(.quinary)
-            Text("No Helm releases found")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("No Helm releases were detected in this namespace.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
+        UnifiedEmptyState(message: "No Helm releases were detected in this namespace.")
     }
 
     // MARK: - Table
@@ -103,6 +77,7 @@ struct HelmReleaseListView: View {
             }
             .width(ideal: 60)
         }
+        .unifiedTableBackground()
     }
 }
 

--- a/apps/macos/cubelite/cubelite/Views/IngressListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/IngressListView.swift
@@ -26,41 +26,15 @@ struct IngressListView: View {
     // MARK: - States
 
     private var loadingView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading ingresses…")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
+        UnifiedLoadingState(label: "Loading ingresses…")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
-                .foregroundStyle(.orange)
-            Text("Failed to load ingresses")
-                .font(.headline)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-        }
+        UnifiedErrorState(title: "Failed to load ingresses", message: message)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "globe")
-                .font(.system(size: 36))
-                .foregroundStyle(.quinary)
-            Text("No ingresses found")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("There are no ingresses in this namespace.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
+        UnifiedEmptyState(message: "There are no ingresses in this namespace.")
     }
 
     // MARK: - Table
@@ -126,5 +100,6 @@ struct IngressListView: View {
             }
             .width(ideal: 60)
         }
+        .unifiedTableBackground()
     }
 }

--- a/apps/macos/cubelite/cubelite/Views/PodListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PodListView.swift
@@ -28,41 +28,15 @@ struct PodListView: View {
     // MARK: - States
 
     private var loadingView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading pods…")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
+        UnifiedLoadingState(label: "Loading pods…")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
-                .foregroundStyle(.orange)
-            Text("Failed to load pods")
-                .font(.headline)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-        }
+        UnifiedErrorState(title: "Failed to load pods", message: message)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "cube.box")
-                .font(.system(size: 36))
-                .foregroundStyle(.quinary)
-            Text("No pods found")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("There are no pods in this namespace.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
+        UnifiedEmptyState(message: "There are no pods in this namespace.")
     }
 
     // MARK: - Table
@@ -131,6 +105,7 @@ struct PodListView: View {
             }
             .width(ideal: 90)
         }
+        .unifiedTableBackground()
     }
 
 }

--- a/apps/macos/cubelite/cubelite/Views/SecretListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/SecretListView.swift
@@ -27,41 +27,15 @@ struct SecretListView: View {
     // MARK: - States
 
     private var loadingView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading secrets…")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
+        UnifiedLoadingState(label: "Loading secrets…")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
-                .foregroundStyle(.orange)
-            Text("Failed to load secrets")
-                .font(.headline)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-        }
+        UnifiedErrorState(title: "Failed to load secrets", message: message)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "lock.shield")
-                .font(.system(size: 36))
-                .foregroundStyle(.quinary)
-            Text("No secrets found")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("There are no secrets in this namespace.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
+        UnifiedEmptyState(message: "There are no secrets in this namespace.")
     }
 
     // MARK: - Table
@@ -102,6 +76,7 @@ struct SecretListView: View {
             }
             .width(ideal: 60)
         }
+        .unifiedTableBackground()
     }
 }
 

--- a/apps/macos/cubelite/cubelite/Views/ServiceListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ServiceListView.swift
@@ -28,41 +28,15 @@ struct ServiceListView: View {
     // MARK: - States
 
     private var loadingView: some View {
-        VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading services…")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
+        UnifiedLoadingState(label: "Loading services…")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 32))
-                .foregroundStyle(.orange)
-            Text("Failed to load services")
-                .font(.headline)
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-        }
+        UnifiedErrorState(title: "Failed to load services", message: message)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "network")
-                .font(.system(size: 36))
-                .foregroundStyle(.quinary)
-            Text("No services found")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("There are no services in this namespace.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
+        UnifiedEmptyState(message: "There are no services in this namespace.")
     }
 
     // MARK: - Table
@@ -113,6 +87,7 @@ struct ServiceListView: View {
             }
             .width(ideal: 60)
         }
+        .unifiedTableBackground()
     }
 }
 

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedStates.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedStates.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+// MARK: - Unified list states (Design System v1)
+//
+// Shared loading / empty / error presentation for every resource list,
+// matching the desktop app: centered 12pt disabled text for empty states,
+// err-colored message for failures.
+
+/// Centered spinner with a caption while a list is loading.
+struct UnifiedLoadingState: View {
+    let label: String
+
+    var body: some View {
+        VStack(spacing: 10) {
+            ProgressView().controlSize(.small)
+            Text(label)
+                .font(.system(size: 12))
+                .foregroundStyle(DesignTokens.textDisabled)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Centered 12pt disabled message (spec empty state).
+struct UnifiedEmptyState: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.system(size: 12))
+            .foregroundStyle(DesignTokens.textDisabled)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Centered error presentation in the status err color.
+struct UnifiedErrorState: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 24))
+                .foregroundStyle(DesignTokens.statusErr)
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(DesignTokens.textPrimary)
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundStyle(DesignTokens.textTertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+extension View {
+    /// Places a `Table`/`List` on the unified panel background.
+    func unifiedTableBackground() -> some View {
+        scrollContentBackground(.hidden)
+            .background(DesignTokens.surfacePanel)
+    }
+}

--- a/apps/macos/cubelite/cubeliteTests/DeploymentDetailTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/DeploymentDetailTests.swift
@@ -111,21 +111,21 @@ final class DeploymentDetailTests: XCTestCase {
 
     // MARK: - Condition Status Color Mapping
 
-    func testConditionStatusColor_trueIsGreen() {
-        XCTAssertEqual(Color.conditionStatus("True"), Color.green)
+    func testConditionStatusColor_trueIsStatusOk() {
+        XCTAssertEqual(Color.conditionStatus("True"), DesignTokens.statusOk)
     }
 
-    func testConditionStatusColor_falseIsRed() {
-        XCTAssertEqual(Color.conditionStatus("False"), Color.red)
+    func testConditionStatusColor_falseIsStatusErr() {
+        XCTAssertEqual(Color.conditionStatus("False"), DesignTokens.statusErr)
     }
 
-    func testConditionStatusColor_unknownIsOrange() {
-        XCTAssertEqual(Color.conditionStatus("Unknown"), Color.orange)
+    func testConditionStatusColor_unknownIsStatusWarn() {
+        XCTAssertEqual(Color.conditionStatus("Unknown"), DesignTokens.statusWarn)
     }
 
-    func testConditionStatusColor_unrecognisedValueIsOrange() {
-        XCTAssertEqual(Color.conditionStatus(""), Color.orange)
-        XCTAssertEqual(Color.conditionStatus("maybe"), Color.orange)
+    func testConditionStatusColor_unrecognisedValueIsStatusWarn() {
+        XCTAssertEqual(Color.conditionStatus(""), DesignTokens.statusWarn)
+        XCTAssertEqual(Color.conditionStatus("maybe"), DesignTokens.statusWarn)
     }
 
     // MARK: - Helpers

--- a/apps/macos/cubelite/cubeliteTests/K8sFormattersTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/K8sFormattersTests.swift
@@ -120,49 +120,49 @@ final class K8sFormattersTests: XCTestCase {
     // MARK: Pod Phase Colors
 
     func testPodPhase_running_isGreen() {
-        XCTAssertEqual(Color.podPhase("Running"), .green)
+        XCTAssertEqual(Color.podPhase("Running"), DesignTokens.statusOk)
     }
 
     func testPodPhase_pending_isOrange() {
-        XCTAssertEqual(Color.podPhase("Pending"), .orange)
+        XCTAssertEqual(Color.podPhase("Pending"), DesignTokens.statusWarn)
     }
 
     func testPodPhase_succeeded_isBlue() {
-        XCTAssertEqual(Color.podPhase("Succeeded"), .blue)
+        XCTAssertEqual(Color.podPhase("Succeeded"), DesignTokens.statusInfo)
     }
 
     func testPodPhase_failed_isRed() {
-        XCTAssertEqual(Color.podPhase("Failed"), .red)
+        XCTAssertEqual(Color.podPhase("Failed"), DesignTokens.statusErr)
     }
 
     func testPodPhase_nil_isSecondary() {
-        XCTAssertEqual(Color.podPhase(nil), .secondary)
+        XCTAssertEqual(Color.podPhase(nil), DesignTokens.textTertiary)
     }
 
     func testPodPhase_unknown_isSecondary() {
-        XCTAssertEqual(Color.podPhase("Unknown"), .secondary)
+        XCTAssertEqual(Color.podPhase("Unknown"), DesignTokens.textTertiary)
     }
 
     func testPodPhase_caseSensitive_lowercaseReturnsSecondary() {
         // Kubernetes phases are case-sensitive: "running" ≠ "Running"
-        XCTAssertEqual(Color.podPhase("running"), .secondary)
+        XCTAssertEqual(Color.podPhase("running"), DesignTokens.textTertiary)
     }
 
     // MARK: Condition Status Colors
 
     func testConditionStatus_true_isGreen() {
-        XCTAssertEqual(Color.conditionStatus("True"), .green)
+        XCTAssertEqual(Color.conditionStatus("True"), DesignTokens.statusOk)
     }
 
     func testConditionStatus_false_isRed() {
-        XCTAssertEqual(Color.conditionStatus("False"), .red)
+        XCTAssertEqual(Color.conditionStatus("False"), DesignTokens.statusErr)
     }
 
     func testConditionStatus_unknown_isOrange() {
-        XCTAssertEqual(Color.conditionStatus("Unknown"), .orange)
+        XCTAssertEqual(Color.conditionStatus("Unknown"), DesignTokens.statusWarn)
     }
 
     func testConditionStatus_emptyString_isOrange() {
-        XCTAssertEqual(Color.conditionStatus(""), .orange)
+        XCTAssertEqual(Color.conditionStatus(""), DesignTokens.statusWarn)
     }
 }


### PR DESCRIPTION
Closes #249 — final brick of the macOS unified-UI port (tokens #264 → shell #265 → palette #266 → **views**).

## What
- `Color.podPhase` / `Color.conditionStatus` now map onto the Design System v1 **status tokens** (ok / warn / err / info, tertiary for unknown) — every list dot, pill and detail view follows the palette in one move, light and dark
- **UnifiedLoadingState / UnifiedEmptyState / UnifiedErrorState** shared components (centered 12pt disabled empty text per spec; err-colored failures) replace the ad-hoc per-view states in all seven resource lists (Pods, Deployments, Services, Secrets, ConfigMaps, Ingresses, Helm)
- Tables sit on the `surfacePanel` background (`unifiedTableBackground`)
- Unit tests updated to assert the token palette

## Umbrella status
With this merged, #249's breakdown is complete: token bridge, shell (rail/header/sidebar/status bar), ⌘K palette + ⌘1–5, views on the token language. Remaining macOS work (watch API, log streaming, actions, exec/port-forward, keychain…) is tracked by its own v0.3.0 issues.

## Verification
- `xcodebuild build-for-testing` — **TEST BUILD SUCCEEDED**
- `xcodebuild test-without-building` — 376+ unit tests; one unrelated flake (`LoadClientIdentityTests.testLoadClientIdentity_validECCertAndKey`, keychain race) passes in isolation
- No desktop/Rust changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)