### PR TITLE
ci(release): auto-release on version bump — no manual tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,49 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  version:
+    name: Detect releasable version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.check.outputs.tag }}
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Compare workspace version against existing tags
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(awk -F '"' '/^version = /{print $2; exit}' Cargo.toml)"
+          if [ -z "$VERSION" ]; then
+            echo "Could not read workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+          TAG="v$VERSION"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — nothing to do."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Will release $TAG."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build-macos-native:
     name: Build macOS app
+    needs: version
+    if: needs.version.outputs.should_release == 'true'
     runs-on: macos-15
     timeout-minutes: 45
     steps:
@@ -52,6 +87,8 @@ jobs:
 
   build-desktop:
     name: Build desktop (${{ matrix.platform }})
+    needs: version
+    if: needs.version.outputs.should_release == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -122,14 +159,15 @@ jobs:
 
   publish-release:
     name: Publish GitHub Release
-    needs: [build-macos-native, build-desktop]
+    needs: [version, build-macos-native, build-desktop]
     # Publish as long as the native macOS app built; a broken desktop
     # platform must not hold the whole release hostage.
-    if: always() && needs.build-macos-native.result == 'success'
+    if: always() && needs.version.outputs.should_release == 'true' && needs.build-macos-native.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -145,8 +183,9 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Compose release notes from CHANGELOG
+        env:
+          TAG: ${{ needs.version.outputs.tag }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
           # Pull the "## [X.Y.Z]" section out of CHANGELOG.md when present.
           awk -v ver="$VERSION" '
@@ -163,16 +202,24 @@ jobs:
             echo "[Installation guide](https://massimilianolapuma.github.io/cubelite/docs/installation.html) · builds are not yet notarized/signed; see the guide for the one-time Gatekeeper/SmartScreen step."
           } >> notes.md
 
-      - name: Create release
+      - name: Create tag + release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.version.outputs.tag }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
           PRERELEASE_FLAG=""
           case "$TAG" in *-*) PRERELEASE_FLAG="--prerelease" ;; esac
+          # --target creates the tag at this commit; no manual tagging needed.
           gh release create "$TAG" \
             --title "CubeLite $TAG" \
             --notes-file notes.md \
-            --verify-tag \
+            --target "$GITHUB_SHA" \
             $PRERELEASE_FLAG \
             assets/*
+
+      - name: Redeploy GitHub Pages
+        # Releases created with GITHUB_TOKEN don't emit workflow-triggering
+        # events (recursion guard), so kick the Pages deploy explicitly.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run pages.yml --ref main

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,34 +1,34 @@
 # Releasing CubeLite
 
-One tag push does everything: builds, publishes the GitHub Release with installers, and redeploys the website/docs.
+Releases are fully automatic: merging a version bump to `main` builds, tags, and publishes everything. No manual tagging.
 
-## Checklist
+## Checklist (one PR)
 
-1. **Bump versions** (keep them aligned with the tag):
-   - `Cargo.toml` → `[workspace.package] version` (drives the Tauri desktop bundles)
+1. **Bump versions** (keep them aligned):
+   - `Cargo.toml` → `[workspace.package] version` — **this is the trigger and the source of truth for the tag**
    - `apps/desktop/src-tauri/tauri.conf.json` → `version`
    - Xcode project → `MARKETING_VERSION` for the cubelite target
-2. **CHANGELOG.md**: rename the `## [Unreleased]` section to `## [X.Y.Z] - YYYY-MM-DD` and start a fresh empty `## [Unreleased]` above it. The release notes are extracted from this section.
-3. Merge to `main`, then tag:
+   - refresh the lockfile: `cargo update --workspace`
+2. **CHANGELOG.md**: rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` and start a fresh empty `## [Unreleased]` above it. This section becomes the release notes.
+3. Open the PR, merge to `main`. Done.
 
-   ```sh
-   git tag vX.Y.Z && git push origin vX.Y.Z
-   ```
+## What automation does on merge
 
-## What automation does on the tag
+`release.yml` fires on any `main` push that touches `Cargo.toml`:
 
-- `release.yml` builds:
-  - native macOS app (Release, ad-hoc signed) → `CubeLite-macOS.dmg` / `.zip`
-  - Tauri desktop bundles on macOS/Linux/Windows → `CubeLite-Desktop-*` assets
-  - publishes the GitHub Release with the CHANGELOG section as notes, `SHA256SUMS.txt`, and **stable asset names** (so `releases/latest/download/…` links on the site and in the docs never need editing)
-  - tags containing a `-` (e.g. `v0.4.0-beta.1`) are marked pre-release
-  - a failing desktop platform does **not** block the release; the macOS native assets are the gate
-- `pages.yml` redeploys the website on release publish; the site's version badge reads the latest release from the GitHub API at page load, and the user guide is re-rendered from `docs/guide/*.md`.
+1. **version** job reads the workspace version; if release `vX.Y.Z` already exists the run ends there (so unrelated `Cargo.toml` edits are free).
+2. Builds:
+   - native macOS app (Release, ad-hoc signed) → `CubeLite-macOS.dmg` / `.zip`
+   - Tauri desktop bundles on macOS/Linux/Windows → `CubeLite-Desktop-*`
+3. **publish-release** creates the `vX.Y.Z` tag *and* the GitHub Release in one step (`gh release create --target`), with the CHANGELOG section as notes, `SHA256SUMS.txt`, and **stable asset names** (`releases/latest/download/…` links never change). Versions containing `-` (e.g. `0.4.0-beta.1`) are marked pre-release. A failing desktop platform does **not** block the release; the macOS native build is the gate.
+4. **Pages redeploy** is dispatched explicitly at the end (releases created by the workflow token don't emit triggering events), so the site's docs and version badge refresh.
+
+`workflow_dispatch` on `release.yml` is the manual escape hatch: run it from the Actions UI to (re)attempt a release of the current `main` version.
 
 ## After the release
 
 - Verify the download links on <https://massimilianolapuma.github.io/cubelite/> resolve to the new version.
-- If a desktop platform job failed, fix it and re-run just that job from the Actions UI, then upload the missing asset to the existing release (`gh release upload vX.Y.Z <file>`).
+- If a desktop platform job failed, fix it, then upload the missing asset to the existing release (`gh release upload vX.Y.Z <file>`).
 
 ## Not automated yet
 


### PR DESCRIPTION
Follow-up to #288/#290: releasing no longer needs a manual `git tag`.

## New flow
Merge a version-bump PR (per updated `docs/RELEASING.md`) → done. On any `main` push touching `Cargo.toml`:

1. **version** job reads the workspace version from `Cargo.toml`; if release `vX.Y.Z` already exists, the run stops there (unrelated Cargo.toml edits cost one 5-minute job, no builds).
2. Build jobs run as before (macOS native + Tauri matrix, `fail-fast: false`).
3. **publish-release** runs `gh release create vX.Y.Z --target $GITHUB_SHA …` — creating the **tag and the Release atomically**. Prerelease detection unchanged (`-` in version).
4. Explicit `gh workflow run pages.yml` at the end: tags/releases created with `GITHUB_TOKEN` don't emit workflow-triggering events (GitHub's recursion guard), so the site redeploy is dispatched directly (`workflow_dispatch` is exempt from the guard). This is also why the old `on: push: tags` trigger had to go — an auto-created tag would never have fired it.

## Bootstrap for v0.3.0
#290 (the 0.3.0 bump) merged **before** this workflow existed, so it won't fire retroactively. `workflow_dispatch` is the escape hatch: after merging this PR, trigger **Release** from the Actions UI (or I can run `gh workflow run release.yml`) — it will detect 0.3.0 has no release and ship it.

## Security
Only `GITHUB_TOKEN` is used; the tag value derives from `Cargo.toml` on `main` and is passed through `env`, never interpolated into scripts from event payloads. `contents: write` + `actions: write` scoped to the publish job only (Sonar S8233 compliant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)