### PR TITLE
feat(macos): pod port-forward over the Kubernetes WebSocket protocol

### DIFF
--- a/apps/macos/cubelite/cubelite/CubeliteApp.swift
+++ b/apps/macos/cubelite/cubelite/CubeliteApp.swift
@@ -13,11 +13,14 @@ struct CubeliteApp: App {
     /// Persists whether the user has completed the first-launch onboarding flow.
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @State private var logStore = LogStore()
+    @State private var portForwardService: PortForwardService
 
     init() {
         let ks = KubeconfigService()
         self.kubeconfigService = ks
-        self.kubeAPIService = KubeAPIService(kubeconfigService: ks)
+        let api = KubeAPIService(kubeconfigService: ks)
+        self.kubeAPIService = api
+        self._portForwardService = State(initialValue: PortForwardService(kubeAPIService: api))
         // Default-initialised; the real `onError` closure is bound in `.task`
         // once `logStore` and `appSettings` are available in scope.
         self._loginItemController = State(initialValue: LoginItemController())
@@ -26,7 +29,11 @@ struct CubeliteApp: App {
     var body: some Scene {
         WindowGroup("CubeLite") {
             if hasCompletedOnboarding {
-                MainView(kubeconfigService: kubeconfigService, kubeAPIService: kubeAPIService)
+                MainView(
+                    kubeconfigService: kubeconfigService,
+                    kubeAPIService: kubeAPIService,
+                    portForwardService: portForwardService
+                )
                     .environment(clusterState)
                     .environment(appSettings)
                     .environment(logStore)

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -470,6 +470,47 @@ actor KubeAPIService {
             path: path, timeout: 3600, failurePrefix: "Watch failed", contextName: contextName)
     }
 
+    /// Opens the Kubernetes port-forward WebSocket for one pod port using
+    /// the SPDY-over-WebSocket channel protocol (`v4.channel.k8s.io`).
+    /// The caller owns the returned task (resume/cancel).
+    func portForwardWebSocket(
+        namespace: String,
+        pod: String,
+        remotePort: Int,
+        inContext contextName: String? = nil
+    ) async throws -> URLSessionWebSocketTask {
+        let config = try await kubeconfigService.load()
+        let (cluster, user) = try resolveConnectionInfo(from: config, contextName: contextName)
+
+        guard let serverString = cluster.server, !serverString.isEmpty else {
+            throw CubeliteError.clientError(reason: "Cluster has no valid server URL")
+        }
+        var base = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
+        base = base.replacingOccurrences(of: "https://", with: "wss://")
+        let path = "/api/v1/namespaces/\(namespace)/pods/\(pod)/portforward?ports=\(remotePort)"
+        guard let url = URL(string: base + path) else {
+            throw CubeliteError.clientError(reason: "Invalid URL: \(base + path)")
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("v4.channel.k8s.io", forHTTPHeaderField: "Sec-WebSocket-Protocol")
+        let httpBase = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
+        if let token = await bearerToken(for: user, account: httpBase) {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let session: URLSession
+        if let cached = sessionCache[httpBase] {
+            session = cached
+        } else {
+            let newSession = try makeSession(cluster: cluster, user: user)
+            sessionCache[httpBase] = newSession
+            session = newSession
+        }
+
+        return session.webSocketTask(with: request)
+    }
+
     // MARK: - Log Streaming
 
     /// Follows a pod's log as an async stream of raw lines

--- a/apps/macos/cubelite/cubelite/Services/PortForwardService.swift
+++ b/apps/macos/cubelite/cubelite/Services/PortForwardService.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Network
+
+/// One active port-forward: a local TCP listener relaying to a pod port
+/// through the Kubernetes port-forward WebSocket protocol.
+@MainActor
+@Observable
+final class PortForwardSession: Identifiable {
+
+    enum State: Equatable {
+        case starting
+        case active
+        case failed(String)
+    }
+
+    let id = UUID()
+    let context: String
+    let namespace: String
+    let pod: String
+    let localPort: UInt16
+    let remotePort: Int
+    var state: State = .starting
+
+    fileprivate var listener: NWListener?
+    fileprivate var relays: [UUID: PortForwardRelay] = [:]
+
+    init(context: String, namespace: String, pod: String, localPort: UInt16, remotePort: Int) {
+        self.context = context
+        self.namespace = namespace
+        self.pod = pod
+        self.localPort = localPort
+        self.remotePort = remotePort
+    }
+}
+
+/// Manages the lifecycle of all port-forward sessions.
+@MainActor
+@Observable
+final class PortForwardService {
+
+    private(set) var sessions: [PortForwardSession] = []
+    private let kubeAPIService: KubeAPIService
+
+    init(kubeAPIService: KubeAPIService) {
+        self.kubeAPIService = kubeAPIService
+    }
+
+    /// Starts a listener on `localPort` relaying each accepted connection to
+    /// `pod:remotePort` over its own port-forward WebSocket.
+    func start(
+        context: String, namespace: String, pod: String, localPort: UInt16, remotePort: Int
+    ) throws {
+        let session = PortForwardSession(
+            context: context, namespace: namespace, pod: pod,
+            localPort: localPort, remotePort: remotePort)
+
+        guard let port = NWEndpoint.Port(rawValue: localPort) else {
+            throw CubeliteError.clientError(reason: "Invalid local port \(localPort)")
+        }
+        let listener = try NWListener(using: .tcp, on: port)
+        session.listener = listener
+
+        listener.stateUpdateHandler = { [weak session] state in
+            Task { @MainActor in
+                switch state {
+                case .ready: session?.state = .active
+                case .failed(let error): session?.state = .failed(error.localizedDescription)
+                default: break
+                }
+            }
+        }
+        listener.newConnectionHandler = { [weak self, weak session] connection in
+            Task { @MainActor in
+                guard let self, let session else { return }
+                await self.attach(connection: connection, to: session)
+            }
+        }
+        listener.start(queue: .main)
+        sessions.append(session)
+    }
+
+    /// Stops a session: closes the listener and every live relay.
+    func stop(_ session: PortForwardSession) {
+        session.listener?.cancel()
+        for relay in session.relays.values {
+            relay.close()
+        }
+        session.relays.removeAll()
+        sessions.removeAll { $0.id == session.id }
+    }
+
+    /// Sessions attached to one pod.
+    func sessions(namespace: String, pod: String) -> [PortForwardSession] {
+        sessions.filter { $0.namespace == namespace && $0.pod == pod }
+    }
+
+    private func attach(connection: NWConnection, to session: PortForwardSession) async {
+        do {
+            let ws = try await kubeAPIService.portForwardWebSocket(
+                namespace: session.namespace,
+                pod: session.pod,
+                remotePort: session.remotePort,
+                inContext: session.context
+            )
+            let relay = PortForwardRelay(connection: connection, webSocket: ws) {
+                [weak session] id in
+                Task { @MainActor in session?.relays[id] = nil }
+            }
+            session.relays[relay.id] = relay
+            relay.start()
+        } catch {
+            connection.cancel()
+            session.state = .failed(error.localizedDescription)
+        }
+    }
+}
+
+/// Bidirectional relay between one local TCP connection and one
+/// port-forward WebSocket (channel 0 = data, channel 1 = error; the first
+/// frame of each channel carries a 2-byte little-endian port header).
+final class PortForwardRelay: @unchecked Sendable {
+
+    let id = UUID()
+    private let connection: NWConnection
+    private let webSocket: URLSessionWebSocketTask
+    private let onClose: @Sendable (UUID) -> Void
+    private var seenHeaderForChannel: Set<UInt8> = []
+    private let lock = NSLock()
+
+    init(
+        connection: NWConnection,
+        webSocket: URLSessionWebSocketTask,
+        onClose: @escaping @Sendable (UUID) -> Void
+    ) {
+        self.connection = connection
+        self.webSocket = webSocket
+        self.onClose = onClose
+    }
+
+    func start() {
+        webSocket.resume()
+        connection.start(queue: .global(qos: .userInitiated))
+        pumpWebSocket()
+        pumpLocal()
+    }
+
+    func close() {
+        webSocket.cancel(with: .normalClosure, reason: nil)
+        connection.cancel()
+        onClose(id)
+    }
+
+    // MARK: - WS → TCP
+
+    private func pumpWebSocket() {
+        webSocket.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(.data(var payload)):
+                guard !payload.isEmpty else { return self.pumpWebSocket() }
+                let channel = payload.removeFirst()
+                let isFirst: Bool = {
+                    self.lock.lock()
+                    defer { self.lock.unlock() }
+                    return self.seenHeaderForChannel.insert(channel).inserted
+                }()
+                // The first frame per channel is the 2-byte port header.
+                if isFirst {
+                    payload = payload.dropFirst(2)
+                }
+                if channel == 0, !payload.isEmpty {
+                    self.connection.send(
+                        content: payload, completion: .contentProcessed { _ in })
+                }
+                self.pumpWebSocket()
+            case .success(.string):
+                self.pumpWebSocket()
+            case .success:
+                self.pumpWebSocket()
+            case .failure:
+                self.close()
+            }
+        }
+    }
+
+    // MARK: - TCP → WS
+
+    private func pumpLocal() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) {
+            [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if let data, !data.isEmpty {
+                var framed = Data([0])  // channel 0 = data
+                framed.append(data)
+                self.webSocket.send(.data(framed)) { [weak self] sendError in
+                    if sendError != nil {
+                        self?.close()
+                    }
+                }
+            }
+            if isComplete || error != nil {
+                self.close()
+            } else {
+                self.pumpLocal()
+            }
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Services/PortForwardService.swift
+++ b/apps/macos/cubelite/cubelite/Services/PortForwardService.swift
@@ -170,7 +170,11 @@ final class PortForwardRelay: @unchecked Sendable {
                 }
                 if channel == 0, !payload.isEmpty {
                     self.connection.send(
-                        content: payload, completion: .contentProcessed { _ in })
+                        content: payload,
+                        completion: .contentProcessed { _ in
+                            // Best-effort relay: a failed local write surfaces
+                            // as the connection closing, handled by pumpLocal.
+                        })
                 }
                 self.pumpWebSocket()
             case .success(.string):

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -153,6 +153,7 @@ extension MainView {
             ResourceDetailView(
                 resource: resource,
                 kubeAPIService: kubeAPIService,
+                portForwardService: portForwardService,
                 context: sidebarSelection?.context ?? selectedContext,
                 onPodMutated: {
                     selectedPodID = nil

--- a/apps/macos/cubelite/cubelite/Views/MainView.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView.swift
@@ -35,6 +35,8 @@ struct MainView: View {
 
     let kubeconfigService: KubeconfigService
     let kubeAPIService: KubeAPIService
+    /// Port-forward session manager (owned by the app scene).
+    var portForwardService: PortForwardService?
 
     @Environment(ClusterState.self) var clusterState
     @Environment(LogStore.self) var logStore

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -19,6 +19,8 @@ struct ResourceDetailView: View {
     /// Backend used by the pod actions; nil renders the detail read-only
     /// (previews, tests).
     var kubeAPIService: KubeAPIService?
+    /// Port-forward manager; nil hides the port-forward section.
+    var portForwardService: PortForwardService?
     /// Context the resource belongs to (required for actions).
     var context: String?
     /// Invoked after a successful mutation so the parent can reload.
@@ -42,6 +44,9 @@ struct ResourceDetailView: View {
                 }
                 if case .pod(let pod) = resource, kubeAPIService != nil {
                     podActions(pod)
+                }
+                if case .pod(let pod) = resource, portForwardService != nil {
+                    portForwardSection(pod)
                 }
             }
             .padding(20)
@@ -146,6 +151,73 @@ struct ResourceDetailView: View {
     }
 
     @State private var manifestItem: ManifestItem?
+    @State private var forwardLocalPort: String = ""
+    @State private var forwardRemotePort: String = "80"
+
+    // MARK: - Port Forward
+
+    @ViewBuilder
+    private func portForwardSection(_ pod: PodInfo) -> some View {
+        if let service = portForwardService, let context {
+            VStack(alignment: .leading, spacing: 8) {
+                Divider().padding(.vertical, 8)
+                Text("PORT FORWARD")
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .kerning(0.7)
+                    .foregroundStyle(DesignTokens.textTertiary)
+                HStack(spacing: 6) {
+                    TextField("remote", text: $forwardRemotePort)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 60)
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 9))
+                        .foregroundStyle(DesignTokens.textTertiary)
+                    TextField("local", text: $forwardLocalPort)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 60)
+                    Button("Forward") {
+                        let remote = Int(forwardRemotePort) ?? 80
+                        let local = UInt16(forwardLocalPort) ?? UInt16(clamping: remote)
+                        do {
+                            try service.start(
+                                context: context, namespace: pod.namespace, pod: pod.name,
+                                localPort: local, remotePort: remote)
+                        } catch {
+                            actionError = error.localizedDescription
+                        }
+                    }
+                    .controlSize(.small)
+                }
+                ForEach(service.sessions(namespace: pod.namespace, pod: pod.name)) { session in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(sessionColor(session.state))
+                            .frame(width: 6, height: 6)
+                        Text("localhost:\(session.localPort) → \(session.remotePort)")
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(DesignTokens.textSecondary)
+                        if case .failed(let reason) = session.state {
+                            Text(reason)
+                                .font(.system(size: 10))
+                                .foregroundStyle(DesignTokens.statusErr)
+                                .lineLimit(1)
+                        }
+                        Spacer(minLength: 0)
+                        Button("Stop") { service.stop(session) }
+                            .controlSize(.mini)
+                    }
+                }
+            }
+        }
+    }
+
+    private func sessionColor(_ state: PortForwardSession.State) -> Color {
+        switch state {
+        case .active: DesignTokens.statusOk
+        case .starting: DesignTokens.statusWarn
+        case .failed: DesignTokens.statusErr
+        }
+    }
 
     private struct ManifestItem: Identifiable {
         let id = UUID()

--- a/apps/macos/cubelite/cubelite/cubelite.entitlements
+++ b/apps/macos/cubelite/cubelite/cubelite.entitlements
@@ -8,6 +8,9 @@
         <!-- Outbound network connections (K8s API calls via URLSession) -->
         <key>com.apple.security.network.client</key>
         <true/>
+        <!-- Local listener for pod port-forward sessions -->
+        <key>com.apple.security.network.server</key>
+        <true/>
         <!--
         Temporary exception: read/write access to ~/.kube/ outside the sandbox container.
         Required because FileManager.homeDirectoryForCurrentUser is redirected to the


### PR DESCRIPTION
Closes #122

## Backend
- `KubeAPIService.portForwardWebSocket`: opens `/pods/{name}/portforward?ports=N` as a **`v4.channel.k8s.io`** WebSocket (wss, keychain-backed bearer auth, per-server session reuse)
- **`PortForwardService`** (app-scene singleton): one `NWListener` per session on the chosen local port; each accepted TCP connection gets its own WebSocket. `PortForwardRelay` pumps both directions with the channel protocol (byte 0 = data / 1 = error, per-channel 2-byte port header stripped from the first frame); teardown cascades from either side
- `com.apple.security.network.server` entitlement added for the local listener (sandbox-compatible)

## UI (pod detail)
- **PORT FORWARD** section: remote → local port fields + Forward; live session list with state dot (ok/warn/err), `localhost:L → R` mono label and Stop

## Verification
`xcodebuild` build + full unit suite: build clean, 376 passed; one unrelated flake (`AppSettingsContextNamespacesTests`, shared UserDefaults) passes in isolation. Live end-to-end relay needs a real cluster — recommended smoke: forward 80 from an nginx pod and curl localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)