### PR TITLE
feat(macos): pod actions — Describe, Restart, Delete with confirmation

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -252,6 +252,26 @@ actor KubeAPIService {
     private func fetch<T: Codable & Sendable>(path: String, contextName: String? = nil) async throws
         -> T
     {
+        let data = try await send(path: path, method: "GET", contextName: contextName)
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw CubeliteError.clientError(
+                reason: "Failed to decode API response: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// Performs an HTTP request against the cluster API server and returns
+    /// the raw response body. Shared by reads (`fetch`) and mutations.
+    private func send(
+        path: String,
+        method: String,
+        body: Data? = nil,
+        contentType: String? = nil,
+        contextName: String? = nil
+    ) async throws -> Data {
         let config = try await kubeconfigService.load()
         let (cluster, user) = try resolveConnectionInfo(from: config, contextName: contextName)
 
@@ -265,8 +285,12 @@ actor KubeAPIService {
         }
 
         var request = URLRequest(url: url)
-        request.httpMethod = "GET"
+        request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let body {
+            request.httpBody = body
+            request.setValue(contentType ?? "application/json", forHTTPHeaderField: "Content-Type")
+        }
 
         // Bearer token authentication
         if let token = user.token, !token.isEmpty {
@@ -319,14 +343,35 @@ actor KubeAPIService {
             )
         }
 
-        do {
-            let decoder = JSONDecoder()
-            return try decoder.decode(T.self, from: data)
-        } catch {
-            throw CubeliteError.clientError(
-                reason: "Failed to decode API response: \(error.localizedDescription)"
-            )
-        }
+        return data
+    }
+
+    // MARK: - Mutations
+
+    /// Deletes a pod; the owning controller (if any) recreates it.
+    func deletePod(namespace: String, name: String, inContext contextName: String? = nil)
+        async throws
+    {
+        _ = try await send(
+            path: "/api/v1/namespaces/\(namespace)/pods/\(name)",
+            method: "DELETE",
+            contextName: contextName
+        )
+    }
+
+    /// Fetches the raw pod manifest as pretty-printed JSON (Describe panel).
+    func podManifestJSON(namespace: String, name: String, inContext contextName: String? = nil)
+        async throws -> String
+    {
+        let data = try await send(
+            path: "/api/v1/namespaces/\(namespace)/pods/\(name)",
+            method: "GET",
+            contextName: contextName
+        )
+        let object = try JSONSerialization.jsonObject(with: data)
+        let pretty = try JSONSerialization.data(
+            withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+        return String(decoding: pretty, as: UTF8.self)
     }
 
     /// URL error codes that indicate the cluster server is unreachable.

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -135,8 +135,18 @@ extension MainView {
             DeploymentDetailView(deployment: dep)
                 .frame(minWidth: 320, idealWidth: 460, maxWidth: 600)
         case .pod:
-            ResourceDetailView(resource: resource)
-                .frame(minWidth: 260, idealWidth: 340, maxWidth: 420)
+            ResourceDetailView(
+                resource: resource,
+                kubeAPIService: kubeAPIService,
+                context: sidebarSelection?.context ?? selectedContext,
+                onPodMutated: {
+                    selectedPodID = nil
+                    if let sel = sidebarSelection {
+                        Task { await loadResources(context: sel.context, namespace: sel.namespace) }
+                    }
+                }
+            )
+            .frame(minWidth: 260, idealWidth: 340, maxWidth: 420)
         }
     }
 

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -16,6 +16,18 @@ enum SelectedResource: Sendable {
 struct ResourceDetailView: View {
 
     let resource: SelectedResource
+    /// Backend used by the pod actions; nil renders the detail read-only
+    /// (previews, tests).
+    var kubeAPIService: KubeAPIService?
+    /// Context the resource belongs to (required for actions).
+    var context: String?
+    /// Invoked after a successful mutation so the parent can reload.
+    var onPodMutated: (() -> Void)?
+
+    @State private var showDeleteConfirm = false
+    @State private var manifest: String?
+    @State private var actionError: String?
+    @State private var isActing = false
 
     var body: some View {
         ScrollView {
@@ -27,10 +39,128 @@ struct ResourceDetailView: View {
                 case .pod(let pod): podDetail(pod)
                 case .deployment(let dep): deploymentDetail(dep)
                 }
+                if case .pod(let pod) = resource, kubeAPIService != nil {
+                    podActions(pod)
+                }
             }
             .padding(20)
         }
         .background(Color(nsColor: .controlBackgroundColor))
+        .alert(
+            "Delete Pod", isPresented: $showDeleteConfirm, presenting: currentPod
+        ) { pod in
+            Button("Cancel", role: .cancel) {}
+            Button("Delete Pod", role: .destructive) {
+                runAction { service, ctx in
+                    try await service.deletePod(
+                        namespace: pod.namespace, name: pod.name, inContext: ctx)
+                }
+            }
+        } message: { pod in
+            Text("This will delete \(pod.name) in namespace \(pod.namespace). "
+                + "The workload controller may recreate it.")
+        }
+        .sheet(item: $manifestItem) { item in
+            manifestSheet(item.text)
+        }
+        .alert(
+            "Action failed", isPresented: .constant(actionError != nil),
+            actions: {
+                Button("OK") { actionError = nil }
+            },
+            message: { Text(actionError ?? "") }
+        )
+    }
+
+    private var currentPod: PodInfo? {
+        if case .pod(let pod) = resource { return pod }
+        return nil
+    }
+
+    // MARK: - Pod Actions
+
+    private func podActions(_ pod: PodInfo) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider().padding(.vertical, 8)
+            HStack(spacing: 8) {
+                Button {
+                    runAction { service, ctx in
+                        let text = try await service.podManifestJSON(
+                            namespace: pod.namespace, name: pod.name, inContext: ctx)
+                        manifestItem = ManifestItem(text: text)
+                    }
+                } label: {
+                    Label("Describe", systemImage: "doc.text.magnifyingglass")
+                }
+                Button {
+                    // A pod "restart" is a delete; the controller recreates it.
+                    runAction { service, ctx in
+                        try await service.deletePod(
+                            namespace: pod.namespace, name: pod.name, inContext: ctx)
+                    }
+                } label: {
+                    Label("Restart", systemImage: "arrow.clockwise")
+                }
+                Button(role: .destructive) {
+                    showDeleteConfirm = true
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+            .controlSize(.small)
+            .disabled(isActing)
+            if isActing {
+                ProgressView().controlSize(.small)
+            }
+        }
+    }
+
+    @State private var manifestItem: ManifestItem?
+
+    private struct ManifestItem: Identifiable {
+        let id = UUID()
+        let text: String
+    }
+
+    private func manifestSheet(_ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("\(resourceName) — manifest")
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                Button("Done") { manifestItem = nil }
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(12)
+            Divider()
+            ScrollView([.vertical, .horizontal]) {
+                Text(text)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(DesignTokens.textLog)
+                    .textSelection(.enabled)
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(DesignTokens.surfaceSunken)
+        }
+        .frame(minWidth: 560, minHeight: 420)
+    }
+
+    /// Runs a mutation with the shared spinner/error handling; reloads on success.
+    private func runAction(
+        _ operation: @escaping (KubeAPIService, String?) async throws -> Void
+    ) {
+        guard let service = kubeAPIService else { return }
+        isActing = true
+        Task {
+            defer { isActing = false }
+            do {
+                try await operation(service, context)
+                onPodMutated?()
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
     }
 
     // MARK: - Header


### PR DESCRIPTION
Closes #110

## Backend (KubeAPIService)
- `fetch` refactored onto a shared `send(path:method:body:)` — auth, per-server session caching and TLS/connection/403 error mapping now serve reads **and** mutations
- `deletePod` (DELETE; the owning controller recreates) and `podManifestJSON` (pretty-printed raw manifest)

## UI (pod detail panel)
- **Describe**: monospaced manifest sheet on the `surfaceSunken` token, text-selectable
- **Restart**: deletes the pod inline (controller recreates) with spinner
- **Delete**: destructive confirmation alert repeating pod name + namespace before the call
- Error alert on failure; on success the parent clears the selection and reloads the list

## Verification
- `xcodebuild build-for-testing` — **TEST BUILD SUCCEEDED**
- `xcodebuild test-without-building` — **377 tests passed, exit 0** (including the previously flaky keychain test)
- No desktop/Rust changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)