### PR TITLE
feat(macos): CronJobs and PersistentVolumeClaims resource views

### DIFF
--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -24,6 +24,10 @@ final class ClusterState {
     var deployments: [DeploymentInfo] = []
     /// Batch jobs in the selected namespace.
     var jobs: [JobInfo] = []
+    /// Cron jobs in the selected namespace.
+    var cronJobs: [CronJobInfo] = []
+    /// Persistent volume claims in the selected namespace.
+    var pvcs: [PvcInfo] = []
     /// Stateful sets in the selected namespace.
     var statefulSets: [StatefulSetInfo] = []
 
@@ -95,6 +99,10 @@ enum ResourceType: String, CaseIterable, Identifiable {
     case statefulSets = "StatefulSets"
     /// Batch jobs.
     case jobs = "Jobs"
+    /// Cron jobs.
+    case cronJobs = "CronJobs"
+    /// Persistent volume claims.
+    case pvcs = "PVCs"
     /// Cluster nodes (read-only).
     case nodes = "Nodes"
 
@@ -112,6 +120,8 @@ enum ResourceType: String, CaseIterable, Identifiable {
         case .helmReleases: "shippingbox"
         case .statefulSets: "externaldrive.badge.timemachine"
         case .jobs: "checklist"
+        case .cronJobs: "clock.arrow.circlepath"
+        case .pvcs: "externaldrive"
         case .nodes: "server.rack"
         }
     }

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -213,6 +213,119 @@ extension K8sStatefulSet {
     }
 }
 
+/// Display model for a CronJob.
+struct CronJobInfo: Codable, Sendable, Identifiable {
+    var id: String { "\(namespace)/\(name)" }
+
+    let name: String
+    let namespace: String
+    /// Cron schedule expression.
+    let schedule: String
+    /// `true` when the cron job is suspended.
+    let suspend: Bool
+    /// Number of currently active jobs.
+    let active: Int
+    /// ISO 8601 timestamp of the last scheduled run.
+    let lastSchedule: String?
+    /// ISO 8601 creation timestamp.
+    let creationTimestamp: String?
+}
+
+/// Raw Kubernetes cron job as returned by the API.
+struct K8sCronJob: Codable, Sendable {
+    let metadata: K8sObjectMeta?
+    let spec: K8sCronJobSpec?
+    let status: K8sCronJobStatus?
+}
+
+/// CronJob spec subset.
+struct K8sCronJobSpec: Codable, Sendable {
+    let schedule: String?
+    let suspend: Bool?
+}
+
+/// CronJob status subset.
+struct K8sCronJobStatus: Codable, Sendable {
+    let active: [K8sObjectReference]?
+    let lastScheduleTime: String?
+}
+
+/// Minimal object reference (used by CronJob active entries).
+struct K8sObjectReference: Codable, Sendable {
+    let name: String?
+}
+
+extension K8sCronJob {
+    /// Maps the raw cron job onto the display model.
+    func toCronJobInfo() -> CronJobInfo {
+        CronJobInfo(
+            name: metadata?.name ?? "",
+            namespace: metadata?.namespace ?? "",
+            schedule: spec?.schedule ?? "",
+            suspend: spec?.suspend ?? false,
+            active: status?.active?.count ?? 0,
+            lastSchedule: status?.lastScheduleTime,
+            creationTimestamp: metadata?.creationTimestamp
+        )
+    }
+}
+
+/// Display model for a PersistentVolumeClaim.
+struct PvcInfo: Codable, Sendable, Identifiable {
+    var id: String { "\(namespace)/\(name)" }
+
+    let name: String
+    let namespace: String
+    /// Claim phase (`"Bound"`, `"Pending"`, `"Lost"`).
+    let status: String?
+    /// Bound volume name, when bound.
+    let volume: String?
+    /// Actual storage capacity (e.g. `"10Gi"`).
+    let capacity: String?
+    /// Access modes.
+    let accessModes: [String]
+    /// Storage class name, when set.
+    let storageClass: String?
+    /// ISO 8601 creation timestamp.
+    let creationTimestamp: String?
+}
+
+/// Raw Kubernetes persistent volume claim as returned by the API.
+struct K8sPvc: Codable, Sendable {
+    let metadata: K8sObjectMeta?
+    let spec: K8sPvcSpec?
+    let status: K8sPvcStatus?
+}
+
+/// PVC spec subset.
+struct K8sPvcSpec: Codable, Sendable {
+    let storageClassName: String?
+    let volumeName: String?
+}
+
+/// PVC status subset.
+struct K8sPvcStatus: Codable, Sendable {
+    let phase: String?
+    let accessModes: [String]?
+    let capacity: [String: String]?
+}
+
+extension K8sPvc {
+    /// Maps the raw claim onto the display model.
+    func toPvcInfo() -> PvcInfo {
+        PvcInfo(
+            name: metadata?.name ?? "",
+            namespace: metadata?.namespace ?? "",
+            status: status?.phase,
+            volume: spec?.volumeName,
+            capacity: status?.capacity?["storage"],
+            accessModes: status?.accessModes ?? [],
+            storageClass: spec?.storageClassName,
+            creationTimestamp: metadata?.creationTimestamp
+        )
+    }
+}
+
 /// Display model for a cluster node (read-only inventory).
 struct NodeInfo: Codable, Sendable, Identifiable {
     var id: String { name }

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -381,6 +381,38 @@ actor KubeAPIService {
         return response.items.map { $0.toStatefulSetInfo() }
     }
 
+    /// Lists cron jobs, optionally scoped to a namespace and/or context.
+    func listCronJobs(namespace: String? = nil, inContext contextName: String? = nil)
+        async throws -> [CronJobInfo]
+    {
+        let path: String
+        if let ns = namespace {
+            let encoded = ns.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ns
+            path = "/apis/batch/v1/namespaces/\(encoded)/cronjobs"
+        } else {
+            path = "/apis/batch/v1/cronjobs"
+        }
+        let response: K8sListResponse<K8sCronJob> = try await fetch(
+            path: path, contextName: contextName)
+        return response.items.map { $0.toCronJobInfo() }
+    }
+
+    /// Lists persistent volume claims, optionally scoped to a namespace and/or context.
+    func listPvcs(namespace: String? = nil, inContext contextName: String? = nil)
+        async throws -> [PvcInfo]
+    {
+        let path: String
+        if let ns = namespace {
+            let encoded = ns.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ns
+            path = "/api/v1/namespaces/\(encoded)/persistentvolumeclaims"
+        } else {
+            path = "/api/v1/persistentvolumeclaims"
+        }
+        let response: K8sListResponse<K8sPvc> = try await fetch(
+            path: path, contextName: contextName)
+        return response.items.map { $0.toPvcInfo() }
+    }
+
     /// Lists cluster nodes (read-only; requires nodes RBAC).
     func listNodes(inContext contextName: String? = nil) async throws -> [NodeInfo] {
         let response: K8sListResponse<K8sNode> = try await fetch(

--- a/apps/macos/cubelite/cubelite/Views/CronJobListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/CronJobListView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Table listing CronJobs for the selected context and namespace.
+///
+/// Columns: Status, Name, Schedule, Suspend, Active, Last schedule, Age.
+struct CronJobListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                UnifiedLoadingState(label: "Loading cron jobs…")
+            } else if let error = clusterState.resourceError {
+                UnifiedErrorState(title: "Failed to load cron jobs", message: error)
+            } else if clusterState.cronJobs.isEmpty {
+                UnifiedEmptyState(message: "There are no cron jobs in this namespace.")
+            } else {
+                table
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var table: some View {
+        Table(clusterState.cronJobs) {
+            TableColumn("") { job in
+                Circle()
+                    .fill(job.suspend ? DesignTokens.statusWarn : DesignTokens.statusOk)
+                    .frame(width: 8, height: 8)
+                    .help(job.suspend ? "Suspended" : "Scheduled")
+            }
+            .width(16)
+
+            TableColumn("Name") { job in
+                Text(job.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+
+            TableColumn("Schedule") { job in
+                Text(job.schedule)
+                    .font(.callout.monospaced())
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(110)
+
+            TableColumn("Suspend") { job in
+                Text(job.suspend ? "True" : "False")
+                    .foregroundStyle(
+                        job.suspend ? DesignTokens.statusWarn : DesignTokens.textSecondary)
+            }
+            .width(70)
+
+            TableColumn("Active") { job in
+                Text("\(job.active)")
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(60)
+
+            TableColumn("Last schedule") { job in
+                Text(job.lastSchedule.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(100)
+
+            TableColumn("Age") { job in
+                Text(job.creationTimestamp.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(70)
+        }
+        .unifiedTableBackground()
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -30,7 +30,7 @@ extension MainView {
             case .dashboard:
                 DashboardView()
             case .pods, .deployments, .services, .secrets, .configMaps, .ingresses,
-                .helmReleases, .nodes, .jobs, .statefulSets:
+                .helmReleases, .nodes, .jobs, .statefulSets, .cronJobs, .pvcs:
                 resourceBrowserView(context: sel.context, namespace: sel.namespace)
             }
         } else {
@@ -120,6 +120,10 @@ extension MainView {
                     StatefulSetListView()
                 case .jobs:
                     JobListView()
+                case .cronJobs:
+                    CronJobListView()
+                case .pvcs:
+                    PvcListView()
                 case .nodes:
                     NodeListView()
                 case .dashboard:

--- a/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+ResourceLoader.swift
@@ -83,6 +83,26 @@ extension MainView {
             return
         }
 
+        // CronJobs
+        if let cronJobs = await fetchResource("cronjobs", {
+            try await kubeAPIService.listCronJobs(namespace: namespace, inContext: context)
+        }) {
+            clusterState.cronJobs = cronJobs
+        } else if fatalError != nil {
+            finishResourceLoad(fatalError: fatalError, forbidden: forbidden, namespace: namespace)
+            return
+        }
+
+        // PVCs
+        if let pvcs = await fetchResource("persistentvolumeclaims", {
+            try await kubeAPIService.listPvcs(namespace: namespace, inContext: context)
+        }) {
+            clusterState.pvcs = pvcs
+        } else if fatalError != nil {
+            finishResourceLoad(fatalError: fatalError, forbidden: forbidden, namespace: namespace)
+            return
+        }
+
         // Nodes (cluster-scoped, best-effort: RBAC commonly denies them and
         // the rest of the views must keep working).
         clusterState.nodes = (try? await kubeAPIService.listNodes(inContext: context)) ?? []

--- a/apps/macos/cubelite/cubelite/Views/PvcListView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PvcListView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+/// Table listing PersistentVolumeClaims for the selected context/namespace.
+///
+/// Columns: Status, Name, Volume, Capacity, Access modes, StorageClass, Age.
+struct PvcListView: View {
+
+    @Environment(ClusterState.self) private var clusterState
+
+    var body: some View {
+        Group {
+            if clusterState.isLoadingResources {
+                UnifiedLoadingState(label: "Loading persistent volume claims…")
+            } else if let error = clusterState.resourceError {
+                UnifiedErrorState(title: "Failed to load claims", message: error)
+            } else if clusterState.pvcs.isEmpty {
+                UnifiedEmptyState(message: "There are no persistent volume claims in this namespace.")
+            } else {
+                table
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func tone(_ status: String?) -> Color {
+        switch status {
+        case "Bound": DesignTokens.statusOk
+        case "Lost": DesignTokens.statusErr
+        default: DesignTokens.statusWarn
+        }
+    }
+
+    private var table: some View {
+        Table(clusterState.pvcs) {
+            TableColumn("") { pvc in
+                Circle()
+                    .fill(tone(pvc.status))
+                    .frame(width: 8, height: 8)
+                    .help(pvc.status ?? "Unknown")
+            }
+            .width(16)
+
+            TableColumn("Name") { pvc in
+                Text(pvc.name)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+            }
+
+            TableColumn("Status") { pvc in
+                Text(pvc.status ?? "—")
+                    .foregroundStyle(tone(pvc.status))
+            }
+            .width(70)
+
+            TableColumn("Volume") { pvc in
+                Text(pvc.volume ?? "—")
+                    .font(.callout.monospaced())
+                    .foregroundStyle(DesignTokens.textSecondary)
+                    .lineLimit(1)
+            }
+
+            TableColumn("Capacity") { pvc in
+                Text(pvc.capacity ?? "—")
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(70)
+
+            TableColumn("Access") { pvc in
+                Text(pvc.accessModes.isEmpty ? "—" : pvc.accessModes.joined(separator: ", "))
+                    .foregroundStyle(DesignTokens.textSecondary)
+                    .lineLimit(1)
+            }
+            .width(110)
+
+            TableColumn("Class") { pvc in
+                Text(pvc.storageClass ?? "—")
+                    .foregroundStyle(DesignTokens.textSecondary)
+            }
+            .width(80)
+
+            TableColumn("Age") { pvc in
+                Text(pvc.creationTimestamp.k8sAge)
+                    .foregroundStyle(DesignTokens.textTertiary)
+            }
+            .width(60)
+        }
+        .unifiedTableBackground()
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -22,13 +22,13 @@ struct UnifiedSidebarView: View {
                 items: [.dashboard, .nodes]),
             Section(
                 label: "Workloads", dot: DesignTokens.clusterBlue,
-                items: [.pods, .deployments, .statefulSets, .jobs, .helmReleases]),
+                items: [.pods, .deployments, .statefulSets, .jobs, .cronJobs, .helmReleases]),
             Section(
                 label: "Network", dot: DesignTokens.clusterViolet,
                 items: [.services, .ingresses]),
             Section(
                 label: "Config", dot: DesignTokens.statusWarn,
-                items: [.configMaps, .secrets]),
+                items: [.configMaps, .secrets, .pvcs]),
         ]
     }
 

--- a/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
@@ -147,7 +147,7 @@ final class ResourceTypeTests: XCTestCase {
 
     func testCaseIterable_containsAllCases() {
         let all = ResourceType.allCases
-        XCTAssertEqual(all.count, 11)
+        XCTAssertEqual(all.count, 13)
         XCTAssertTrue(all.contains(.dashboard))
         XCTAssertTrue(all.contains(.pods))
         XCTAssertTrue(all.contains(.deployments))
@@ -159,5 +159,7 @@ final class ResourceTypeTests: XCTestCase {
         XCTAssertTrue(all.contains(.nodes))
         XCTAssertTrue(all.contains(.jobs))
         XCTAssertTrue(all.contains(.statefulSets))
+        XCTAssertTrue(all.contains(.cronJobs))
+        XCTAssertTrue(all.contains(.pvcs))
     }
 }

--- a/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
@@ -235,7 +235,7 @@ final class MainViewStateTests: XCTestCase {
     }
 
     func testResourceType_allCases_matchesEnum() {
-        XCTAssertEqual(ResourceType.allCases.count, 11)
+        XCTAssertEqual(ResourceType.allCases.count, 13)
     }
 
     func testResourceType_pods_hasSystemImage() {


### PR DESCRIPTION
Closes #77 — completes the missing-resource-types umbrella (Services, Ingress, Secrets, ConfigMaps, Helm shipped long ago; Nodes #269, Jobs #270, StatefulSets #271 in this chain). Port-forwarding stays tracked by its own #122. Stacked on #273.

- `CronJobInfo`/`K8sCronJob` and `PvcInfo`/`K8sPvc` models with decoding
- `KubeAPIService.listCronJobs` (batch/v1) and `listPvcs` (core/v1), namespace optional, loaded with the resource batch
- **CronJobs** joins Workloads and **PVCs** joins Config in the sidebar
- Unified table styling: suspended cronjobs in warn, claims Bound/Pending/Lost in ok/warn/err
- ResourceType tests updated (13 cases)

## Verification
`xcodebuild` build + full unit suite: **exit 0, 376+ passed**. No desktop/Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)