### PR TITLE
docs(guide): document the Gatekeeper "damaged" message accurately

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -2,8 +2,13 @@
 
 ## Installation
 
-**macOS says the app "cannot be opened because the developer cannot be verified".**
-The builds are not notarized yet ([#121](https://github.com/massimilianolapuma/cubelite/issues/121)). Right-click the app → **Open** → **Open**, or run `xattr -dr com.apple.quarantine /Applications/cubelite.app`.
+**macOS says the app "is damaged and can't be opened. You should eject the disk image."**
+It isn't damaged — this is Gatekeeper's message for unsigned downloads on recent macOS, and the right-click → Open trick does not bypass it. The builds are not signed/notarized yet ([#121](https://github.com/massimilianolapuma/cubelite/issues/121)). Drag the app to Applications, then clear the quarantine flag:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/cubelite.app        # native app
+xattr -dr com.apple.quarantine /Applications/CubeLite.app        # desktop app
+```
 
 **Windows SmartScreen blocks the desktop installer.**
 The installer is unsigned for now. **More info → Run anyway**.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -8,7 +8,7 @@ Requires macOS 14 Sonoma or later.
 
 1. Download [`CubeLite-macOS.dmg`](https://github.com/massimilianolapuma/cubelite/releases/latest/download/CubeLite-macOS.dmg) (or the [zip](https://github.com/massimilianolapuma/cubelite/releases/latest/download/CubeLite-macOS.zip)).
 2. Open the DMG and drag **CubeLite** into **Applications**.
-3. First launch: CubeLite is not yet notarized, so macOS Gatekeeper will warn you. Either **right-click the app → Open → Open**, or clear the quarantine flag:
+3. First launch: CubeLite is not yet signed or notarized, so macOS Gatekeeper blocks it with **"CubeLite is damaged and can't be opened. You should eject the disk image."** The app is not actually damaged — this is what recent macOS versions say about unsigned downloads, and the right-click → Open trick does *not* help here. Clear the quarantine flag instead:
 
    ```sh
    xattr -dr com.apple.quarantine /Applications/cubelite.app
@@ -27,6 +27,7 @@ Requires macOS 14 Sonoma or later.
 | Linux (Debian/Ubuntu) | [`CubeLite-Desktop-Linux.deb`](https://github.com/massimilianolapuma/cubelite/releases/latest/download/CubeLite-Desktop-Linux.deb) |
 | Windows | [`CubeLite-Desktop-Windows.msi`](https://github.com/massimilianolapuma/cubelite/releases/latest/download/CubeLite-Desktop-Windows.msi) |
 
+macOS: same Gatekeeper "damaged" warning as the native app — after dragging to Applications run `xattr -dr com.apple.quarantine /Applications/CubeLite.app`.
 Linux AppImage: make it executable first (`chmod +x CubeLite-Desktop-Linux.AppImage`).
 Windows: SmartScreen may warn about an unsigned installer — choose **More info → Run anyway**.
 


### PR DESCRIPTION
User-reported: opening `CubeLite-Desktop-macOS.dmg` from the v0.3.0 release shows **"CubeLite.app is damaged and can't be opened. You should eject the disk image."**

Verified against the actual release asset: the desktop app is only linker-signed (`codesign -dv` → `flags=0x20002(adhoc,linker-signed)`), and on recent macOS Gatekeeper reports quarantined unsigned/ad-hoc apps as "damaged". The right-click → Open trick does **not** work in this state; the only workaround is clearing quarantine:

```sh
xattr -dr com.apple.quarantine /Applications/CubeLite.app   # desktop
xattr -dr com.apple.quarantine /Applications/cubelite.app   # native
```

Guide and FAQ updated with the exact message and per-app commands (the guide previously described the older "developer cannot be verified" dialog and suggested right-click → Open, which misleads here).

Real fix remains #121 (Developer ID + notarization) — ad-hoc signing in the pipeline cannot remove this warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)