### PR TITLE
feat(macos): Jobs resource view

### DIFF
--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -24,6 +24,8 @@ final class ClusterState {
     var deployments: [DeploymentInfo] = []
     /// Batch jobs in the selected namespace.
     var jobs: [JobInfo] = []
+    /// Stateful sets in the selected namespace.
+    var statefulSets: [StatefulSetInfo] = []
 
     /// Services in the selected namespace.
     var services: [ServiceInfo] = []
@@ -89,6 +91,8 @@ enum ResourceType: String, CaseIterable, Identifiable {
     case ingresses = "Ingresses"
     /// Helm Releases resource type.
     case helmReleases = "Helm Releases"
+    /// Stateful sets.
+    case statefulSets = "StatefulSets"
     /// Batch jobs.
     case jobs = "Jobs"
     /// Cluster nodes (read-only).
@@ -106,6 +110,7 @@ enum ResourceType: String, CaseIterable, Identifiable {
         case .configMaps: "doc.text"
         case .ingresses: "globe"
         case .helmReleases: "shippingbox"
+        case .statefulSets: "externaldrive.badge.timemachine"
         case .jobs: "checklist"
         case .nodes: "server.rack"
         }

--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -22,6 +22,8 @@ final class ClusterState {
 
     /// Deployments in the selected namespace.
     var deployments: [DeploymentInfo] = []
+    /// Batch jobs in the selected namespace.
+    var jobs: [JobInfo] = []
 
     /// Services in the selected namespace.
     var services: [ServiceInfo] = []
@@ -87,6 +89,8 @@ enum ResourceType: String, CaseIterable, Identifiable {
     case ingresses = "Ingresses"
     /// Helm Releases resource type.
     case helmReleases = "Helm Releases"
+    /// Batch jobs.
+    case jobs = "Jobs"
     /// Cluster nodes (read-only).
     case nodes = "Nodes"
 
@@ -102,6 +106,7 @@ enum ResourceType: String, CaseIterable, Identifiable {
         case .configMaps: "doc.text"
         case .ingresses: "globe"
         case .helmReleases: "shippingbox"
+        case .jobs: "checklist"
         case .nodes: "server.rack"
         }
     }

--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -14,6 +14,8 @@ final class ClusterState {
 
     /// Pods in the selected namespace (or all namespaces).
     var pods: [PodInfo] = []
+    /// Cluster nodes (read-only inventory; empty when RBAC denies nodes).
+    var nodes: [NodeInfo] = []
 
     /// Available namespaces for the currently browsed context.
     var namespaces: [NamespaceInfo] = []
@@ -85,6 +87,8 @@ enum ResourceType: String, CaseIterable, Identifiable {
     case ingresses = "Ingresses"
     /// Helm Releases resource type.
     case helmReleases = "Helm Releases"
+    /// Cluster nodes (read-only).
+    case nodes = "Nodes"
 
     var id: String { rawValue }
 
@@ -98,6 +102,7 @@ enum ResourceType: String, CaseIterable, Identifiable {
         case .configMaps: "doc.text"
         case .ingresses: "globe"
         case .helmReleases: "shippingbox"
+        case .nodes: "server.rack"
         }
     }
 }

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -169,6 +169,50 @@ extension K8sJob {
     }
 }
 
+/// Display model for a StatefulSet.
+struct StatefulSetInfo: Codable, Sendable, Identifiable {
+    var id: String { "\(namespace)/\(name)" }
+
+    let name: String
+    let namespace: String
+    /// Desired replicas.
+    let replicas: Int
+    /// Replicas currently reporting ready.
+    let readyReplicas: Int
+    /// ISO 8601 creation timestamp.
+    let creationTimestamp: String?
+}
+
+/// Raw Kubernetes stateful set as returned by the API.
+struct K8sStatefulSet: Codable, Sendable {
+    let metadata: K8sObjectMeta?
+    let spec: K8sStatefulSetSpec?
+    let status: K8sStatefulSetStatus?
+}
+
+/// StatefulSet spec subset.
+struct K8sStatefulSetSpec: Codable, Sendable {
+    let replicas: Int?
+}
+
+/// StatefulSet status subset.
+struct K8sStatefulSetStatus: Codable, Sendable {
+    let readyReplicas: Int?
+}
+
+extension K8sStatefulSet {
+    /// Maps the raw stateful set onto the display model.
+    func toStatefulSetInfo() -> StatefulSetInfo {
+        StatefulSetInfo(
+            name: metadata?.name ?? "",
+            namespace: metadata?.namespace ?? "",
+            replicas: spec?.replicas ?? 0,
+            readyReplicas: status?.readyReplicas ?? 0,
+            creationTimestamp: metadata?.creationTimestamp
+        )
+    }
+}
+
 /// Display model for a cluster node (read-only inventory).
 struct NodeInfo: Codable, Sendable, Identifiable {
     var id: String { name }

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -117,6 +117,63 @@ struct DeploymentCondition: Codable, Sendable, Identifiable {
 // MARK: - Kubernetes API Response Types
 
 /// Generic list response from the Kubernetes API.
+/// Display model for a cluster node (read-only inventory).
+struct NodeInfo: Codable, Sendable, Identifiable {
+    var id: String { name }
+
+    let name: String
+    /// `"Ready"` / `"NotReady"` from the Ready condition.
+    let status: String
+    /// Roles from `node-role.kubernetes.io/*` labels.
+    let roles: [String]
+    /// Kubelet version.
+    let version: String?
+    /// ISO 8601 creation timestamp.
+    let creationTimestamp: String?
+}
+
+/// Raw Kubernetes node as returned by the API.
+struct K8sNode: Codable, Sendable {
+    let metadata: K8sObjectMeta?
+    let status: K8sNodeStatus?
+}
+
+/// Node status: conditions + kubelet info.
+struct K8sNodeStatus: Codable, Sendable {
+    let conditions: [K8sNodeCondition]?
+    let nodeInfo: K8sNodeSystemInfo?
+}
+
+/// One node condition entry.
+struct K8sNodeCondition: Codable, Sendable {
+    let type: String
+    let status: String
+}
+
+/// Subset of the node system info.
+struct K8sNodeSystemInfo: Codable, Sendable {
+    let kubeletVersion: String?
+}
+
+extension K8sNode {
+    /// Maps the raw node onto the display model.
+    func toNodeInfo() -> NodeInfo {
+        let ready = status?.conditions?.first(where: { $0.type == "Ready" })?.status == "True"
+        let roles = (metadata?.labels ?? [:])
+            .keys
+            .compactMap { $0.hasPrefix("node-role.kubernetes.io/") ? String($0.dropFirst(24)) : nil }
+            .filter { !$0.isEmpty }
+            .sorted()
+        return NodeInfo(
+            name: metadata?.name ?? "",
+            status: ready ? "Ready" : "NotReady",
+            roles: roles,
+            version: status?.nodeInfo?.kubeletVersion,
+            creationTimestamp: metadata?.creationTimestamp
+        )
+    }
+}
+
 struct K8sListResponse<T: Codable & Sendable>: Codable, Sendable {
     let kind: String?
     let apiVersion: String?

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -117,6 +117,58 @@ struct DeploymentCondition: Codable, Sendable, Identifiable {
 // MARK: - Kubernetes API Response Types
 
 /// Generic list response from the Kubernetes API.
+/// Display model for a batch Job.
+struct JobInfo: Codable, Sendable, Identifiable {
+    var id: String { "\(namespace)/\(name)" }
+
+    let name: String
+    let namespace: String
+    /// Desired completions (spec.completions, defaults to 1).
+    let completions: Int
+    /// Pods completed successfully.
+    let succeeded: Int
+    /// Pods currently running.
+    let active: Int
+    /// Pods that failed.
+    let failed: Int
+    /// ISO 8601 creation timestamp.
+    let creationTimestamp: String?
+}
+
+/// Raw Kubernetes job as returned by the API.
+struct K8sJob: Codable, Sendable {
+    let metadata: K8sObjectMeta?
+    let spec: K8sJobSpec?
+    let status: K8sJobStatus?
+}
+
+/// Job spec subset.
+struct K8sJobSpec: Codable, Sendable {
+    let completions: Int?
+}
+
+/// Job status counters.
+struct K8sJobStatus: Codable, Sendable {
+    let succeeded: Int?
+    let active: Int?
+    let failed: Int?
+}
+
+extension K8sJob {
+    /// Maps the raw job onto the display model.
+    func toJobInfo() -> JobInfo {
+        JobInfo(
+            name: metadata?.name ?? "",
+            namespace: metadata?.namespace ?? "",
+            completions: spec?.completions ?? 1,
+            succeeded: status?.succeeded ?? 0,
+            active: status?.active ?? 0,
+            failed: status?.failed ?? 0,
+            creationTimestamp: metadata?.creationTimestamp
+        )
+    }
+}
+
 /// Display model for a cluster node (read-only inventory).
 struct NodeInfo: Codable, Sendable, Identifiable {
     var id: String { name }

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -346,6 +346,22 @@ actor KubeAPIService {
         return data
     }
 
+    /// Lists batch jobs, optionally scoped to a namespace and/or context.
+    func listJobs(namespace: String? = nil, inContext contextName: String? = nil) async throws
+        -> [JobInfo]
+    {
+        let path: String
+        if let ns = namespace {
+            let encoded = ns.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ns
+            path = "/apis/batch/v1/namespaces/\(encoded)/jobs"
+        } else {
+            path = "/apis/batch/v1/jobs"
+        }
+        let response: K8sListResponse<K8sJob> = try await fetch(
+            path: path, contextName: contextName)
+        return response.items.map { $0.toJobInfo() }
+    }
+
     /// Lists cluster nodes (read-only; requires nodes RBAC).
     func listNodes(inContext contextName: String? = nil) async throws -> [NodeInfo] {
         let response: K8sListResponse<K8sNode> = try await fetch(

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -362,6 +362,22 @@ actor KubeAPIService {
         return response.items.map { $0.toJobInfo() }
     }
 
+    /// Lists stateful sets, optionally scoped to a namespace and/or context.
+    func listStatefulSets(namespace: String? = nil, inContext contextName: String? = nil)
+        async throws -> [StatefulSetInfo]
+    {
+        let path: String
+        if let ns = namespace {
+            let encoded = ns.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ns
+            path = "/apis/apps/v1/namespaces/\(encoded)/statefulsets"
+        } else {
+            path = "/apis/apps/v1/statefulsets"
+        }
+        let response: K8sListResponse<K8sStatefulSet> = try await fetch(
+            path: path, contextName: contextName)
+        return response.items.map { $0.toStatefulSetInfo() }
+    }
+
     /// Lists cluster nodes (read-only; requires nodes RBAC).
     func listNodes(inContext contextName: String? = nil) async throws -> [NodeInfo] {
         let response: K8sListResponse<K8sNode> = try await fetch(

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -385,6 +385,67 @@ actor KubeAPIService {
         return response.items.map { $0.toNodeInfo() }
     }
 
+    // MARK: - Log Streaming
+
+    /// Follows a pod's log as an async stream of raw lines
+    /// (`tailLines` history first, then live lines until cancelled).
+    func streamPodLogs(
+        namespace: String,
+        pod: String,
+        tailLines: Int = 100,
+        inContext contextName: String? = nil
+    ) async throws -> AsyncThrowingStream<String, Error> {
+        let config = try await kubeconfigService.load()
+        let (cluster, user) = try resolveConnectionInfo(from: config, contextName: contextName)
+
+        guard let serverString = cluster.server, !serverString.isEmpty else {
+            throw CubeliteError.clientError(reason: "Cluster has no valid server URL")
+        }
+        let base = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
+        let path =
+            "/api/v1/namespaces/\(namespace)/pods/\(pod)/log"
+            + "?follow=true&timestamps=true&tailLines=\(tailLines)"
+        guard let url = URL(string: base + path) else {
+            throw CubeliteError.clientError(reason: "Invalid URL: \(base + path)")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        if let token = user.token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let session: URLSession
+        if let cached = sessionCache[base] {
+            session = cached
+        } else {
+            let newSession = try makeSession(cluster: cluster, user: user)
+            sessionCache[base] = newSession
+            session = newSession
+        }
+
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode)
+        else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw CubeliteError.clientError(reason: "Log stream failed: HTTP \(code)")
+        }
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    for try await line in bytes.lines {
+                        continuation.yield(line)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
     // MARK: - Mutations
 
     /// Deletes a pod; the owning controller (if any) recreates it.

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -346,6 +346,13 @@ actor KubeAPIService {
         return data
     }
 
+    /// Lists cluster nodes (read-only; requires nodes RBAC).
+    func listNodes(inContext contextName: String? = nil) async throws -> [NodeInfo] {
+        let response: K8sListResponse<K8sNode> = try await fetch(
+            path: "/api/v1/nodes", contextName: contextName)
+        return response.items.map { $0.toNodeInfo() }
+    }
+
     // MARK: - Mutations
 
     /// Deletes a pod; the owning controller (if any) recreates it.

--- a/apps/macos/cubelite/cubelite/Views/JobListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/JobListView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Table listing batch Jobs for the selected context and namespace.
+///
+/// Columns: Status, Name, Completions, Active, Failed, Age.
+struct JobListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                UnifiedLoadingState(label: "Loading jobs…")
+            } else if let error = clusterState.resourceError {
+                UnifiedErrorState(title: "Failed to load jobs", message: error)
+            } else if clusterState.jobs.isEmpty {
+                UnifiedEmptyState(message: "There are no jobs in this namespace.")
+            } else {
+                jobTable
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func tone(for job: JobInfo) -> Color {
+        if job.failed > 0 { return DesignTokens.statusErr }
+        if job.active > 0 { return DesignTokens.statusWarn }
+        if job.succeeded >= job.completions { return DesignTokens.statusOk }
+        return DesignTokens.textTertiary
+    }
+
+    private var jobTable: some View {
+        Table(clusterState.jobs) {
+            TableColumn("") { job in
+                Circle()
+                    .fill(tone(for: job))
+                    .frame(width: 8, height: 8)
+            }
+            .width(16)
+
+            TableColumn("Name") { job in
+                Text(job.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+
+            TableColumn("Completions") { job in
+                Text("\(job.succeeded)/\(job.completions)")
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(90)
+
+            TableColumn("Active") { job in
+                Text("\(job.active)")
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(60)
+
+            TableColumn("Failed") { job in
+                Text("\(job.failed)")
+                    .foregroundStyle(
+                        job.failed > 0 ? DesignTokens.statusErr : DesignTokens.textSecondary)
+            }
+            .width(60)
+
+            TableColumn("Age") { job in
+                Text(job.creationTimestamp.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(70)
+        }
+        .unifiedTableBackground()
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -29,7 +29,8 @@ extension MainView {
             switch selectedResourceType ?? .dashboard {
             case .dashboard:
                 DashboardView()
-            case .pods, .deployments, .services, .secrets, .configMaps, .ingresses, .helmReleases:
+            case .pods, .deployments, .services, .secrets, .configMaps, .ingresses,
+                .helmReleases, .nodes:
                 resourceBrowserView(context: sel.context, namespace: sel.namespace)
             }
         } else {
@@ -115,6 +116,8 @@ extension MainView {
                             selectedPodID = nil
                             selectedDeploymentID = nil
                         }
+                case .nodes:
+                    NodeListView()
                 case .dashboard:
                     EmptyView()
                 }

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -30,7 +30,7 @@ extension MainView {
             case .dashboard:
                 DashboardView()
             case .pods, .deployments, .services, .secrets, .configMaps, .ingresses,
-                .helmReleases, .nodes, .jobs:
+                .helmReleases, .nodes, .jobs, .statefulSets:
                 resourceBrowserView(context: sel.context, namespace: sel.namespace)
             }
         } else {
@@ -116,6 +116,8 @@ extension MainView {
                             selectedPodID = nil
                             selectedDeploymentID = nil
                         }
+                case .statefulSets:
+                    StatefulSetListView()
                 case .jobs:
                     JobListView()
                 case .nodes:

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -30,7 +30,7 @@ extension MainView {
             case .dashboard:
                 DashboardView()
             case .pods, .deployments, .services, .secrets, .configMaps, .ingresses,
-                .helmReleases, .nodes:
+                .helmReleases, .nodes, .jobs:
                 resourceBrowserView(context: sel.context, namespace: sel.namespace)
             }
         } else {
@@ -116,6 +116,8 @@ extension MainView {
                             selectedPodID = nil
                             selectedDeploymentID = nil
                         }
+                case .jobs:
+                    JobListView()
                 case .nodes:
                     NodeListView()
                 case .dashboard:

--- a/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
@@ -63,6 +63,16 @@ extension MainView {
             return
         }
 
+        // StatefulSets
+        if let statefulSets = await fetchResource("statefulsets", {
+            try await kubeAPIService.listStatefulSets(namespace: namespace, inContext: context)
+        }) {
+            clusterState.statefulSets = statefulSets
+        } else if fatalError != nil {
+            finishResourceLoad(fatalError: fatalError, forbidden: forbidden, namespace: namespace)
+            return
+        }
+
         // Jobs
         if let jobs = await fetchResource("jobs", {
             try await kubeAPIService.listJobs(namespace: namespace, inContext: context)

--- a/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
@@ -63,6 +63,16 @@ extension MainView {
             return
         }
 
+        // Jobs
+        if let jobs = await fetchResource("jobs", {
+            try await kubeAPIService.listJobs(namespace: namespace, inContext: context)
+        }) {
+            clusterState.jobs = jobs
+        } else if fatalError != nil {
+            finishResourceLoad(fatalError: fatalError, forbidden: forbidden, namespace: namespace)
+            return
+        }
+
         // Nodes (cluster-scoped, best-effort: RBAC commonly denies them and
         // the rest of the views must keep working).
         clusterState.nodes = (try? await kubeAPIService.listNodes(inContext: context)) ?? []

--- a/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
@@ -63,6 +63,10 @@ extension MainView {
             return
         }
 
+        // Nodes (cluster-scoped, best-effort: RBAC commonly denies them and
+        // the rest of the views must keep working).
+        clusterState.nodes = (try? await kubeAPIService.listNodes(inContext: context)) ?? []
+
         // Deployments
         if let deployments = await fetchResource("deployments", {
             try await kubeAPIService.listDeployments(namespace: namespace, inContext: context)

--- a/apps/macos/cubelite/cubelite/Views/NodeListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/NodeListView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Table listing cluster nodes (read-only inventory).
+///
+/// Columns: Status, Name, Roles, Version, Age. Nodes are cluster-scoped and
+/// loaded best-effort: when RBAC denies them the list is simply empty.
+struct NodeListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                UnifiedLoadingState(label: "Loading nodes…")
+            } else if clusterState.nodes.isEmpty {
+                UnifiedEmptyState(
+                    message: "No nodes visible — the cluster may deny node listing.")
+            } else {
+                nodeTable
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var nodeTable: some View {
+        Table(clusterState.nodes) {
+            TableColumn("") { node in
+                Circle()
+                    .fill(
+                        node.status == "Ready"
+                            ? DesignTokens.statusOk : DesignTokens.statusErr
+                    )
+                    .frame(width: 8, height: 8)
+                    .help(node.status)
+            }
+            .width(16)
+
+            TableColumn("Name") { node in
+                Text(node.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+
+            TableColumn("Status") { node in
+                Text(node.status)
+                    .foregroundStyle(
+                        node.status == "Ready"
+                            ? DesignTokens.statusOk : DesignTokens.statusErr)
+            }
+            .width(90)
+
+            TableColumn("Roles") { node in
+                Text(node.roles.isEmpty ? "—" : node.roles.joined(separator: ", "))
+                    .foregroundStyle(DesignTokens.textSecondary)
+                    .lineLimit(1)
+            }
+
+            TableColumn("Version") { node in
+                Text(node.version ?? "—")
+                    .font(.callout.monospaced())
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(110)
+
+            TableColumn("Age") { node in
+                Text(node.creationTimestamp.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(70)
+        }
+        .unifiedTableBackground()
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/PodLogsView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PodLogsView.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+/// Live pod log viewer (Design System v1): follows the pod's log via the
+/// streaming API, colors detected severities, supports pause and clear.
+struct PodLogsView: View {
+
+    let pod: PodInfo
+    let kubeAPIService: KubeAPIService
+    let context: String?
+    let onClose: () -> Void
+
+    private static let bufferCap = 500
+
+    @State private var lines: [LogLine] = []
+    @State private var following = true
+    @State private var streamError: String?
+    @State private var streamTask: Task<Void, Never>?
+
+    /// One parsed log line.
+    struct LogLine: Identifiable {
+        let id: Int
+        let time: String?
+        let level: Level
+        let message: String
+
+        enum Level {
+            case info, warn, error
+
+            var color: Color {
+                switch self {
+                case .info: DesignTokens.statusInfo
+                case .warn: DesignTokens.statusWarn
+                case .error: DesignTokens.statusErr
+                }
+            }
+
+            var label: String {
+                switch self {
+                case .info: "INFO"
+                case .warn: "WARN"
+                case .error: "ERROR"
+                }
+            }
+        }
+
+        /// Splits the kubelet RFC 3339 prefix and detects the severity.
+        static func parse(_ raw: String, id: Int) -> LogLine {
+            var time: String?
+            var message = raw
+            if let space = raw.firstIndex(of: " "),
+                raw[raw.startIndex..<space].contains("T"),
+                raw.hasPrefix("2")
+            {
+                time = String(raw[raw.startIndex..<space]).components(separatedBy: "T").last
+                message = String(raw[raw.index(after: space)...])
+            }
+            let upper = message.uppercased()
+            let level: Level =
+                upper.contains("ERROR") || upper.contains("FATAL") || upper.contains("PANIC")
+                ? .error
+                : upper.contains("WARN") ? .warn : .info
+            return LogLine(id: id, time: time, level: level, message: message)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Rectangle().fill(DesignTokens.borderFaint).frame(height: 1)
+            content
+        }
+        .frame(minWidth: 640, minHeight: 420)
+        .onAppear { startStream() }
+        .onDisappear { streamTask?.cancel() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("\(pod.name) — logs")
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            Button {
+                following.toggle()
+            } label: {
+                Text(following ? "● Following" : "⏸ Paused")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(
+                        following ? DesignTokens.statusOk : DesignTokens.statusWarn)
+            }
+            .buttonStyle(.plain)
+            Button("Clear") { lines = [] }
+                .controlSize(.small)
+            Button("Done", action: onClose)
+                .keyboardShortcut(.defaultAction)
+                .controlSize(.small)
+        }
+        .padding(12)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let streamError {
+            UnifiedErrorState(title: "Log stream failed", message: streamError)
+        } else if lines.isEmpty {
+            UnifiedLoadingState(label: "Waiting for log lines…")
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 1) {
+                        ForEach(lines) { line in
+                            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                Text(line.time ?? "—")
+                                    .font(.system(size: 10.5, design: .monospaced))
+                                    .foregroundStyle(DesignTokens.textDisabled)
+                                    .frame(width: 90, alignment: .leading)
+                                Text(line.level.label)
+                                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                                    .foregroundStyle(line.level.color)
+                                    .frame(width: 40, alignment: .leading)
+                                Text(line.message)
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundStyle(DesignTokens.textLog)
+                                    .textSelection(.enabled)
+                            }
+                            .id(line.id)
+                        }
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(DesignTokens.surfaceSunken)
+                .onChange(of: lines.count) { _, _ in
+                    if following, let last = lines.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private func startStream() {
+        streamTask = Task {
+            do {
+                var nextID = 0
+                let stream = try await kubeAPIService.streamPodLogs(
+                    namespace: pod.namespace, pod: pod.name, inContext: context)
+                for try await raw in stream {
+                    let line = LogLine.parse(raw, id: nextID)
+                    nextID += 1
+                    lines.append(line)
+                    if lines.count > Self.bufferCap {
+                        lines.removeFirst(lines.count - Self.bufferCap)
+                    }
+                }
+            } catch is CancellationError {
+                // Sheet dismissed.
+            } catch {
+                streamError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -25,6 +25,7 @@ struct ResourceDetailView: View {
     var onPodMutated: (() -> Void)?
 
     @State private var showDeleteConfirm = false
+    @State private var showLogs = false
     @State private var manifest: String?
     @State private var actionError: String?
     @State private var isActing = false
@@ -63,6 +64,16 @@ struct ResourceDetailView: View {
         .sheet(item: $manifestItem) { item in
             manifestSheet(item.text)
         }
+        .sheet(isPresented: $showLogs) {
+            if let service = kubeAPIService, let pod = currentPod {
+                PodLogsView(
+                    pod: pod,
+                    kubeAPIService: service,
+                    context: context,
+                    onClose: { showLogs = false }
+                )
+            }
+        }
         .alert(
             "Action failed", isPresented: .constant(actionError != nil),
             actions: {
@@ -83,6 +94,11 @@ struct ResourceDetailView: View {
         VStack(alignment: .leading, spacing: 8) {
             Divider().padding(.vertical, 8)
             HStack(spacing: 8) {
+                Button {
+                    showLogs = true
+                } label: {
+                    Label("Logs", systemImage: "doc.plaintext")
+                }
                 Button {
                     runAction { service, ctx in
                         let text = try await service.podManifestJSON(

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -17,7 +17,9 @@ struct UnifiedSidebarView: View {
 
     private var sections: [Section] {
         [
-            Section(label: "Cluster", dot: DesignTokens.accentDefault, items: [.dashboard]),
+            Section(
+                label: "Cluster", dot: DesignTokens.accentDefault,
+                items: [.dashboard, .nodes]),
             Section(
                 label: "Workloads", dot: DesignTokens.clusterBlue,
                 items: [.pods, .deployments, .helmReleases]),

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -22,7 +22,7 @@ struct UnifiedSidebarView: View {
                 items: [.dashboard, .nodes]),
             Section(
                 label: "Workloads", dot: DesignTokens.clusterBlue,
-                items: [.pods, .deployments, .jobs, .helmReleases]),
+                items: [.pods, .deployments, .statefulSets, .jobs, .helmReleases]),
             Section(
                 label: "Network", dot: DesignTokens.clusterViolet,
                 items: [.services, .ingresses]),

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -22,7 +22,7 @@ struct UnifiedSidebarView: View {
                 items: [.dashboard, .nodes]),
             Section(
                 label: "Workloads", dot: DesignTokens.clusterBlue,
-                items: [.pods, .deployments, .helmReleases]),
+                items: [.pods, .deployments, .jobs, .helmReleases]),
             Section(
                 label: "Network", dot: DesignTokens.clusterViolet,
                 items: [.services, .ingresses]),

--- a/apps/macos/cubelite/cubelite/Views/StatefulSetListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/StatefulSetListView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Table listing StatefulSets for the selected context and namespace.
+///
+/// Columns: Status, Name, Ready, Status label, Age.
+struct StatefulSetListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                UnifiedLoadingState(label: "Loading stateful sets…")
+            } else if let error = clusterState.resourceError {
+                UnifiedErrorState(title: "Failed to load stateful sets", message: error)
+            } else if clusterState.statefulSets.isEmpty {
+                UnifiedEmptyState(message: "There are no stateful sets in this namespace.")
+            } else {
+                table
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func isAvailable(_ set: StatefulSetInfo) -> Bool {
+        set.replicas > 0 && set.readyReplicas >= set.replicas
+    }
+
+    private var table: some View {
+        Table(clusterState.statefulSets) {
+            TableColumn("") { set in
+                Circle()
+                    .fill(isAvailable(set) ? DesignTokens.statusOk : DesignTokens.statusWarn)
+                    .frame(width: 8, height: 8)
+            }
+            .width(16)
+
+            TableColumn("Name") { set in
+                Text(set.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+
+            TableColumn("Ready") { set in
+                Text("\(set.readyReplicas)/\(set.replicas)")
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(70)
+
+            TableColumn("Status") { set in
+                Text(isAvailable(set) ? "Available" : "Progressing")
+                    .foregroundStyle(
+                        isAvailable(set) ? DesignTokens.statusOk : DesignTokens.statusWarn)
+            }
+            .width(100)
+
+            TableColumn("Age") { set in
+                Text(set.creationTimestamp.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(70)
+        }
+        .unifiedTableBackground()
+    }
+}

--- a/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
@@ -147,7 +147,7 @@ final class ResourceTypeTests: XCTestCase {
 
     func testCaseIterable_containsAllCases() {
         let all = ResourceType.allCases
-        XCTAssertEqual(all.count, 8)
+        XCTAssertEqual(all.count, 9)
         XCTAssertTrue(all.contains(.dashboard))
         XCTAssertTrue(all.contains(.pods))
         XCTAssertTrue(all.contains(.deployments))
@@ -156,5 +156,6 @@ final class ResourceTypeTests: XCTestCase {
         XCTAssertTrue(all.contains(.configMaps))
         XCTAssertTrue(all.contains(.ingresses))
         XCTAssertTrue(all.contains(.helmReleases))
+        XCTAssertTrue(all.contains(.nodes))
     }
 }

--- a/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
@@ -147,7 +147,7 @@ final class ResourceTypeTests: XCTestCase {
 
     func testCaseIterable_containsAllCases() {
         let all = ResourceType.allCases
-        XCTAssertEqual(all.count, 10)
+        XCTAssertEqual(all.count, 11)
         XCTAssertTrue(all.contains(.dashboard))
         XCTAssertTrue(all.contains(.pods))
         XCTAssertTrue(all.contains(.deployments))
@@ -158,5 +158,6 @@ final class ResourceTypeTests: XCTestCase {
         XCTAssertTrue(all.contains(.helmReleases))
         XCTAssertTrue(all.contains(.nodes))
         XCTAssertTrue(all.contains(.jobs))
+        XCTAssertTrue(all.contains(.statefulSets))
     }
 }

--- a/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
@@ -147,7 +147,7 @@ final class ResourceTypeTests: XCTestCase {
 
     func testCaseIterable_containsAllCases() {
         let all = ResourceType.allCases
-        XCTAssertEqual(all.count, 9)
+        XCTAssertEqual(all.count, 10)
         XCTAssertTrue(all.contains(.dashboard))
         XCTAssertTrue(all.contains(.pods))
         XCTAssertTrue(all.contains(.deployments))
@@ -157,5 +157,6 @@ final class ResourceTypeTests: XCTestCase {
         XCTAssertTrue(all.contains(.ingresses))
         XCTAssertTrue(all.contains(.helmReleases))
         XCTAssertTrue(all.contains(.nodes))
+        XCTAssertTrue(all.contains(.jobs))
     }
 }

--- a/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
@@ -235,7 +235,7 @@ final class MainViewStateTests: XCTestCase {
     }
 
     func testResourceType_allCases_matchesEnum() {
-        XCTAssertEqual(ResourceType.allCases.count, 10)
+        XCTAssertEqual(ResourceType.allCases.count, 11)
     }
 
     func testResourceType_pods_hasSystemImage() {

--- a/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
@@ -235,7 +235,7 @@ final class MainViewStateTests: XCTestCase {
     }
 
     func testResourceType_allCases_matchesEnum() {
-        XCTAssertEqual(ResourceType.allCases.count, 9)
+        XCTAssertEqual(ResourceType.allCases.count, 10)
     }
 
     func testResourceType_pods_hasSystemImage() {

--- a/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
@@ -234,8 +234,8 @@ final class MainViewStateTests: XCTestCase {
         XCTAssertEqual(ResourceType.deployments.rawValue, "Deployments")
     }
 
-    func testResourceType_allCases_countIsThree() {
-        XCTAssertEqual(ResourceType.allCases.count, 8)
+    func testResourceType_allCases_matchesEnum() {
+        XCTAssertEqual(ResourceType.allCases.count, 9)
     }
 
     func testResourceType_pods_hasSystemImage() {


### PR DESCRIPTION
Closes #115 — sub-issue of #77. Stacked on #269 (auto-retargets to main when it merges).

- `JobInfo` model + `K8sJob` decoding (completions / succeeded / active / failed)
- `KubeAPIService.listJobs` (batch/v1, namespace optional), loaded with the resource batch
- **Jobs** entry in the sidebar Workloads group; `JobListView` on the unified table style (status dot err/warn/ok, completions x/y, failed count in err, age)
- ResourceType tests updated

## Verification
`xcodebuild` build + full unit suite: **exit 0, 377 passed**. No desktop/Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)