### PR TITLE
feat(macos): StatefulSets resource view

### DIFF
--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -24,6 +24,8 @@ final class ClusterState {
     var deployments: [DeploymentInfo] = []
     /// Batch jobs in the selected namespace.
     var jobs: [JobInfo] = []
+    /// Stateful sets in the selected namespace.
+    var statefulSets: [StatefulSetInfo] = []
 
     /// Services in the selected namespace.
     var services: [ServiceInfo] = []
@@ -89,6 +91,8 @@ enum ResourceType: String, CaseIterable, Identifiable {
     case ingresses = "Ingresses"
     /// Helm Releases resource type.
     case helmReleases = "Helm Releases"
+    /// Stateful sets.
+    case statefulSets = "StatefulSets"
     /// Batch jobs.
     case jobs = "Jobs"
     /// Cluster nodes (read-only).
@@ -106,6 +110,7 @@ enum ResourceType: String, CaseIterable, Identifiable {
         case .configMaps: "doc.text"
         case .ingresses: "globe"
         case .helmReleases: "shippingbox"
+        case .statefulSets: "externaldrive.badge.timemachine"
         case .jobs: "checklist"
         case .nodes: "server.rack"
         }

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -169,6 +169,50 @@ extension K8sJob {
     }
 }
 
+/// Display model for a StatefulSet.
+struct StatefulSetInfo: Codable, Sendable, Identifiable {
+    var id: String { "\(namespace)/\(name)" }
+
+    let name: String
+    let namespace: String
+    /// Desired replicas.
+    let replicas: Int
+    /// Replicas currently reporting ready.
+    let readyReplicas: Int
+    /// ISO 8601 creation timestamp.
+    let creationTimestamp: String?
+}
+
+/// Raw Kubernetes stateful set as returned by the API.
+struct K8sStatefulSet: Codable, Sendable {
+    let metadata: K8sObjectMeta?
+    let spec: K8sStatefulSetSpec?
+    let status: K8sStatefulSetStatus?
+}
+
+/// StatefulSet spec subset.
+struct K8sStatefulSetSpec: Codable, Sendable {
+    let replicas: Int?
+}
+
+/// StatefulSet status subset.
+struct K8sStatefulSetStatus: Codable, Sendable {
+    let readyReplicas: Int?
+}
+
+extension K8sStatefulSet {
+    /// Maps the raw stateful set onto the display model.
+    func toStatefulSetInfo() -> StatefulSetInfo {
+        StatefulSetInfo(
+            name: metadata?.name ?? "",
+            namespace: metadata?.namespace ?? "",
+            replicas: spec?.replicas ?? 0,
+            readyReplicas: status?.readyReplicas ?? 0,
+            creationTimestamp: metadata?.creationTimestamp
+        )
+    }
+}
+
 /// Display model for a cluster node (read-only inventory).
 struct NodeInfo: Codable, Sendable, Identifiable {
     var id: String { name }

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -362,6 +362,22 @@ actor KubeAPIService {
         return response.items.map { $0.toJobInfo() }
     }
 
+    /// Lists stateful sets, optionally scoped to a namespace and/or context.
+    func listStatefulSets(namespace: String? = nil, inContext contextName: String? = nil)
+        async throws -> [StatefulSetInfo]
+    {
+        let path: String
+        if let ns = namespace {
+            let encoded = ns.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ns
+            path = "/apis/apps/v1/namespaces/\(encoded)/statefulsets"
+        } else {
+            path = "/apis/apps/v1/statefulsets"
+        }
+        let response: K8sListResponse<K8sStatefulSet> = try await fetch(
+            path: path, contextName: contextName)
+        return response.items.map { $0.toStatefulSetInfo() }
+    }
+
     /// Lists cluster nodes (read-only; requires nodes RBAC).
     func listNodes(inContext contextName: String? = nil) async throws -> [NodeInfo] {
         let response: K8sListResponse<K8sNode> = try await fetch(

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -30,7 +30,7 @@ extension MainView {
             case .dashboard:
                 DashboardView()
             case .pods, .deployments, .services, .secrets, .configMaps, .ingresses,
-                .helmReleases, .nodes, .jobs:
+                .helmReleases, .nodes, .jobs, .statefulSets:
                 resourceBrowserView(context: sel.context, namespace: sel.namespace)
             }
         } else {
@@ -116,6 +116,8 @@ extension MainView {
                             selectedPodID = nil
                             selectedDeploymentID = nil
                         }
+                case .statefulSets:
+                    StatefulSetListView()
                 case .jobs:
                     JobListView()
                 case .nodes:

--- a/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
@@ -63,6 +63,16 @@ extension MainView {
             return
         }
 
+        // StatefulSets
+        if let statefulSets = await fetchResource("statefulsets", {
+            try await kubeAPIService.listStatefulSets(namespace: namespace, inContext: context)
+        }) {
+            clusterState.statefulSets = statefulSets
+        } else if fatalError != nil {
+            finishResourceLoad(fatalError: fatalError, forbidden: forbidden, namespace: namespace)
+            return
+        }
+
         // Jobs
         if let jobs = await fetchResource("jobs", {
             try await kubeAPIService.listJobs(namespace: namespace, inContext: context)

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -22,7 +22,7 @@ struct UnifiedSidebarView: View {
                 items: [.dashboard, .nodes]),
             Section(
                 label: "Workloads", dot: DesignTokens.clusterBlue,
-                items: [.pods, .deployments, .jobs, .helmReleases]),
+                items: [.pods, .deployments, .statefulSets, .jobs, .helmReleases]),
             Section(
                 label: "Network", dot: DesignTokens.clusterViolet,
                 items: [.services, .ingresses]),

--- a/apps/macos/cubelite/cubelite/Views/StatefulSetListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/StatefulSetListView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Table listing StatefulSets for the selected context and namespace.
+///
+/// Columns: Status, Name, Ready, Status label, Age.
+struct StatefulSetListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                UnifiedLoadingState(label: "Loading stateful sets…")
+            } else if let error = clusterState.resourceError {
+                UnifiedErrorState(title: "Failed to load stateful sets", message: error)
+            } else if clusterState.statefulSets.isEmpty {
+                UnifiedEmptyState(message: "There are no stateful sets in this namespace.")
+            } else {
+                table
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func isAvailable(_ set: StatefulSetInfo) -> Bool {
+        set.replicas > 0 && set.readyReplicas >= set.replicas
+    }
+
+    private var table: some View {
+        Table(clusterState.statefulSets) {
+            TableColumn("") { set in
+                Circle()
+                    .fill(isAvailable(set) ? DesignTokens.statusOk : DesignTokens.statusWarn)
+                    .frame(width: 8, height: 8)
+            }
+            .width(16)
+
+            TableColumn("Name") { set in
+                Text(set.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+
+            TableColumn("Ready") { set in
+                Text("\(set.readyReplicas)/\(set.replicas)")
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(70)
+
+            TableColumn("Status") { set in
+                Text(isAvailable(set) ? "Available" : "Progressing")
+                    .foregroundStyle(
+                        isAvailable(set) ? DesignTokens.statusOk : DesignTokens.statusWarn)
+            }
+            .width(100)
+
+            TableColumn("Age") { set in
+                Text(set.creationTimestamp.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(70)
+        }
+        .unifiedTableBackground()
+    }
+}

--- a/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
@@ -147,7 +147,7 @@ final class ResourceTypeTests: XCTestCase {
 
     func testCaseIterable_containsAllCases() {
         let all = ResourceType.allCases
-        XCTAssertEqual(all.count, 10)
+        XCTAssertEqual(all.count, 11)
         XCTAssertTrue(all.contains(.dashboard))
         XCTAssertTrue(all.contains(.pods))
         XCTAssertTrue(all.contains(.deployments))
@@ -158,5 +158,6 @@ final class ResourceTypeTests: XCTestCase {
         XCTAssertTrue(all.contains(.helmReleases))
         XCTAssertTrue(all.contains(.nodes))
         XCTAssertTrue(all.contains(.jobs))
+        XCTAssertTrue(all.contains(.statefulSets))
     }
 }

--- a/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
@@ -235,7 +235,7 @@ final class MainViewStateTests: XCTestCase {
     }
 
     func testResourceType_allCases_matchesEnum() {
-        XCTAssertEqual(ResourceType.allCases.count, 10)
+        XCTAssertEqual(ResourceType.allCases.count, 11)
     }
 
     func testResourceType_pods_hasSystemImage() {


### PR DESCRIPTION
Closes #116 — sub-issue of #77. Stacked on #270 (auto-retargets when the chain merges).

- `StatefulSetInfo` model + `K8sStatefulSet` decoding
- `KubeAPIService.listStatefulSets` (apps/v1, namespace optional), loaded with the resource batch
- **StatefulSets** entry in the sidebar Workloads group; `StatefulSetListView` on the unified table style (ready x/y, derived Available/Progressing in ok/warn, age)
- ResourceType tests updated

## Verification
`xcodebuild` build + full unit suite: **exit 0, 377 passed**. No desktop/Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)