### PR TITLE
fix(macos): TLS-skip flag reaches the session factory in every path (#309)

### DIFF
--- a/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
+++ b/apps/macos/cubelite/cubelite/Services/KubeAPIService.swift
@@ -36,17 +36,20 @@ actor KubeAPIService {
 
     /// Whether to skip TLS certificate verification for all clusters.
     ///
-    /// Set from `AppSettings.skipTLSVerification` via `updateSkipTLS(_:)`.
-    /// Reading `UserDefaults` directly in `makeSession()` is unreliable under
-    /// the sandbox (Xcode re-installs can wipe the container) and has timing
-    /// issues on first launch. Keeping the flag in-memory avoids both problems.
-    private var skipTLSVerification: Bool = false
+    /// Seeded from the persisted setting at init and updated live via
+    /// `updateSkipTLS(_:)`. Seeding at init removes the startup race where
+    /// concurrent loaders created (and cached) sessions before the MainView
+    /// task pushed the persisted value into this actor (#309).
+    private var skipTLSVerification: Bool
 
     /// Creates a new API service backed by the given kubeconfig service.
     ///
-    /// - Parameter kubeconfigService: The service used to load kubeconfig state.
-    init(kubeconfigService: KubeconfigService) {
+    /// - Parameters:
+    ///   - kubeconfigService: The service used to load kubeconfig state.
+    ///   - defaults: Source of the persisted TLS-skip flag (tests override).
+    init(kubeconfigService: KubeconfigService, defaults: UserDefaults = .standard) {
         self.kubeconfigService = kubeconfigService
+        self.skipTLSVerification = defaults.bool(forKey: AppSettings.Keys.skipTLSVerification)
     }
 
     /// Invalidates and discards all cached URLSessions.
@@ -69,6 +72,9 @@ actor KubeAPIService {
         skipTLSVerification = skip
         invalidateSession()
     }
+
+    /// Current TLS-skip state (test hook for the seeding contract, #309).
+    var isSkippingTLSVerification: Bool { skipTLSVerification }
 
     // MARK: - Public API
 

--- a/apps/macos/cubelite/cubelite/Views/PreferencesView.swift
+++ b/apps/macos/cubelite/cubelite/Views/PreferencesView.swift
@@ -140,6 +140,14 @@ private struct AdvancedPreferencesTab: View {
             }
             Section {
                 Toggle("Skip TLS certificate verification", isOn: $s.skipTLSVerification)
+                    .onChange(of: s.skipTLSVerification) { _, newValue in
+                        // Sync the actor here, not only from MainView: the
+                        // Settings scene outlives the main window, and a toggle
+                        // flipped while it is closed must still reach the
+                        // session factory (#309).
+                        guard let service = kubeAPIService else { return }
+                        Task { await service.updateSkipTLS(newValue) }
+                    }
                 Text(
                     "⚠️ Accepts self-signed certificates from all clusters. Only enable for local development (e.g., minikube)."
                 )

--- a/apps/macos/cubelite/cubeliteTests/SkipTLSSeedingTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/SkipTLSSeedingTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import cubelite
+
+/// #309 — the TLS-skip flag must reach the session factory even when no
+/// MainView lifecycle hook ever fires (Settings-only toggle, startup race).
+final class SkipTLSSeedingTests: XCTestCase {
+
+    /// Fresh suite per call so the non-Sendable instance can be sent into
+    /// the actor init (region isolation) without crossing this test class.
+    private static func makeDefaults(skip: Bool?) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: "SkipTLSSeedingTests")!
+        defaults.removePersistentDomain(forName: "SkipTLSSeedingTests")
+        if let skip {
+            defaults.set(skip, forKey: AppSettings.Keys.skipTLSVerification)
+        }
+        return defaults
+    }
+
+    func testInit_seedsSkipFlagFromPersistedSetting() async {
+        let defaults = Self.makeDefaults(skip: true)
+        let service = KubeAPIService(
+            kubeconfigService: KubeconfigService(), defaults: defaults)
+        let skipping = await service.isSkippingTLSVerification
+        XCTAssertTrue(skipping)
+    }
+
+    func testInit_defaultsToStrictVerification() async {
+        let defaults = Self.makeDefaults(skip: nil)
+        let service = KubeAPIService(
+            kubeconfigService: KubeconfigService(), defaults: defaults)
+        let skipping = await service.isSkippingTLSVerification
+        XCTAssertFalse(skipping)
+    }
+
+    func testUpdateSkipTLS_overridesSeededValue() async {
+        let defaults = Self.makeDefaults(skip: true)
+        let service = KubeAPIService(
+            kubeconfigService: KubeconfigService(), defaults: defaults)
+        await service.updateSkipTLS(false)
+        let skipping = await service.isSkippingTLSVerification
+        XCTAssertFalse(skipping)
+    }
+}


### PR DESCRIPTION
Root cause: `skipTLSVerification` reached the `KubeAPIService` actor only through MainView lifecycle hooks (`.task` sync + `.onChange`). Two paths left cached sessions with `skip=false`:

- startup race: concurrent config/resource loaders created and cached sessions before the MainView task pushed the persisted value
- Settings-scene toggle with the main window closed: `.onChange` never fired at all

Delegate logic itself verified correct (probe against a self-signed host: skip=true → 200, skip=false → -1202).

Fix: seed the actor flag from the persisted setting in `init` (sandbox is off since #296, so UserDefaults is reliable) and sync from the Preferences toggle directly. MainView hooks stay as harmless redundancy (`updateSkipTLS` guards equality).

Tests: `SkipTLSSeedingTests` — seeded true/false at init, live override.

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)