### PR TITLE
feat(macos): Nodes resource view (read-only)

### DIFF
--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -14,6 +14,8 @@ final class ClusterState {
 
     /// Pods in the selected namespace (or all namespaces).
     var pods: [PodInfo] = []
+    /// Cluster nodes (read-only inventory; empty when RBAC denies nodes).
+    var nodes: [NodeInfo] = []
 
     /// Available namespaces for the currently browsed context.
     var namespaces: [NamespaceInfo] = []
@@ -85,6 +87,8 @@ enum ResourceType: String, CaseIterable, Identifiable {
     case ingresses = "Ingresses"
     /// Helm Releases resource type.
     case helmReleases = "Helm Releases"
+    /// Cluster nodes (read-only).
+    case nodes = "Nodes"
 
     var id: String { rawValue }
 
@@ -98,6 +102,7 @@ enum ResourceType: String, CaseIterable, Identifiable {
         case .configMaps: "doc.text"
         case .ingresses: "globe"
         case .helmReleases: "shippingbox"
+        case .nodes: "server.rack"
         }
     }
 }

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -117,6 +117,63 @@ struct DeploymentCondition: Codable, Sendable, Identifiable {
 // MARK: - Kubernetes API Response Types
 
 /// Generic list response from the Kubernetes API.
+/// Display model for a cluster node (read-only inventory).
+struct NodeInfo: Codable, Sendable, Identifiable {
+    var id: String { name }
+
+    let name: String
+    /// `"Ready"` / `"NotReady"` from the Ready condition.
+    let status: String
+    /// Roles from `node-role.kubernetes.io/*` labels.
+    let roles: [String]
+    /// Kubelet version.
+    let version: String?
+    /// ISO 8601 creation timestamp.
+    let creationTimestamp: String?
+}
+
+/// Raw Kubernetes node as returned by the API.
+struct K8sNode: Codable, Sendable {
+    let metadata: K8sObjectMeta?
+    let status: K8sNodeStatus?
+}
+
+/// Node status: conditions + kubelet info.
+struct K8sNodeStatus: Codable, Sendable {
+    let conditions: [K8sNodeCondition]?
+    let nodeInfo: K8sNodeSystemInfo?
+}
+
+/// One node condition entry.
+struct K8sNodeCondition: Codable, Sendable {
+    let type: String
+    let status: String
+}
+
+/// Subset of the node system info.
+struct K8sNodeSystemInfo: Codable, Sendable {
+    let kubeletVersion: String?
+}
+
+extension K8sNode {
+    /// Maps the raw node onto the display model.
+    func toNodeInfo() -> NodeInfo {
+        let ready = status?.conditions?.first(where: { $0.type == "Ready" })?.status == "True"
+        let roles = (metadata?.labels ?? [:])
+            .keys
+            .compactMap { $0.hasPrefix("node-role.kubernetes.io/") ? String($0.dropFirst(24)) : nil }
+            .filter { !$0.isEmpty }
+            .sorted()
+        return NodeInfo(
+            name: metadata?.name ?? "",
+            status: ready ? "Ready" : "NotReady",
+            roles: roles,
+            version: status?.nodeInfo?.kubeletVersion,
+            creationTimestamp: metadata?.creationTimestamp
+        )
+    }
+}
+
 struct K8sListResponse<T: Codable & Sendable>: Codable, Sendable {
     let kind: String?
     let apiVersion: String?

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -346,6 +346,13 @@ actor KubeAPIService {
         return data
     }
 
+    /// Lists cluster nodes (read-only; requires nodes RBAC).
+    func listNodes(inContext contextName: String? = nil) async throws -> [NodeInfo] {
+        let response: K8sListResponse<K8sNode> = try await fetch(
+            path: "/api/v1/nodes", contextName: contextName)
+        return response.items.map { $0.toNodeInfo() }
+    }
+
     // MARK: - Mutations
 
     /// Deletes a pod; the owning controller (if any) recreates it.

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -29,7 +29,8 @@ extension MainView {
             switch selectedResourceType ?? .dashboard {
             case .dashboard:
                 DashboardView()
-            case .pods, .deployments, .services, .secrets, .configMaps, .ingresses, .helmReleases:
+            case .pods, .deployments, .services, .secrets, .configMaps, .ingresses,
+                .helmReleases, .nodes:
                 resourceBrowserView(context: sel.context, namespace: sel.namespace)
             }
         } else {
@@ -115,6 +116,8 @@ extension MainView {
                             selectedPodID = nil
                             selectedDeploymentID = nil
                         }
+                case .nodes:
+                    NodeListView()
                 case .dashboard:
                     EmptyView()
                 }

--- a/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
@@ -63,6 +63,10 @@ extension MainView {
             return
         }
 
+        // Nodes (cluster-scoped, best-effort: RBAC commonly denies them and
+        // the rest of the views must keep working).
+        clusterState.nodes = (try? await kubeAPIService.listNodes(inContext: context)) ?? []
+
         // Deployments
         if let deployments = await fetchResource("deployments", {
             try await kubeAPIService.listDeployments(namespace: namespace, inContext: context)

--- a/apps/macos/cubelite/cubelite/Views/NodeListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/NodeListView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Table listing cluster nodes (read-only inventory).
+///
+/// Columns: Status, Name, Roles, Version, Age. Nodes are cluster-scoped and
+/// loaded best-effort: when RBAC denies them the list is simply empty.
+struct NodeListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                UnifiedLoadingState(label: "Loading nodes…")
+            } else if clusterState.nodes.isEmpty {
+                UnifiedEmptyState(
+                    message: "No nodes visible — the cluster may deny node listing.")
+            } else {
+                nodeTable
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var nodeTable: some View {
+        Table(clusterState.nodes) {
+            TableColumn("") { node in
+                Circle()
+                    .fill(
+                        node.status == "Ready"
+                            ? DesignTokens.statusOk : DesignTokens.statusErr
+                    )
+                    .frame(width: 8, height: 8)
+                    .help(node.status)
+            }
+            .width(16)
+
+            TableColumn("Name") { node in
+                Text(node.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+
+            TableColumn("Status") { node in
+                Text(node.status)
+                    .foregroundStyle(
+                        node.status == "Ready"
+                            ? DesignTokens.statusOk : DesignTokens.statusErr)
+            }
+            .width(90)
+
+            TableColumn("Roles") { node in
+                Text(node.roles.isEmpty ? "—" : node.roles.joined(separator: ", "))
+                    .foregroundStyle(DesignTokens.textSecondary)
+                    .lineLimit(1)
+            }
+
+            TableColumn("Version") { node in
+                Text(node.version ?? "—")
+                    .font(.callout.monospaced())
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(110)
+
+            TableColumn("Age") { node in
+                Text(node.creationTimestamp.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(70)
+        }
+        .unifiedTableBackground()
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -17,7 +17,9 @@ struct UnifiedSidebarView: View {
 
     private var sections: [Section] {
         [
-            Section(label: "Cluster", dot: DesignTokens.accentDefault, items: [.dashboard]),
+            Section(
+                label: "Cluster", dot: DesignTokens.accentDefault,
+                items: [.dashboard, .nodes]),
             Section(
                 label: "Workloads", dot: DesignTokens.clusterBlue,
                 items: [.pods, .deployments, .helmReleases]),

--- a/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
@@ -147,7 +147,7 @@ final class ResourceTypeTests: XCTestCase {
 
     func testCaseIterable_containsAllCases() {
         let all = ResourceType.allCases
-        XCTAssertEqual(all.count, 8)
+        XCTAssertEqual(all.count, 9)
         XCTAssertTrue(all.contains(.dashboard))
         XCTAssertTrue(all.contains(.pods))
         XCTAssertTrue(all.contains(.deployments))
@@ -156,5 +156,6 @@ final class ResourceTypeTests: XCTestCase {
         XCTAssertTrue(all.contains(.configMaps))
         XCTAssertTrue(all.contains(.ingresses))
         XCTAssertTrue(all.contains(.helmReleases))
+        XCTAssertTrue(all.contains(.nodes))
     }
 }

--- a/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
@@ -234,8 +234,8 @@ final class MainViewStateTests: XCTestCase {
         XCTAssertEqual(ResourceType.deployments.rawValue, "Deployments")
     }
 
-    func testResourceType_allCases_countIsThree() {
-        XCTAssertEqual(ResourceType.allCases.count, 8)
+    func testResourceType_allCases_matchesEnum() {
+        XCTAssertEqual(ResourceType.allCases.count, 9)
     }
 
     func testResourceType_pods_hasSystemImage() {


### PR DESCRIPTION
Closes #113 — sub-issue of #77.

- `NodeInfo` display model + `K8sNode` decoding (Ready condition → status, `node-role.kubernetes.io/*` labels → roles, kubelet version)
- `KubeAPIService.listNodes` (`/api/v1/nodes`)
- Loaded **best-effort** with the resource batch: RBAC commonly denies cluster-scoped node listing, so failures degrade to an empty list with an explanatory empty state instead of breaking the other views
- `NodeListView` on the unified table style (status dot ok/err, mono name/version, roles, age) + **Nodes** entry in the sidebar Cluster group
- ResourceType tests updated

## Verification
`xcodebuild build-for-testing` + full unit suite: **exit 0, 376+ passed**. No desktop/Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)