### PR TITLE
feat(desktop): log service layer — container-aware streams, previous logs (#295 PR A)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -1,11 +1,12 @@
 use cubelite_core::{
     client::KubeClient,
     helm::HelmReleaseInfo,
-    logs::stream_pod_logs,
+    logs::{stream_pod_logs, stream_pod_logs_opts, LogStreamOptions},
     metrics::{NodeCapacityInfo, PodMetricsInfo},
     resources::{
-        ConfigMapInfo, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo, JobInfo, NamespaceInfo,
-        NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo, StatefulSetInfo,
+        ConfigMapInfo, ContainerDetail, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo,
+        JobInfo, NamespaceInfo, NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo,
+        StatefulSetInfo,
     },
     ResourceType, ResourceWatcher, WatchEvent,
 };
@@ -544,6 +545,77 @@ pub async fn stream_logs(
         .insert(stream_id.clone(), handles);
 
     Ok(stream_id)
+}
+
+/// Start a single-container log stream for the log panel.
+///
+/// Lines are emitted as `pod-log-line:{stream_id}` events (a `LogLine`
+/// payload each); when the stream ends — server drop, previous-instance
+/// fetch completed — a final `pod-log-end:{stream_id}` event fires so the
+/// frontend session store can reconnect with backoff. Returns the stream ID
+/// for [`stop_logs`].
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn stream_pod_log(
+    app: AppHandle,
+    kubeconfig_path: String,
+    namespace: String,
+    pod: String,
+    container: Option<String>,
+    previous: bool,
+    tail_lines: Option<i64>,
+    since_time: Option<String>,
+    context: Option<String>,
+) -> Result<String, String> {
+    let kube_client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+    let client = kube_client.client();
+
+    let stream_id = LOG_COUNTER.fetch_add(1, Ordering::SeqCst).to_string();
+    let opts = LogStreamOptions {
+        container,
+        previous,
+        follow: !previous,
+        tail_lines: tail_lines.unwrap_or(500),
+        since_time,
+    };
+
+    let app_clone = app.clone();
+    let id_clone = stream_id.clone();
+    let mut stream = stream_pod_logs_opts(client, namespace, pod, opts);
+    let handle = tokio::spawn(async move {
+        while let Some(line) = stream.next().await {
+            // Ignore emit errors — the frontend window may have been closed.
+            let _ = app_clone.emit(&format!("pod-log-line:{id_clone}"), line);
+        }
+        let _ = app_clone.emit(&format!("pod-log-end:{id_clone}"), ());
+    });
+
+    app.state::<LogState>()
+        .handles
+        .lock()
+        .await
+        .insert(stream_id.clone(), vec![handle]);
+
+    Ok(stream_id)
+}
+
+/// Fetch one pod's containers (app, sidecar, init) with live status.
+#[tauri::command]
+pub async fn get_pod_containers(
+    kubeconfig_path: String,
+    namespace: String,
+    pod: String,
+    context: Option<String>,
+) -> Result<Vec<ContainerDetail>, String> {
+    let kube_client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+    kube_client
+        .get_pod_containers(&namespace, &pod)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Stop an aggregated log stream by its stream ID.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,12 +2,12 @@ pub mod commands;
 pub mod env;
 
 use commands::kubernetes::{
-    cluster_capacity, delete_pod, get_current_context, get_resource_yaml, list_configmaps,
-    list_contexts, list_cronjobs, list_deployments, list_events, list_helm_releases,
-    list_ingresses, list_jobs, list_namespaces, list_nodes, list_pod_metrics, list_pods, list_pvcs,
-    list_secrets, list_services, list_statefulsets, probe_cluster, restart_deployment,
-    scale_deployment, set_context, stop_logs, stream_logs, unwatch_resources, watch_resources,
-    LogState, WatchState,
+    cluster_capacity, delete_pod, get_current_context, get_pod_containers, get_resource_yaml,
+    list_configmaps, list_contexts, list_cronjobs, list_deployments, list_events,
+    list_helm_releases, list_ingresses, list_jobs, list_namespaces, list_nodes, list_pod_metrics,
+    list_pods, list_pvcs, list_secrets, list_services, list_statefulsets, probe_cluster,
+    restart_deployment, scale_deployment, set_context, stop_logs, stream_logs, stream_pod_log,
+    unwatch_resources, watch_resources, LogState, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -40,6 +40,8 @@ pub fn run() {
             watch_resources,
             unwatch_resources,
             stream_logs,
+            stream_pod_log,
+            get_pod_containers,
             stop_logs,
             delete_pod,
             restart_deployment,

--- a/apps/desktop/src/lib/components/views/LogsView.svelte
+++ b/apps/desktop/src/lib/components/views/LogsView.svelte
@@ -30,6 +30,7 @@
 	];
 
 	const levelColor: Record<LogLevel, string> = {
+		debug: 'var(--color-text-tertiary)',
 		info: 'var(--color-status-info)',
 		warn: 'var(--color-status-warn)',
 		error: 'var(--color-status-err)'

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -288,7 +288,7 @@ export type ClusterHealthInfo = {
   error: string | null;
 };
 
-export type LogLevel = "info" | "warn" | "error";
+export type LogLevel = "debug" | "info" | "warn" | "error";
 
 export type LogLine = {
   pod: string;
@@ -301,6 +301,26 @@ export type LogLine = {
 export type PodRef = {
   namespace: string;
   name: string;
+};
+
+/// Full per-container detail for the log-panel container picker.
+export type ContainerDetail = {
+  name: string;
+  init: boolean;
+  sidecar: boolean;
+  restarts: number;
+  ready: boolean;
+  state: "running" | "waiting" | "terminated";
+  state_reason: string | null;
+  last_terminated_reason: string | null;
+  last_terminated_at: string | null;
+};
+
+export type PodLogStreamOptions = {
+  container?: string;
+  previous?: boolean;
+  tailLines?: number;
+  sinceTime?: string;
 };
 
 export function listHelmReleases(
@@ -440,6 +460,47 @@ export function streamLogs(
 
 export function stopLogs(streamId: string): Promise<void> {
   return invoke("stop_logs", { streamId });
+}
+
+/**
+ * Start a single-container log stream for the log panel.
+ *
+ * Lines arrive as `pod-log-line:{streamId}` events; a final
+ * `pod-log-end:{streamId}` event signals that the stream ended (server drop
+ * or completed previous-instance fetch). Tear down with {@link stopLogs}.
+ */
+export function streamPodLog(
+  kubeconfigPath: string,
+  namespace: string,
+  pod: string,
+  opts: PodLogStreamOptions = {},
+  context?: string,
+): Promise<string> {
+  return invoke<string>("stream_pod_log", {
+    kubeconfigPath,
+    namespace,
+    pod,
+    container: opts.container ?? null,
+    previous: opts.previous ?? false,
+    tailLines: opts.tailLines ?? null,
+    sinceTime: opts.sinceTime ?? null,
+    context: context ?? null,
+  });
+}
+
+/** Fetch one pod's containers (app, sidecar, init) with live status. */
+export function getPodContainers(
+  kubeconfigPath: string,
+  namespace: string,
+  pod: string,
+  context?: string,
+): Promise<ContainerDetail[]> {
+  return invoke<ContainerDetail[]>("get_pod_containers", {
+    kubeconfigPath,
+    namespace,
+    pod,
+    context: context ?? null,
+  });
 }
 
 export function deletePod(

--- a/crates/cubelite-core/src/client.rs
+++ b/crates/cubelite-core/src/client.rs
@@ -169,6 +169,27 @@ impl KubeClient {
         Ok(pod_list.items.into_iter().filter_map(pod_to_info).collect())
     }
 
+    /// Fetch one pod's containers (app, sidecar, init) with live status,
+    /// for the log-panel container picker.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KubeconfigError::ClientError`] when the API call fails.
+    pub async fn get_pod_containers(
+        &self,
+        namespace: &str,
+        pod: &str,
+    ) -> Result<Vec<crate::resources::ContainerDetail>, KubeconfigError> {
+        let api: Api<Pod> = Api::namespaced(self.inner.clone(), namespace);
+        let raw = api
+            .get(pod)
+            .await
+            .map_err(|e| KubeconfigError::ClientError {
+                reason: e.to_string(),
+            })?;
+        Ok(crate::watcher::pod_to_container_details(&raw))
+    }
+
     /// List all namespaces visible to the authenticated user.
     ///
     /// # Errors

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -47,8 +47,8 @@ pub use kubeconfig::KubeConfig;
 pub use logs::{LogLevel, LogLine};
 pub use metrics::{NodeCapacityInfo, PodMetricsInfo};
 pub use resources::{
-    ConfigMapInfo, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo, JobInfo, NamespaceInfo,
-    NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo, StatefulSetInfo,
+    ConfigMapInfo, ContainerDetail, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo, JobInfo,
+    NamespaceInfo, NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo, StatefulSetInfo,
 };
 pub use types::{
     ClusterDetails, ContextDetails, ContextInfo, KubeConfigFile, NamedCluster, NamedContext,

--- a/crates/cubelite-core/src/logs.rs
+++ b/crates/cubelite-core/src/logs.rs
@@ -12,10 +12,12 @@ use k8s_openapi::api::core::v1::Pod;
 use kube::{api::LogParams, Api, Client};
 use serde::{Deserialize, Serialize};
 
-/// Severity bucket for a log line (UI filter chips: INFO / WARN / ERROR).
+/// Severity bucket for a log line (UI filter chips: DEBUG / INFO / WARN / ERROR).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
+    /// Verbose markers (`DEBUG`, `TRACE`).
+    Debug,
     /// Informational output (default when no marker is found).
     Info,
     /// Warning markers (`WARN`, `WARNING`).
@@ -49,8 +51,58 @@ fn detect_level(message: &str) -> LogLevel {
         LogLevel::Error
     } else if upper.contains("WARN") {
         LogLevel::Warn
+    } else if upper.contains("DEBUG") || upper.contains("TRACE") {
+        LogLevel::Debug
     } else {
         LogLevel::Info
+    }
+}
+
+/// Options for a single-container log stream (the log panel).
+///
+/// `previous` implies a non-following fetch of the prior instance's output;
+/// `since_time` (RFC 3339) resumes a dropped stream without re-sending
+/// history. Timestamps are always requested.
+#[derive(Debug, Clone)]
+pub struct LogStreamOptions {
+    /// Container to read; `None` lets the API pick the single container.
+    pub container: Option<String>,
+    /// Read the previous instance's logs (crash-looped container).
+    pub previous: bool,
+    /// Follow the live stream; forced off when `previous` is set.
+    pub follow: bool,
+    /// History window.
+    pub tail_lines: i64,
+    /// RFC 3339 lower bound; invalid values are ignored.
+    pub since_time: Option<String>,
+}
+
+impl Default for LogStreamOptions {
+    fn default() -> Self {
+        Self {
+            container: None,
+            previous: false,
+            follow: true,
+            tail_lines: 500,
+            since_time: None,
+        }
+    }
+}
+
+/// Map [`LogStreamOptions`] to kube-rs [`LogParams`] (pure, unit-tested).
+pub fn log_params(opts: &LogStreamOptions) -> LogParams {
+    LogParams {
+        follow: opts.follow && !opts.previous,
+        previous: opts.previous,
+        timestamps: true,
+        tail_lines: Some(opts.tail_lines),
+        container: opts.container.clone(),
+        since_time: opts.since_time.as_deref().and_then(|raw| {
+            k8s_openapi::chrono::DateTime::parse_from_rfc3339(raw)
+                .ok()
+                .map(|dt| dt.with_timezone(&k8s_openapi::chrono::Utc))
+        }),
+        ..Default::default()
     }
 }
 
@@ -84,15 +136,31 @@ pub fn stream_pod_logs(
     pod: String,
     tail_lines: i64,
 ) -> Pin<Box<dyn Stream<Item = LogLine> + Send>> {
+    stream_pod_logs_opts(
+        client,
+        namespace,
+        pod,
+        LogStreamOptions {
+            tail_lines,
+            ..Default::default()
+        },
+    )
+}
+
+/// Follow (or statically fetch, for `previous`) one container's logs as a
+/// stream of parsed [`LogLine`] items, honoring [`LogStreamOptions`].
+///
+/// Same error semantics as [`stream_pod_logs`].
+pub fn stream_pod_logs_opts(
+    client: Client,
+    namespace: String,
+    pod: String,
+    opts: LogStreamOptions,
+) -> Pin<Box<dyn Stream<Item = LogLine> + Send>> {
     Box::pin(
         futures::stream::once(async move {
             let api: Api<Pod> = Api::namespaced(client, &namespace);
-            let params = LogParams {
-                follow: true,
-                timestamps: true,
-                tail_lines: Some(tail_lines),
-                ..Default::default()
-            };
+            let params = log_params(&opts);
 
             match api.log_stream(&pod, &params).await {
                 Ok(reader) => {
@@ -150,6 +218,50 @@ mod tests {
         assert_eq!(detect_level("panic: index out of range"), LogLevel::Error);
         assert_eq!(detect_level("warning: deprecated flag"), LogLevel::Warn);
         assert_eq!(detect_level("all good"), LogLevel::Info);
+        assert_eq!(detect_level("DEBUG verbose dump"), LogLevel::Debug);
+        assert_eq!(detect_level("trace: enter handler"), LogLevel::Debug);
+    }
+
+    #[test]
+    fn log_params_defaults_follow_with_timestamps_and_tail() {
+        let params = log_params(&LogStreamOptions::default());
+        assert!(params.follow);
+        assert!(params.timestamps);
+        assert!(!params.previous);
+        assert_eq!(params.tail_lines, Some(500));
+        assert_eq!(params.container, None);
+        assert_eq!(params.since_time, None);
+    }
+
+    #[test]
+    fn log_params_previous_forces_non_follow() {
+        let params = log_params(&LogStreamOptions {
+            previous: true,
+            ..Default::default()
+        });
+        assert!(!params.follow);
+        assert!(params.previous);
+        assert!(params.timestamps);
+    }
+
+    #[test]
+    fn log_params_passes_container_and_valid_since_time() {
+        let params = log_params(&LogStreamOptions {
+            container: Some("envoy".into()),
+            since_time: Some("2026-07-15T10:00:00Z".into()),
+            ..Default::default()
+        });
+        assert_eq!(params.container.as_deref(), Some("envoy"));
+        assert!(params.since_time.is_some());
+    }
+
+    #[test]
+    fn log_params_ignores_invalid_since_time() {
+        let params = log_params(&LogStreamOptions {
+            since_time: Some("not-a-date".into()),
+            ..Default::default()
+        });
+        assert_eq!(params.since_time, None);
     }
 
     #[test]

--- a/crates/cubelite-core/src/resources.rs
+++ b/crates/cubelite-core/src/resources.rs
@@ -12,6 +12,34 @@ pub struct ContainerInfo {
     pub ready: bool,
 }
 
+/// Full per-container detail for the log-panel container picker.
+///
+/// Ordering contract of producers: app containers first (spec order), then
+/// native sidecars (init containers with `restartPolicy: Always`), then
+/// plain init containers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContainerDetail {
+    /// Container name.
+    pub name: String,
+    /// Plain init container (runs to completion before the pod starts).
+    pub init: bool,
+    /// Native sidecar: `initContainers` entry with `restartPolicy: Always`.
+    pub sidecar: bool,
+    /// Restart count from the container status (0 when unknown).
+    pub restarts: i32,
+    /// `true` when the container reports ready.
+    pub ready: bool,
+    /// Current state bucket: `"running"`, `"waiting"` or `"terminated"`.
+    pub state: String,
+    /// Reason of the current state (e.g. `CrashLoopBackOff`, `Completed`).
+    pub state_reason: Option<String>,
+    /// Reason of the last terminated instance (e.g. `OOMKilled`), for the
+    /// previous-logs affordance.
+    pub last_terminated_reason: Option<String>,
+    /// RFC 3339 finish time of the last terminated instance.
+    pub last_terminated_at: Option<String>,
+}
+
 /// Lightweight representation of a Kubernetes Pod for display purposes.
 ///
 /// Fields added after v0.1 carry `#[serde(default)]` so older payloads

--- a/crates/cubelite-core/src/watcher.rs
+++ b/crates/cubelite-core/src/watcher.rs
@@ -320,7 +320,10 @@ pub fn pod_to_container_details(pod: &Pod) -> Vec<crate::resources::ContainerDet
     let (sidecars, plain_init): (Vec<_>, Vec<_>) = init_containers
         .iter()
         .partition(|c| c.restart_policy.as_deref() == Some("Always"));
-    let sidecars: Vec<_> = sidecars.iter().map(|c| detail(&c.name, true, true)).collect();
+    let sidecars: Vec<_> = sidecars
+        .iter()
+        .map(|c| detail(&c.name, true, true))
+        .collect();
     let plain_init: Vec<_> = plain_init
         .iter()
         .map(|c| detail(&c.name, true, false))

--- a/crates/cubelite-core/src/watcher.rs
+++ b/crates/cubelite-core/src/watcher.rs
@@ -264,6 +264,71 @@ pub(crate) fn pod_to_info(pod: Pod) -> Option<PodInfo> {
     })
 }
 
+/// Extract picker-ready [`ContainerDetail`] rows from a raw [`Pod`].
+///
+/// Order: app containers (spec order), native sidecars (init containers
+/// with `restartPolicy: Always`), plain init containers.
+pub fn pod_to_container_details(pod: &Pod) -> Vec<crate::resources::ContainerDetail> {
+    use k8s_openapi::api::core::v1::ContainerStatus;
+
+    let spec = pod.spec.clone().unwrap_or_default();
+    let status = pod.status.clone().unwrap_or_default();
+    let statuses: Vec<ContainerStatus> = status
+        .container_statuses
+        .unwrap_or_default()
+        .into_iter()
+        .chain(status.init_container_statuses.unwrap_or_default())
+        .collect();
+
+    let detail = |name: &str, init: bool, sidecar: bool| {
+        let cs = statuses.iter().find(|s| s.name == name);
+        let raw_state = cs.and_then(|s| s.state.clone()).unwrap_or_default();
+        let (state, state_reason) = if raw_state.running.is_some() {
+            ("running".to_string(), None)
+        } else if let Some(terminated) = raw_state.terminated {
+            ("terminated".to_string(), terminated.reason)
+        } else {
+            (
+                "waiting".to_string(),
+                raw_state.waiting.and_then(|w| w.reason),
+            )
+        };
+        let last_terminated = cs
+            .and_then(|s| s.last_state.clone())
+            .and_then(|s| s.terminated);
+        crate::resources::ContainerDetail {
+            name: name.to_string(),
+            init: init && !sidecar,
+            sidecar,
+            restarts: cs.map(|s| s.restart_count).unwrap_or(0),
+            ready: cs.map(|s| s.ready).unwrap_or(false),
+            state,
+            state_reason,
+            last_terminated_reason: last_terminated.as_ref().and_then(|t| t.reason.clone()),
+            last_terminated_at: last_terminated
+                .as_ref()
+                .and_then(|t| t.finished_at.as_ref().map(|ts| ts.0.to_rfc3339())),
+        }
+    };
+
+    let app: Vec<_> = spec
+        .containers
+        .iter()
+        .map(|c| detail(&c.name, false, false))
+        .collect();
+    let init_containers = spec.init_containers.unwrap_or_default();
+    let (sidecars, plain_init): (Vec<_>, Vec<_>) = init_containers
+        .iter()
+        .partition(|c| c.restart_policy.as_deref() == Some("Always"));
+    let sidecars: Vec<_> = sidecars.iter().map(|c| detail(&c.name, true, true)).collect();
+    let plain_init: Vec<_> = plain_init
+        .iter()
+        .map(|c| detail(&c.name, true, false))
+        .collect();
+
+    app.into_iter().chain(sidecars).chain(plain_init).collect()
+}
+
 /// Convert a raw [`Namespace`] object into a [`NamespaceInfo`], returning
 /// `None` if there is no name.
 pub(crate) fn namespace_to_info(ns: Namespace) -> Option<NamespaceInfo> {
@@ -1132,5 +1197,147 @@ mod tests {
         assert_eq!(info.conditions.len(), 1);
         assert_eq!(info.conditions[0].condition_type, "Available");
         assert_eq!(info.conditions[0].status, "True");
+    }
+
+    /// Pod with an app container (crash-looping), a native sidecar init
+    /// container and a plain init container — the handoff example pod.
+    fn multi_container_pod() -> k8s_openapi::api::core::v1::Pod {
+        use k8s_openapi::api::core::v1::{
+            Container, ContainerState, ContainerStateRunning, ContainerStateTerminated,
+            ContainerStateWaiting, ContainerStatus, Pod, PodSpec, PodStatus,
+        };
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+
+        let finished = Time(
+            k8s_openapi::chrono::DateTime::parse_from_rfc3339("2026-07-15T10:00:00Z")
+                .expect("valid ts")
+                .with_timezone(&k8s_openapi::chrono::Utc),
+        );
+
+        Pod {
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "worker".into(),
+                    ..Default::default()
+                }],
+                init_containers: Some(vec![
+                    Container {
+                        name: "envoy".into(),
+                        restart_policy: Some("Always".into()),
+                        ..Default::default()
+                    },
+                    Container {
+                        name: "init-migrate".into(),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }),
+            status: Some(PodStatus {
+                container_statuses: Some(vec![ContainerStatus {
+                    name: "worker".into(),
+                    ready: false,
+                    restart_count: 7,
+                    state: Some(ContainerState {
+                        waiting: Some(ContainerStateWaiting {
+                            reason: Some("CrashLoopBackOff".into()),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    last_state: Some(ContainerState {
+                        terminated: Some(ContainerStateTerminated {
+                            reason: Some("OOMKilled".into()),
+                            finished_at: Some(finished),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }]),
+                init_container_statuses: Some(vec![
+                    ContainerStatus {
+                        name: "envoy".into(),
+                        ready: true,
+                        restart_count: 0,
+                        state: Some(ContainerState {
+                            running: Some(ContainerStateRunning::default()),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    ContainerStatus {
+                        name: "init-migrate".into(),
+                        ready: false,
+                        restart_count: 0,
+                        state: Some(ContainerState {
+                            terminated: Some(ContainerStateTerminated {
+                                reason: Some("Completed".into()),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn container_details_orders_app_sidecar_then_init() {
+        let details = pod_to_container_details(&multi_container_pod());
+        let names: Vec<_> = details.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, ["worker", "envoy", "init-migrate"]);
+    }
+
+    #[test]
+    fn container_details_flags_sidecar_and_init() {
+        let details = pod_to_container_details(&multi_container_pod());
+        let envoy = &details[1];
+        assert!(envoy.sidecar);
+        assert!(!envoy.init);
+        assert_eq!(envoy.state, "running");
+        let init = &details[2];
+        assert!(init.init);
+        assert!(!init.sidecar);
+        assert_eq!(init.state, "terminated");
+        assert_eq!(init.state_reason.as_deref(), Some("Completed"));
+    }
+
+    #[test]
+    fn container_details_maps_state_restarts_and_last_termination() {
+        let details = pod_to_container_details(&multi_container_pod());
+        let worker = &details[0];
+        assert_eq!(worker.restarts, 7);
+        assert_eq!(worker.state, "waiting");
+        assert_eq!(worker.state_reason.as_deref(), Some("CrashLoopBackOff"));
+        assert_eq!(worker.last_terminated_reason.as_deref(), Some("OOMKilled"));
+        assert_eq!(
+            worker.last_terminated_at.as_deref(),
+            Some("2026-07-15T10:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn container_details_missing_status_defaults_to_waiting() {
+        use k8s_openapi::api::core::v1::{Container, Pod, PodSpec};
+        let pod = Pod {
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "app".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let details = pod_to_container_details(&pod);
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0].state, "waiting");
+        assert_eq!(details[0].restarts, 0);
+        assert!(!details[0].ready);
     }
 }

--- a/docs/superpowers/plans/2026-07-15-desktop-log-viewer-pr-a-service.md
+++ b/docs/superpowers/plans/2026-07-15-desktop-log-viewer-pr-a-service.md
@@ -1,0 +1,93 @@
+# Desktop Log Viewer — PR A (Service Layer) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rust + TS service layer for the desktop log panel (#295, parity with macOS #294): per-container log streams with previous/tail/sinceTime, per-pod container details (init/sidecar/state/restarts), scoped Tauri events with an end signal for frontend-driven reconnect.
+
+**Architecture:** `cubelite-core::logs` gains `LogStreamOptions` + `stream_pod_logs_opts` (existing `stream_pod_logs` delegates) and a `LogLevel::Debug` bucket. New pure `pod_to_container_details` (unit-tested) + `KubeClient`-level fetch. Tauri command `stream_pod_log` emits `pod-log-line:{id}` per line and `pod-log-end:{id}` on stream end (reconnect/backoff lives in the frontend session store, matching the macOS split); `get_pod_containers` returns details. TS wrappers + types in `tauri.ts`.
+
+**Tech Stack:** Rust (kube-rs `LogParams` already supports container/previous/tail_lines/since_time), Tauri 2 events, TypeScript.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-15-pod-log-viewer-design.md` (shared with macOS). `timestamps=true` always on the wire.
+- Default tail 500. Existing aggregated `stream_logs`/`LogsView` untouched (separate feature).
+- Repo gates: `cargo test -p cubelite-core`, `cargo clippy --deny warnings`, `pnpm --filter desktop lint`, `pnpm --filter desktop test`. No `any` in TS.
+- Branch: `feat/295-desktop-log-viewer` off main.
+
+---
+
+### Task 1: core — `LogStreamOptions`, Debug level, options-aware stream
+
+**Files:** modify `crates/cubelite-core/src/logs.rs` (+ re-exports in `lib.rs` if needed).
+
+**Interfaces:**
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct LogStreamOptions {
+    pub container: Option<String>,
+    pub previous: bool,          // implies follow=false
+    pub follow: bool,            // ignored (forced false) when previous
+    pub tail_lines: i64,
+    pub since_time: Option<String>, // RFC 3339; parsed, invalid values ignored
+}
+pub fn log_params(opts: &LogStreamOptions) -> LogParams   // pure, unit-tested
+pub fn stream_pod_logs_opts(client, namespace, pod, opts) -> Pin<Box<dyn Stream<Item = LogLine> + Send>>
+// stream_pod_logs(client, ns, pod, tail) delegates with follow=true defaults
+```
+`LogLevel` gains `Debug` (markers `DEBUG`, `TRACE`), serialized `"debug"`; detection order error > warn > debug > info.
+
+**Tests (in-module):** `log_params` — defaults (follow+timestamps+tail500), previous forces follow=false + previous=true, container passthrough, since_time parsed to `Time`, invalid since_time → None; `detect_level` debug cases.
+
+### Task 2: core — container details
+
+**Files:** modify `crates/cubelite-core/src/resources.rs` (struct), `crates/cubelite-core/src/watcher.rs` or new fn beside `pod_to_info` (mapping), client fetch in `crates/cubelite-core/src/client.rs`.
+
+**Interfaces:**
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContainerDetail {
+    pub name: String,
+    pub init: bool,      // plain init container
+    pub sidecar: bool,   // initContainer with restartPolicy: Always (K8s ≥1.28)
+    pub restarts: i32,
+    pub ready: bool,
+    pub state: String,               // "running" | "waiting" | "terminated"
+    pub state_reason: Option<String>,       // CrashLoopBackOff, Completed, …
+    pub last_terminated_reason: Option<String>,
+    pub last_terminated_at: Option<String>,
+}
+pub fn pod_to_container_details(pod: &Pod) -> Vec<ContainerDetail>  // pure; order: app, sidecars, plain init
+impl KubeClient { pub async fn get_pod_containers(&self, namespace: &str, pod: &str) -> Result<Vec<ContainerDetail>, Error> }
+```
+
+**Tests:** construct a `Pod` with app container (waiting CrashLoopBackOff, restarts 7, lastState terminated OOMKilled), sidecar init (`restart_policy: Some("Always".into())`, running), plain init (terminated Completed) + matching `container_statuses`/`init_container_statuses`; assert order, flags, states, last-termination fields; missing-status container defaults (waiting, 0 restarts).
+
+### Task 3: Tauri commands + TS wrappers
+
+**Files:** modify `apps/desktop/src-tauri/src/commands/kubernetes.rs` (+ register in `main.rs`/`lib.rs` invoke_handler), `apps/desktop/src/lib/tauri.ts`.
+
+**Interfaces (Rust):**
+```rust
+#[tauri::command] pub async fn stream_pod_log(
+    app: AppHandle, kubeconfig_path: String, namespace: String, pod: String,
+    container: Option<String>, previous: bool, tail_lines: Option<i64>,
+    since_time: Option<String>, context: Option<String>,
+) -> Result<String, String>   // stream_id; emits pod-log-line:{id} (LogLine), then pod-log-end:{id} (unit) when the stream ends
+#[tauri::command] pub async fn get_pod_containers(
+    kubeconfig_path: String, namespace: String, pod: String, context: Option<String>,
+) -> Result<Vec<ContainerDetail>, String>
+```
+`stream_pod_log` registers its task in the existing `LogState` registry so `stop_logs(stream_id)` cancels it. Previous mode: non-follow stream, lines then end event.
+
+**Interfaces (TS, `tauri.ts`):**
+```typescript
+export interface ContainerDetail { name: string; init: boolean; sidecar: boolean; restarts: number; ready: boolean; state: "running" | "waiting" | "terminated"; state_reason: string | null; last_terminated_reason: string | null; last_terminated_at: string | null }
+export type PodLogLevel = "debug" | "info" | "warn" | "error";  // LogLine.level widened
+export interface PodLogStreamOptions { container?: string; previous?: boolean; tailLines?: number; sinceTime?: string }
+export async function streamPodLog(kubeconfigPath: string, namespace: string, pod: string, opts: PodLogStreamOptions, context?: string): Promise<string>
+export async function getPodContainers(kubeconfigPath: string, namespace: string, pod: string, context?: string): Promise<ContainerDetail[]>
+// stopLogs(streamId) reused for teardown
+```
+
+**Gates:** `cargo test -p cubelite-core` PASS, `cargo clippy --workspace --all-targets -- -D warnings` PASS, `cargo build -p cubelite-desktop` (tauri crate) PASS, `pnpm --filter desktop lint` + `test` PASS. Commit per task; push; PR base main titled `feat(desktop): log service layer — container-aware streams, previous logs (#295 PR A)`.


### PR DESCRIPTION
First stacked PR for #295 — desktop parity with the macOS log panel (#294, PRs #299–#304). Shared spec: `docs/superpowers/specs/2026-07-15-pod-log-viewer-design.md`.

- `cubelite-core`: `LogStreamOptions` (container / previous / tailLines / sinceTime, timestamps always on) + `stream_pod_logs_opts`; `LogLevel::Debug`; pure `log_params` unit-tested
- `cubelite-core`: `ContainerDetail` + `pod_to_container_details` (init/sidecar detection via `restartPolicy: Always`, state + restarts + last termination), unit-tested; `KubeClient::get_pod_containers`
- Tauri: `stream_pod_log` (scoped `pod-log-line:{id}` events + `pod-log-end:{id}` end signal for frontend reconnect), `get_pod_containers`; registered in the handler and reusing the `LogState` registry for `stop_logs`
- TS: `streamPodLog`/`getPodContainers` wrappers, `ContainerDetail`/`PodLogStreamOptions` types, `LogLevel` widened with `"debug"`
- Existing aggregated `stream_logs`/LogsView untouched

Part of #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)