### PR TITLE
fix(ci): correct corrupted deploy-pages action SHA pin

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
The Pages deploy on main ([run 29205613999](https://github.com/massimilianolapuma/cubelite/actions/runs/29205613999)) failed at job setup:

> Unable to resolve action `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc`

The pin predates today's changes but the workflow hadn't run in a while. The real v4.0.5 SHA is `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (verified via `repos/actions/deploy-pages/git/refs/tags`); the workflow had a corrupted tail. One-character-class fix.

Also audited every other pinned action SHA in `pages.yml`, `ci.yml`-shared pins, and `release.yml` against their upstream repos — all resolve correctly; this was the only bad pin.

After merge, re-run the Pages workflow (or push anything under `site/**` / `docs/guide/**`) to get the site deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)