### PR TITLE
fix(macos): pod Logs/Shell sheets never presented

### DIFF
--- a/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
+++ b/apps/macos/cubelite/cubelite/Views/ResourceDetailView.swift
@@ -102,26 +102,6 @@ struct ResourceDetailView: View {
                 )
             }
         }
-        .sheet(isPresented: $showLogs) {
-            if let service = kubeAPIService, let pod = currentPod {
-                PodLogsView(
-                    pod: pod,
-                    kubeAPIService: service,
-                    context: context,
-                    onClose: { showLogs = false }
-                )
-            }
-        }
-        .sheet(isPresented: $showShell) {
-            if let service = kubeAPIService, let pod = currentPod {
-                PodExecView(
-                    pod: pod,
-                    kubeAPIService: service,
-                    context: context,
-                    onClose: { showShell = false }
-                )
-            }
-        }
         .alert(
             "Action failed", isPresented: .constant(actionError != nil),
             actions: {


### PR DESCRIPTION
Pressing **Logs** (or **Shell**) in the pod detail did nothing: `ResourceDetailView` had `.sheet(isPresented: $showLogs)` and `.sheet(isPresented: $showShell)` attached **twice** each (lines 85–124) — merge residue from the #277–#279 stacked chain (`git log -S` traces it to that resolution). Two sheets bound to the same flag issue competing presentation requests and SwiftUI silently presents neither.

Fix: remove the duplicated second pair; one sheet per flag remains.

Gates: build-for-testing ✅ · unit tests exit 0 ✅ (UITests skipped as usual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)