### PR TITLE
feat(macos): exec into pod — line-based shell session

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -470,6 +470,26 @@ actor KubeAPIService {
             path: path, timeout: 3600, failurePrefix: "Watch failed", contextName: contextName)
     }
 
+    /// Opens a Kubernetes exec WebSocket for a shell in the pod's first
+    /// container (`v4.channel.k8s.io`: 0=stdin, 1=stdout, 2=stderr, 3=error).
+    /// The caller owns the returned task (resume/cancel).
+    func execWebSocket(
+        namespace: String,
+        pod: String,
+        command: [String] = ["/bin/sh"],
+        inContext contextName: String? = nil
+    ) async throws -> URLSessionWebSocketTask {
+        var query = "stdin=true&stdout=true&stderr=true&tty=false"
+        for part in command {
+            let encoded =
+                part.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? part
+            query += "&command=\(encoded)"
+        }
+        return try await channelWebSocket(
+            path: "/api/v1/namespaces/\(namespace)/pods/\(pod)/exec?\(query)",
+            inContext: contextName)
+    }
+
     /// Opens the Kubernetes port-forward WebSocket for one pod port using
     /// the SPDY-over-WebSocket channel protocol (`v4.channel.k8s.io`).
     /// The caller owns the returned task (resume/cancel).
@@ -479,22 +499,32 @@ actor KubeAPIService {
         remotePort: Int,
         inContext contextName: String? = nil
     ) async throws -> URLSessionWebSocketTask {
+        try await channelWebSocket(
+            path: "/api/v1/namespaces/\(namespace)/pods/\(pod)/portforward?ports=\(remotePort)",
+            inContext: contextName)
+    }
+
+    /// Opens a `v4.channel.k8s.io` WebSocket against the cluster API
+    /// (exec, attach, port-forward) with keychain-backed bearer auth and
+    /// the per-server session cache.
+    private func channelWebSocket(
+        path: String,
+        inContext contextName: String? = nil
+    ) async throws -> URLSessionWebSocketTask {
         let config = try await kubeconfigService.load()
         let (cluster, user) = try resolveConnectionInfo(from: config, contextName: contextName)
 
         guard let serverString = cluster.server, !serverString.isEmpty else {
             throw CubeliteError.clientError(reason: "Cluster has no valid server URL")
         }
-        var base = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
-        base = base.replacingOccurrences(of: "https://", with: "wss://")
-        let path = "/api/v1/namespaces/\(namespace)/pods/\(pod)/portforward?ports=\(remotePort)"
-        guard let url = URL(string: base + path) else {
-            throw CubeliteError.clientError(reason: "Invalid URL: \(base + path)")
+        let httpBase = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
+        let wsBase = httpBase.replacingOccurrences(of: "https://", with: "wss://")
+        guard let url = URL(string: wsBase + path) else {
+            throw CubeliteError.clientError(reason: "Invalid URL: \(wsBase + path)")
         }
 
         var request = URLRequest(url: url)
         request.setValue("v4.channel.k8s.io", forHTTPHeaderField: "Sec-WebSocket-Protocol")
-        let httpBase = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
         if let token = await bearerToken(for: user, account: httpBase) {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }

--- a/apps/macos/cubelite/cubelite/Views/PodExecView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PodExecView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+/// Line-based shell session inside a pod over the Kubernetes exec
+/// WebSocket (`v4.channel.k8s.io`, tty disabled): commands are sent one
+/// line at a time on the stdin channel; stdout/stderr stream back into a
+/// scrollback rendered on the sunken surface.
+struct PodExecView: View {
+
+    let pod: PodInfo
+    let kubeAPIService: KubeAPIService
+    let context: String?
+    let onClose: () -> Void
+
+    private static let scrollbackCap = 1000
+
+    @State private var lines: [ExecLine] = []
+    @State private var command = ""
+    @State private var sessionError: String?
+    @State private var webSocket: URLSessionWebSocketTask?
+    @FocusState private var inputFocused: Bool
+
+    /// One scrollback entry.
+    struct ExecLine: Identifiable {
+        enum Kind {
+            case input, stdout, stderr, status
+        }
+
+        let id: Int
+        let kind: Kind
+        let text: String
+
+        var color: Color {
+            switch kind {
+            case .input: DesignTokens.accentDefault
+            case .stdout: DesignTokens.textLog
+            case .stderr: DesignTokens.statusErr
+            case .status: DesignTokens.textTertiary
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Rectangle().fill(DesignTokens.borderFaint).frame(height: 1)
+            scrollback
+            Rectangle().fill(DesignTokens.borderFaint).frame(height: 1)
+            inputRow
+        }
+        .frame(minWidth: 640, minHeight: 420)
+        .onAppear { startSession() }
+        .onDisappear { webSocket?.cancel(with: .normalClosure, reason: nil) }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("\(pod.name) — shell")
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            Button("Done", action: onClose)
+                .keyboardShortcut(.cancelAction)
+                .controlSize(.small)
+        }
+        .padding(12)
+    }
+
+    @ViewBuilder
+    private var scrollback: some View {
+        if let sessionError {
+            UnifiedErrorState(title: "Shell session failed", message: sessionError)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 1) {
+                        ForEach(lines) { line in
+                            Text(line.text)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(line.color)
+                                .textSelection(.enabled)
+                                .id(line.id)
+                        }
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(DesignTokens.surfaceSunken)
+                .onChange(of: lines.count) { _, _ in
+                    if let last = lines.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var inputRow: some View {
+        HStack(spacing: 8) {
+            Text("$")
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundStyle(DesignTokens.accentDefault)
+            TextField("command", text: $command)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .focused($inputFocused)
+                .onSubmit { sendCommand() }
+                .disabled(sessionError != nil)
+        }
+        .padding(10)
+    }
+
+    // MARK: - Session
+
+    private func startSession() {
+        inputFocused = true
+        Task {
+            do {
+                let ws = try await kubeAPIService.execWebSocket(
+                    namespace: pod.namespace, pod: pod.name, inContext: context)
+                webSocket = ws
+                ws.resume()
+                append(.status, "connected — line-based shell (/bin/sh, no TTY)")
+                receive(ws)
+            } catch {
+                sessionError = error.localizedDescription
+            }
+        }
+    }
+
+    private func receive(_ ws: URLSessionWebSocketTask) {
+        ws.receive { result in
+            Task { @MainActor in
+                switch result {
+                case .success(.data(var payload)):
+                    guard !payload.isEmpty else { return receive(ws) }
+                    let channel = payload.removeFirst()
+                    let text = String(decoding: payload, as: UTF8.self)
+                    for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
+                        let line = String(raw)
+                        if line.isEmpty { continue }
+                        switch channel {
+                        case 1: append(.stdout, line)
+                        case 2: append(.stderr, line)
+                        case 3: append(.status, line)
+                        default: break
+                        }
+                    }
+                    receive(ws)
+                case .success:
+                    receive(ws)
+                case .failure:
+                    append(.status, "session closed")
+                }
+            }
+        }
+    }
+
+    private func sendCommand() {
+        guard let ws = webSocket, !command.isEmpty else { return }
+        let line = command
+        command = ""
+        append(.input, "$ \(line)")
+        var framed = Data([0])  // channel 0 = stdin
+        framed.append(Data((line + "\n").utf8))
+        ws.send(.data(framed)) { error in
+            if let error {
+                Task { @MainActor in
+                    sessionError = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func append(_ kind: ExecLine.Kind, _ text: String) {
+        lines.append(ExecLine(id: lines.count, kind: kind, text: text))
+        if lines.count > Self.scrollbackCap {
+            lines.removeFirst(lines.count - Self.scrollbackCap)
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -28,6 +28,7 @@ struct ResourceDetailView: View {
 
     @State private var showDeleteConfirm = false
     @State private var showLogs = false
+    @State private var showShell = false
     @State private var manifest: String?
     @State private var actionError: String?
     @State private var isActing = false
@@ -83,6 +84,16 @@ struct ResourceDetailView: View {
                 )
             }
         }
+        .sheet(isPresented: $showShell) {
+            if let service = kubeAPIService, let pod = currentPod {
+                PodExecView(
+                    pod: pod,
+                    kubeAPIService: service,
+                    context: context,
+                    onClose: { showShell = false }
+                )
+            }
+        }
         .sheet(isPresented: $showLogs) {
             if let service = kubeAPIService, let pod = currentPod {
                 PodLogsView(
@@ -90,6 +101,16 @@ struct ResourceDetailView: View {
                     kubeAPIService: service,
                     context: context,
                     onClose: { showLogs = false }
+                )
+            }
+        }
+        .sheet(isPresented: $showShell) {
+            if let service = kubeAPIService, let pod = currentPod {
+                PodExecView(
+                    pod: pod,
+                    kubeAPIService: service,
+                    context: context,
+                    onClose: { showShell = false }
                 )
             }
         }
@@ -117,6 +138,11 @@ struct ResourceDetailView: View {
                     showLogs = true
                 } label: {
                     Label("Logs", systemImage: "doc.plaintext")
+                }
+                Button {
+                    showShell = true
+                } label: {
+                    Label("Shell", systemImage: "terminal")
                 }
                 Button {
                     runAction { service, ctx in


### PR DESCRIPTION
Closes #123

## Backend
- `channelWebSocket`: shared `v4.channel.k8s.io` WebSocket factory (keychain-backed bearer auth, per-server session cache) — port-forward refactored onto it, exec added
- `execWebSocket`: `/exec` with stdin/stdout/stderr channels, `tty=false`

## UI (pod detail → **Shell**)
- Line-based `/bin/sh` session: commands sent per line on the stdin channel; stdout / stderr / error-status streamed into a selectable mono scrollback (cap 1000) on the sunken surface with auto-scroll; `$`-prompt input row, submit on return
- No PTY emulation by design (interactive TUIs like `vi` are out of scope); noted in the connected banner

## Verification
`xcodebuild` build + full unit suite: **exit 0, 377 passed**. Live shell needs a real cluster — smoke: `ls /`, `env`, stderr via `ls /nope`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)