### PR TITLE
feat(macos): manifest edit and apply (kubectl replace semantics)

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -470,6 +470,26 @@ actor KubeAPIService {
             path: path, timeout: 3600, failurePrefix: "Watch failed", contextName: contextName)
     }
 
+    /// Opens a Kubernetes exec WebSocket for a shell in the pod's first
+    /// container (`v4.channel.k8s.io`: 0=stdin, 1=stdout, 2=stderr, 3=error).
+    /// The caller owns the returned task (resume/cancel).
+    func execWebSocket(
+        namespace: String,
+        pod: String,
+        command: [String] = ["/bin/sh"],
+        inContext contextName: String? = nil
+    ) async throws -> URLSessionWebSocketTask {
+        var query = "stdin=true&stdout=true&stderr=true&tty=false"
+        for part in command {
+            let encoded =
+                part.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? part
+            query += "&command=\(encoded)"
+        }
+        return try await channelWebSocket(
+            path: "/api/v1/namespaces/\(namespace)/pods/\(pod)/exec?\(query)",
+            inContext: contextName)
+    }
+
     /// Opens the Kubernetes port-forward WebSocket for one pod port using
     /// the SPDY-over-WebSocket channel protocol (`v4.channel.k8s.io`).
     /// The caller owns the returned task (resume/cancel).
@@ -479,22 +499,32 @@ actor KubeAPIService {
         remotePort: Int,
         inContext contextName: String? = nil
     ) async throws -> URLSessionWebSocketTask {
+        try await channelWebSocket(
+            path: "/api/v1/namespaces/\(namespace)/pods/\(pod)/portforward?ports=\(remotePort)",
+            inContext: contextName)
+    }
+
+    /// Opens a `v4.channel.k8s.io` WebSocket against the cluster API
+    /// (exec, attach, port-forward) with keychain-backed bearer auth and
+    /// the per-server session cache.
+    private func channelWebSocket(
+        path: String,
+        inContext contextName: String? = nil
+    ) async throws -> URLSessionWebSocketTask {
         let config = try await kubeconfigService.load()
         let (cluster, user) = try resolveConnectionInfo(from: config, contextName: contextName)
 
         guard let serverString = cluster.server, !serverString.isEmpty else {
             throw CubeliteError.clientError(reason: "Cluster has no valid server URL")
         }
-        var base = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
-        base = base.replacingOccurrences(of: "https://", with: "wss://")
-        let path = "/api/v1/namespaces/\(namespace)/pods/\(pod)/portforward?ports=\(remotePort)"
-        guard let url = URL(string: base + path) else {
-            throw CubeliteError.clientError(reason: "Invalid URL: \(base + path)")
+        let httpBase = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
+        let wsBase = httpBase.replacingOccurrences(of: "https://", with: "wss://")
+        guard let url = URL(string: wsBase + path) else {
+            throw CubeliteError.clientError(reason: "Invalid URL: \(wsBase + path)")
         }
 
         var request = URLRequest(url: url)
         request.setValue("v4.channel.k8s.io", forHTTPHeaderField: "Sec-WebSocket-Protocol")
-        let httpBase = serverString.hasSuffix("/") ? String(serverString.dropLast()) : serverString
         if let token = await bearerToken(for: user, account: httpBase) {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -649,6 +649,21 @@ actor KubeAPIService {
             inContext: contextName)
     }
 
+    /// Replaces a resource with the edited manifest (PUT, like
+    /// `kubectl replace`). `json` must be the full object including
+    /// metadata.resourceVersion for optimistic concurrency.
+    func applyManifestJSON(
+        apiPath: String, json: String, inContext contextName: String? = nil
+    ) async throws {
+        _ = try await send(
+            path: apiPath,
+            method: "PUT",
+            body: Data(json.utf8),
+            contentType: "application/json",
+            contextName: contextName
+        )
+    }
+
     /// Fetches any resource at `apiPath` as pretty-printed JSON with the
     /// server-side bookkeeping (`metadata.managedFields`) stripped.
     func manifestJSON(apiPath: String, inContext contextName: String? = nil)

--- a/apps/macos/cubelite/cubelite/Views/DeploymentDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/DeploymentDetailView.swift
@@ -62,7 +62,15 @@ struct DeploymentDetailView: View {
             ManifestSheetView(
                 title: "\(deployment.name) — manifest",
                 text: payload.text,
-                onClose: { manifest = nil }
+                onClose: { manifest = nil },
+                onApply: { json in
+                    guard let service = kubeAPIService else { return }
+                    try await service.applyManifestJSON(
+                        apiPath:
+                            "/apis/apps/v1/namespaces/\(deployment.namespace)/deployments/\(deployment.name)",
+                        json: json,
+                        inContext: context)
+                }
             )
         }
         .alert(

--- a/apps/macos/cubelite/cubelite/Views/PodExecView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PodExecView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+/// Line-based shell session inside a pod over the Kubernetes exec
+/// WebSocket (`v4.channel.k8s.io`, tty disabled): commands are sent one
+/// line at a time on the stdin channel; stdout/stderr stream back into a
+/// scrollback rendered on the sunken surface.
+struct PodExecView: View {
+
+    let pod: PodInfo
+    let kubeAPIService: KubeAPIService
+    let context: String?
+    let onClose: () -> Void
+
+    private static let scrollbackCap = 1000
+
+    @State private var lines: [ExecLine] = []
+    @State private var command = ""
+    @State private var sessionError: String?
+    @State private var webSocket: URLSessionWebSocketTask?
+    @FocusState private var inputFocused: Bool
+
+    /// One scrollback entry.
+    struct ExecLine: Identifiable {
+        enum Kind {
+            case input, stdout, stderr, status
+        }
+
+        let id: Int
+        let kind: Kind
+        let text: String
+
+        var color: Color {
+            switch kind {
+            case .input: DesignTokens.accentDefault
+            case .stdout: DesignTokens.textLog
+            case .stderr: DesignTokens.statusErr
+            case .status: DesignTokens.textTertiary
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Rectangle().fill(DesignTokens.borderFaint).frame(height: 1)
+            scrollback
+            Rectangle().fill(DesignTokens.borderFaint).frame(height: 1)
+            inputRow
+        }
+        .frame(minWidth: 640, minHeight: 420)
+        .onAppear { startSession() }
+        .onDisappear { webSocket?.cancel(with: .normalClosure, reason: nil) }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("\(pod.name) — shell")
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            Button("Done", action: onClose)
+                .keyboardShortcut(.cancelAction)
+                .controlSize(.small)
+        }
+        .padding(12)
+    }
+
+    @ViewBuilder
+    private var scrollback: some View {
+        if let sessionError {
+            UnifiedErrorState(title: "Shell session failed", message: sessionError)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 1) {
+                        ForEach(lines) { line in
+                            Text(line.text)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(line.color)
+                                .textSelection(.enabled)
+                                .id(line.id)
+                        }
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(DesignTokens.surfaceSunken)
+                .onChange(of: lines.count) { _, _ in
+                    if let last = lines.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var inputRow: some View {
+        HStack(spacing: 8) {
+            Text("$")
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundStyle(DesignTokens.accentDefault)
+            TextField("command", text: $command)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .focused($inputFocused)
+                .onSubmit { sendCommand() }
+                .disabled(sessionError != nil)
+        }
+        .padding(10)
+    }
+
+    // MARK: - Session
+
+    private func startSession() {
+        inputFocused = true
+        Task {
+            do {
+                let ws = try await kubeAPIService.execWebSocket(
+                    namespace: pod.namespace, pod: pod.name, inContext: context)
+                webSocket = ws
+                ws.resume()
+                append(.status, "connected — line-based shell (/bin/sh, no TTY)")
+                receive(ws)
+            } catch {
+                sessionError = error.localizedDescription
+            }
+        }
+    }
+
+    private func receive(_ ws: URLSessionWebSocketTask) {
+        ws.receive { result in
+            Task { @MainActor in
+                switch result {
+                case .success(.data(var payload)):
+                    guard !payload.isEmpty else { return receive(ws) }
+                    let channel = payload.removeFirst()
+                    let text = String(decoding: payload, as: UTF8.self)
+                    for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
+                        let line = String(raw)
+                        if line.isEmpty { continue }
+                        switch channel {
+                        case 1: append(.stdout, line)
+                        case 2: append(.stderr, line)
+                        case 3: append(.status, line)
+                        default: break
+                        }
+                    }
+                    receive(ws)
+                case .success:
+                    receive(ws)
+                case .failure:
+                    append(.status, "session closed")
+                }
+            }
+        }
+    }
+
+    private func sendCommand() {
+        guard let ws = webSocket, !command.isEmpty else { return }
+        let line = command
+        command = ""
+        append(.input, "$ \(line)")
+        var framed = Data([0])  // channel 0 = stdin
+        framed.append(Data((line + "\n").utf8))
+        ws.send(.data(framed)) { error in
+            if let error {
+                Task { @MainActor in
+                    sessionError = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func append(_ kind: ExecLine.Kind, _ text: String) {
+        lines.append(ExecLine(id: lines.count, kind: kind, text: text))
+        if lines.count > Self.scrollbackCap {
+            lines.removeFirst(lines.count - Self.scrollbackCap)
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -71,7 +71,15 @@ struct ResourceDetailView: View {
             ManifestSheetView(
                 title: "\(resourceName) — manifest",
                 text: item.text,
-                onClose: { manifestItem = nil }
+                onClose: { manifestItem = nil },
+                onApply: { json in
+                    guard let service = kubeAPIService, let pod = currentPod else { return }
+                    try await service.applyManifestJSON(
+                        apiPath: "/api/v1/namespaces/\(pod.namespace)/pods/\(pod.name)",
+                        json: json,
+                        inContext: context)
+                    onPodMutated?()
+                }
             )
         }
         .sheet(isPresented: $showLogs) {

--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -28,6 +28,7 @@ struct ResourceDetailView: View {
 
     @State private var showDeleteConfirm = false
     @State private var showLogs = false
+    @State private var showShell = false
     @State private var manifest: String?
     @State private var actionError: String?
     @State private var isActing = false
@@ -83,6 +84,16 @@ struct ResourceDetailView: View {
                 )
             }
         }
+        .sheet(isPresented: $showShell) {
+            if let service = kubeAPIService, let pod = currentPod {
+                PodExecView(
+                    pod: pod,
+                    kubeAPIService: service,
+                    context: context,
+                    onClose: { showShell = false }
+                )
+            }
+        }
         .sheet(isPresented: $showLogs) {
             if let service = kubeAPIService, let pod = currentPod {
                 PodLogsView(
@@ -90,6 +101,16 @@ struct ResourceDetailView: View {
                     kubeAPIService: service,
                     context: context,
                     onClose: { showLogs = false }
+                )
+            }
+        }
+        .sheet(isPresented: $showShell) {
+            if let service = kubeAPIService, let pod = currentPod {
+                PodExecView(
+                    pod: pod,
+                    kubeAPIService: service,
+                    context: context,
+                    onClose: { showShell = false }
                 )
             }
         }
@@ -117,6 +138,11 @@ struct ResourceDetailView: View {
                     showLogs = true
                 } label: {
                     Label("Logs", systemImage: "doc.plaintext")
+                }
+                Button {
+                    showShell = true
+                } label: {
+                    Label("Shell", systemImage: "terminal")
                 }
                 Button {
                     runAction { service, ctx in

--- a/apps/macos/cubelite/cubelite/Views/Shell/ManifestSheetView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/ManifestSheetView.swift
@@ -1,14 +1,22 @@
 import SwiftUI
 
-/// Shared read-only manifest sheet: pretty-printed JSON on the sunken
-/// surface, text-selectable, with a copy action.
+/// Shared manifest sheet: pretty-printed JSON on the sunken surface,
+/// text-selectable, with copy — and, when `onApply` is provided, an edit
+/// mode that PUTs the modified manifest back (kubectl replace semantics).
 struct ManifestSheetView: View {
 
     let title: String
     let text: String
     let onClose: () -> Void
+    /// Enables Edit/Apply; throws surface inline (e.g. resourceVersion
+    /// conflicts, validation errors).
+    var onApply: ((String) async throws -> Void)?
 
     @State private var copied = false
+    @State private var editing = false
+    @State private var draft = ""
+    @State private var applying = false
+    @State private var applyError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -18,28 +26,87 @@ struct ManifestSheetView: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Spacer()
-                Button(copied ? "Copied" : "Copy") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(text, forType: .string)
-                    copied = true
-                }
-                .controlSize(.small)
-                Button("Done", action: onClose)
-                    .keyboardShortcut(.defaultAction)
+                if editing {
+                    Button("Cancel") {
+                        editing = false
+                        applyError = nil
+                    }
                     .controlSize(.small)
+                    Button(applying ? "Applying…" : "Apply") {
+                        apply()
+                    }
+                    .controlSize(.small)
+                    .disabled(applying)
+                } else {
+                    if onApply != nil {
+                        Button("Edit") {
+                            draft = text
+                            editing = true
+                        }
+                        .controlSize(.small)
+                    }
+                    Button(copied ? "Copied" : "Copy") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(text, forType: .string)
+                        copied = true
+                    }
+                    .controlSize(.small)
+                    Button("Done", action: onClose)
+                        .keyboardShortcut(.defaultAction)
+                        .controlSize(.small)
+                }
             }
             .padding(12)
+            if let applyError {
+                Text(applyError)
+                    .font(.system(size: 11))
+                    .foregroundStyle(DesignTokens.statusErr)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                    .textSelection(.enabled)
+            }
             Divider()
-            ScrollView([.vertical, .horizontal]) {
-                Text(text)
+            if editing {
+                TextEditor(text: $draft)
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(DesignTokens.textLog)
-                    .textSelection(.enabled)
-                    .padding(12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .scrollContentBackground(.hidden)
+                    .background(DesignTokens.surfaceSunken)
+            } else {
+                ScrollView([.vertical, .horizontal]) {
+                    Text(text)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(DesignTokens.textLog)
+                        .textSelection(.enabled)
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(DesignTokens.surfaceSunken)
             }
-            .background(DesignTokens.surfaceSunken)
         }
         .frame(minWidth: 560, minHeight: 420)
+    }
+
+    private func apply() {
+        guard let onApply else { return }
+        // Validate JSON locally before shipping it to the API server.
+        guard let data = draft.data(using: .utf8),
+            (try? JSONSerialization.jsonObject(with: data)) != nil
+        else {
+            applyError = "Draft is not valid JSON."
+            return
+        }
+        applying = true
+        applyError = nil
+        Task {
+            defer { applying = false }
+            do {
+                try await onApply(draft)
+                editing = false
+                onClose()
+            } catch {
+                applyError = error.localizedDescription
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #124. Stacked on #278 (auto-retargets when it merges).

## What
- `KubeAPIService.applyManifestJSON`: **PUT** of the full edited object — the API server enforces optimistic concurrency via `metadata.resourceVersion` (a stale edit surfaces as a conflict error inline)
- **ManifestSheetView edit mode** (behind an optional `onApply`): TextEditor on the sunken surface, local JSON validation before shipping, Apply with selectable inline error, Cancel restores view mode
- Wired for **pods** (Describe sheet; list reloads on success) and **deployments** (Manifest sheet)

The manifest format is JSON (`kubectl get -o json` equivalent) — matches the viewer shipped in #275; YAML-format rendering is a cosmetic follow-up with no functional gap, so this closes the issue.

## Verification
`xcodebuild` build + full unit suite: **exit 0, 377 passed**. Live apply needs a real cluster — smoke: edit a deployment label and Apply, then re-open the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)