### PR TITLE
feat(macos): migrate kubeconfig bearer tokens to Keychain at load

### DIFF
--- a/apps/macos/cubelite/cubelite/Models/KubeContext.swift
+++ b/apps/macos/cubelite/cubelite/Models/KubeContext.swift
@@ -78,6 +78,20 @@ struct UserDetails: Codable, Sendable {
         case clientCertificate = "client-certificate"
         case clientKey = "client-key"
     }
+
+    /// A copy of these credentials with the bearer token removed.
+    ///
+    /// Used after the token has been migrated to the Keychain so the
+    /// in-memory kubeconfig model never carries it past load time.
+    func redactingToken() -> UserDetails {
+        UserDetails(
+            token: nil,
+            clientCertificateData: clientCertificateData,
+            clientKeyData: clientKeyData,
+            clientCertificate: clientCertificate,
+            clientKey: clientKey
+        )
+    }
 }
 
 // MARK: - Processed KubeConfig

--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -420,9 +420,11 @@ actor KubeAPIService {
         return response.items.map { $0.toNodeInfo() }
     }
 
-    /// Bearer token for a request: the keychain copy wins; on first use the
-    /// kubeconfig token is imported into the keychain (keyed by the cluster
-    /// server URL) so subsequent requests never read it from the file again.
+    /// Bearer token for a request: the keychain copy wins. `KubeconfigService`
+    /// migrates file tokens into the keychain (keyed by the cluster server
+    /// URL) at load time and redacts them from the in-memory model, so
+    /// `user.token` is normally nil here; the import fallback remains for
+    /// callers that construct `UserDetails` directly.
     private func bearerToken(for user: UserDetails, account: String) async -> String? {
         if let stored = try? await keychain.retrieveString(tag: .bearerToken, account: account),
             !stored.isEmpty

--- a/apps/macos/cubelite/cubelite/Services/KubeconfigService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeconfigService.swift
@@ -5,7 +5,23 @@ import Yams
 ///
 /// Mirrors the logic of `cubelite-core`'s `kubeconfig.rs` — resolves KUBECONFIG
 /// environment paths, merges multiple configs, and manages the active context.
+///
+/// # Credential handling
+///
+/// Bearer tokens found in kubeconfig files are migrated to the macOS Keychain
+/// during every load (keyed by cluster server URL; an existing Keychain copy
+/// always wins) and then stripped from the returned in-memory model, so no
+/// token outlives the load call outside the Keychain. `save(_:)` re-reads the
+/// on-disk file and only rewrites `current-context`, leaving file credentials
+/// untouched.
 actor KubeconfigService {
+
+    /// Keychain used as the durable home for bearer tokens found in kubeconfig files.
+    private let keychain: KeychainService
+
+    init(keychain: KeychainService = KeychainService()) {
+        self.keychain = keychain
+    }
 
     // MARK: - Path Resolution
 
@@ -107,16 +123,18 @@ actor KubeconfigService {
     ///
     /// Uses `customPaths` when non-empty; otherwise falls back to `KUBECONFIG`
     /// env-var resolution and `~/.kube/config`.
-    func load() throws -> KubeConfig {
+    func load() async throws -> KubeConfig {
         let paths = customPaths.isEmpty ? Self.resolveKubeconfigPaths() : customPaths
-        return try loadFromPaths(paths)
+        return try await loadFromPaths(paths)
     }
 
     /// Loads and merges kubeconfig from the given file paths.
     ///
     /// - The first file's `current-context` wins.
     /// - Contexts are merged; duplicate names from later files are skipped.
-    func loadFromPaths(_ paths: [URL]) throws -> KubeConfig {
+    /// - Bearer tokens are migrated to the Keychain and stripped from the
+    ///   returned model (see the type-level documentation).
+    func loadFromPaths(_ paths: [URL]) async throws -> KubeConfig {
         guard !paths.isEmpty else {
             throw CubeliteError.fileNotFound(path: "No kubeconfig paths resolved")
         }
@@ -178,10 +196,14 @@ actor KubeconfigService {
             )
         }
 
-        // Store the fully merged collections into the raw config
+        await migrateTokensToKeychain(
+            contexts: mergedContexts, clusters: mergedClusters, users: mergedUsers)
+
+        // Store the fully merged collections into the raw config, with bearer
+        // tokens redacted now that the Keychain holds them.
         raw.contexts = mergedContexts
         raw.clusters = mergedClusters
-        raw.users = mergedUsers
+        raw.users = mergedUsers.map { NamedUser(name: $0.name, user: $0.user?.redactingToken()) }
         raw.currentContext = currentContext
 
         return KubeConfig(
@@ -190,6 +212,45 @@ actor KubeconfigService {
             raw: raw,
             paths: paths
         )
+    }
+
+    // MARK: - Credential Migration
+
+    /// Imports every bearer token referenced by a context into the Keychain,
+    /// keyed by the cluster's server URL (trailing slash dropped, matching
+    /// `KubeAPIService` session accounts). An existing Keychain entry always
+    /// wins over the file copy, so user edits made via "Reset stored
+    /// credentials" or the Keychain itself are never clobbered.
+    private func migrateTokensToKeychain(
+        contexts: [NamedContext],
+        clusters: [NamedCluster],
+        users: [NamedUser]
+    ) async {
+        let serversByCluster = Dictionary(
+            clusters.compactMap { named in named.cluster?.server.map { (named.name, $0) } },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let tokensByUser = Dictionary(
+            users.compactMap { named in named.user?.token.map { (named.name, $0) } },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for context in contexts {
+            guard
+                let clusterName = context.context?.cluster,
+                let userName = context.context?.user,
+                let server = serversByCluster[clusterName], !server.isEmpty,
+                let token = tokensByUser[userName], !token.isEmpty
+            else { continue }
+            let account = server.hasSuffix("/") ? String(server.dropLast()) : server
+
+            if let existing = try? await keychain.retrieveString(
+                tag: .bearerToken, account: account), !existing.isEmpty
+            {
+                continue
+            }
+            try? await keychain.storeString(token, tag: .bearerToken, account: account)
+        }
     }
 
     // MARK: - Context Management
@@ -208,15 +269,28 @@ actor KubeconfigService {
 
     // MARK: - Save
 
-    /// Saves the config back to YAML, writing to the first path.
+    /// Persists the config's `current-context` to the first kubeconfig file.
+    ///
+    /// The on-disk file is re-read and only `current-context` is rewritten:
+    /// the in-memory model has bearer tokens redacted, so encoding it directly
+    /// would strip credentials from the user's kubeconfig (and merge entries
+    /// from other files into it).
     func save(_ config: KubeConfig) throws {
         guard let firstPath = config.paths.first else {
             throw CubeliteError.ioError(reason: "No kubeconfig path available for saving")
         }
 
-        let encoder = YAMLEncoder()
-        let yamlString = try encoder.encode(config.raw)
+        var onDisk: RawKubeConfig
+        do {
+            let data = try Data(contentsOf: firstPath)
+            onDisk = try YAMLDecoder().decode(RawKubeConfig.self, from: data)
+        } catch {
+            throw CubeliteError.ioError(
+                reason: "Cannot re-read kubeconfig for saving: \(firstPath.path)")
+        }
+        onDisk.currentContext = config.currentContext
 
+        let yamlString = try YAMLEncoder().encode(onDisk)
         guard let data = yamlString.data(using: .utf8) else {
             throw CubeliteError.ioError(reason: "Failed to encode YAML to UTF-8 data")
         }

--- a/apps/macos/cubelite/cubeliteTests/KubeconfigCredentialMigrationTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/KubeconfigCredentialMigrationTests.swift
@@ -1,0 +1,218 @@
+import XCTest
+
+@testable import cubelite
+
+// MARK: - KubeconfigCredentialMigrationTests
+
+/// Tests for the load-time bearer-token migration: tokens found in kubeconfig
+/// files are imported into the Keychain (keyed by cluster server URL) and
+/// stripped from the in-memory model, while `save(_:)` leaves the on-disk
+/// credentials untouched.
+final class KubeconfigCredentialMigrationTests: XCTestCase {
+
+    private let sut = KubeconfigService()
+    private let keychain = KeychainService()
+    private var cleanupAccounts: [String] = []
+    private var tempFiles: [URL] = []
+
+    override func tearDown() async throws {
+        for account in cleanupAccounts {
+            try? await keychain.delete(tag: .bearerToken, account: account)
+        }
+        for url in tempFiles {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - Import
+
+    func testLoad_importsTokenIntoKeychain_keyedByServer() async throws {
+        let server = uniqueServer()
+        let url = try temporaryFile(contents: yaml(server: server, token: "file-token"))
+
+        _ = try await sut.loadFromPaths([url])
+
+        let stored = try await keychain.retrieveString(tag: .bearerToken, account: server)
+        XCTAssertEqual(stored, "file-token")
+    }
+
+    func testLoad_serverWithTrailingSlash_importsUnderTrimmedAccount() async throws {
+        let base = uniqueServer()
+        let url = try temporaryFile(contents: yaml(server: base + "/", token: "slash-token"))
+
+        _ = try await sut.loadFromPaths([url])
+
+        let stored = try await keychain.retrieveString(tag: .bearerToken, account: base)
+        XCTAssertEqual(stored, "slash-token")
+    }
+
+    func testLoad_existingKeychainEntry_winsOverFileToken() async throws {
+        let server = uniqueServer()
+        try await keychain.storeString("keychain-token", tag: .bearerToken, account: server)
+        let url = try temporaryFile(contents: yaml(server: server, token: "file-token"))
+
+        _ = try await sut.loadFromPaths([url])
+
+        let stored = try await keychain.retrieveString(tag: .bearerToken, account: server)
+        XCTAssertEqual(stored, "keychain-token")
+    }
+
+    func testLoad_userWithoutToken_createsNoKeychainEntry() async throws {
+        let server = uniqueServer()
+        let url = try temporaryFile(contents: yaml(server: server, token: nil))
+
+        _ = try await sut.loadFromPaths([url])
+
+        let stored = try await keychain.retrieveString(tag: .bearerToken, account: server)
+        XCTAssertNil(stored)
+    }
+
+    // MARK: - Redaction
+
+    func testLoad_redactsTokenFromInMemoryModel() async throws {
+        let server = uniqueServer()
+        let url = try temporaryFile(contents: yaml(server: server, token: "file-token"))
+
+        let config = try await sut.loadFromPaths([url])
+
+        for named in config.raw.users ?? [] {
+            XCTAssertNil(named.user?.token, "Token must not survive load for user \(named.name)")
+        }
+    }
+
+    func testLoad_redaction_keepsClientCertificateFields() async throws {
+        let server = uniqueServer()
+        let url = try temporaryFile(
+            contents: """
+                apiVersion: v1
+                kind: Config
+                current-context: ctx
+                contexts:
+                - name: ctx
+                  context:
+                    cluster: cl
+                    user: u
+                clusters:
+                - name: cl
+                  cluster:
+                    server: \(server)
+                users:
+                - name: u
+                  user:
+                    token: file-token
+                    client-certificate-data: Y2VydA==
+                    client-key-data: a2V5
+                """)
+
+        let config = try await sut.loadFromPaths([url])
+
+        let user = config.raw.users?.first?.user
+        XCTAssertNil(user?.token)
+        XCTAssertEqual(user?.clientCertificateData, "Y2VydA==")
+        XCTAssertEqual(user?.clientKeyData, "a2V5")
+    }
+
+    // MARK: - Save preserves file credentials
+
+    func testSave_afterRedactedLoad_keepsTokenOnDisk() async throws {
+        let server = uniqueServer()
+        let url = try temporaryFile(contents: yaml(server: server, token: "file-token"))
+
+        let config = try await sut.loadFromPaths([url])
+        try await sut.save(config)
+
+        let saved = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(
+            saved.contains("file-token"),
+            "save must not strip credentials from the on-disk kubeconfig")
+    }
+
+    func testSave_afterSetActiveContext_updatesContextAndKeepsToken() async throws {
+        let server = uniqueServer()
+        let contents = """
+            apiVersion: v1
+            kind: Config
+            current-context: ctx-a
+            contexts:
+            - name: ctx-a
+              context:
+                cluster: cl
+                user: u
+            - name: ctx-b
+              context:
+                cluster: cl
+                user: u
+            clusters:
+            - name: cl
+              cluster:
+                server: \(server)
+            users:
+            - name: u
+              user:
+                token: file-token
+            """
+        let url = try temporaryFile(contents: contents)
+
+        var config = try await sut.loadFromPaths([url])
+        try await sut.setActiveContext("ctx-b", in: &config)
+        try await sut.save(config)
+
+        let saved = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(saved.contains("current-context: ctx-b"))
+        XCTAssertTrue(saved.contains("file-token"))
+    }
+
+    func testSave_multipleSourcePaths_doesNotMergeOtherFilesIntoFirst() async throws {
+        let serverA = uniqueServer()
+        let serverB = uniqueServer()
+        let urlA = try temporaryFile(contents: yaml(server: serverA, token: "token-a", name: "a"))
+        let urlB = try temporaryFile(contents: yaml(server: serverB, token: "token-b", name: "b"))
+
+        let config = try await sut.loadFromPaths([urlA, urlB])
+        try await sut.save(config)
+
+        let savedFirst = try String(contentsOf: urlA, encoding: .utf8)
+        XCTAssertFalse(
+            savedFirst.contains("ctx-b"),
+            "save must only rewrite current-context, not merge other files into the first")
+        XCTAssertTrue(savedFirst.contains("token-a"))
+    }
+
+    // MARK: - Helpers
+
+    /// Unique fake server per test so Keychain entries never collide across runs.
+    private func uniqueServer() -> String {
+        let server = "https://migrate-\(UUID().uuidString).example"
+        cleanupAccounts.append(server)
+        return server
+    }
+
+    private func temporaryFile(contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cubelite-migration-test-\(UUID().uuidString).yaml")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        tempFiles.append(url)
+        return url
+    }
+
+    private func yaml(server: String, token: String?, name: String = "a") -> String {
+        let tokenLine = token.map { "\n        token: \($0)" } ?? ""
+        return """
+            apiVersion: v1
+            kind: Config
+            current-context: ctx-\(name)
+            contexts:
+            - name: ctx-\(name)
+              context:
+                cluster: cluster-\(name)
+                user: user-\(name)
+            clusters:
+            - name: cluster-\(name)
+              cluster:
+                server: \(server)
+            users:
+            - name: user-\(name)
+              user:\(tokenLine.isEmpty ? " {}" : tokenLine)
+            """
+    }
+}


### PR DESCRIPTION
Closes #107 — completes the remaining scope from the issue comment: one-shot migration sweep at launch and purging tokens from the in-memory kubeconfig model.

## What

- **Load-time token migration**: `KubeconfigService.loadFromPaths` now imports every context's bearer token into the Keychain (keyed by cluster server URL, trailing slash dropped — same account scheme as `KubeAPIService`). An existing Keychain entry always wins over the file copy.
- **In-memory redaction**: after migration, tokens are stripped from the returned `KubeConfig` model (`UserDetails.redactingToken()`), so no token outlives the load call outside the Keychain. Client-certificate fields are untouched.
- **Launch coverage**: the sweep runs on the first load at launch and on every reload, which supersedes a one-shot flag — clusters added to the kubeconfig later are migrated too.
- **`save()` made credential-safe**: it now re-reads the on-disk file and rewrites only `current-context`. Encoding the redacted in-memory model would have stripped tokens from the user's kubeconfig file; as a bonus this also stops merging other kubeconfig files' entries into the first file on save.
- `KubeAPIService.bearerToken` keeps its keychain-first resolution; the file-token import fallback remains for directly constructed `UserDetails`.

## Acceptance criteria mapping

- No tokens remain in-memory beyond load: redaction in `loadFromPaths` ✅
- Migration path for existing users (import on launch): sweep on first load ✅
- Keychain entries created and reused, keychain copy wins ✅
- "Reset stored credentials" still works: deletes entries; next load re-imports fresh from file ✅

## Tests

9 new tests in `KubeconfigCredentialMigrationTests` (import keyed by server, trailing-slash trim, keychain-wins, no-token no-entry, model redaction, cert fields preserved, save keeps on-disk token, save after context switch, save no longer merges files). Unique fake server URLs per run + tearDown cleanup, no Keychain residue.

Gates: build-for-testing ✅ · 386 unit tests passed, 0 failed (UITests skipped as usual) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)