### PR TITLE
fix(desktop): cancellable, fail-fast cluster switch (#308)

### DIFF
--- a/apps/desktop/src/lib/components/ui/ConnectingOverlay.svelte
+++ b/apps/desktop/src/lib/components/ui/ConnectingOverlay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import { app } from '$lib/stores/app.svelte';
+	import { clusters } from '$lib/stores/clusters.svelte';
 </script>
 
 {#if app.connecting !== null}
@@ -14,6 +15,13 @@
 		>
 			<LoaderCircle class="h-4 w-4 animate-spin text-accent" />
 			<span class="type-body text-text-primary">Connecting to {app.connecting}…</span>
+			<button
+				type="button"
+				class="focus-ring type-body rounded-md border border-border-default bg-surface-raised px-2.5 py-1 text-text-secondary hover:brightness-110"
+				onclick={() => clusters.cancelSwitch()}
+			>
+				Cancel
+			</button>
 		</div>
 	</div>
 {/if}

--- a/apps/desktop/src/lib/stores/clusters.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/clusters.svelte.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("$lib/tauri", () => ({
   listContexts: vi.fn(),
   setContext: vi.fn(),
+  probeCluster: vi.fn(),
   listPods: vi.fn(),
   listNamespaces: vi.fn(),
   listDeployments: vi.fn(),
@@ -25,6 +26,7 @@ import {
   listDeployments,
   listNamespaces,
   listPods,
+  probeCluster,
   setContext,
   watchResources,
   type ContextInfo,
@@ -43,6 +45,12 @@ const contexts: ContextInfo[] = [
 beforeEach(() => {
   vi.clearAllMocks();
   installLocalStorageMock();
+  vi.mocked(probeCluster).mockResolvedValue({
+    reachable: true,
+    version: "v1.30.0",
+    node_count: 1,
+    error: null,
+  });
   settings.identityColors.value = {};
   settings.refreshInterval.value = 0;
   app.kubeconfigPath = "/home/u/.kube/config";
@@ -115,9 +123,74 @@ describe("switchCluster", () => {
     expect(app.connecting).toBeNull();
   });
 
-  it("ignores switches while one is already in flight", async () => {
+  it("ignores a switch to the cluster already being connected", async () => {
     app.connecting = "staging";
-    await clusters.switchCluster("prod");
+    await clusters.switchCluster("staging");
     expect(setContext).not.toHaveBeenCalled();
+  });
+
+  it("fails fast to unreachable when the probe reports the cluster down", async () => {
+    vi.mocked(setContext).mockResolvedValue(undefined);
+    vi.mocked(probeCluster).mockResolvedValue({
+      reachable: false,
+      version: null,
+      node_count: null,
+      error: "connect timeout",
+    });
+
+    await clusters.switchCluster("staging");
+
+    expect(clusters.connectionState).toBe("unreachable");
+    expect(clusters.unreachableReason).toBe("connect timeout");
+    expect(listPods).not.toHaveBeenCalled();
+    expect(app.connecting).toBeNull();
+  });
+
+  it("a second switch preempts the in-flight one and its result wins", async () => {
+    vi.mocked(setContext).mockResolvedValue(undefined);
+    vi.mocked(listNamespaces).mockResolvedValue([]);
+    vi.mocked(listDeployments).mockResolvedValue([]);
+    vi.mocked(watchResources).mockResolvedValue("w1");
+    // First switch hangs on the pod list until released.
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<never[]>((resolve) => {
+      releaseFirst = () => resolve([]);
+    });
+    vi.mocked(listPods).mockReturnValueOnce(firstGate).mockResolvedValue([]);
+    clusters.contexts = [...contexts];
+
+    const first = clusters.switchCluster("staging");
+    const second = clusters.switchCluster("prod");
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(app.activeCluster).toBe("prod");
+    expect(app.connecting).toBeNull();
+    expect(clusters.connectionState).toBe("connected");
+    expect(clusters.contexts.find((c) => c.name === "prod")?.is_active).toBe(true);
+  });
+
+  it("cancelSwitch aborts the in-flight switch and discards its result", async () => {
+    vi.mocked(setContext).mockResolvedValue(undefined);
+    let releaseProbe!: () => void;
+    vi.mocked(probeCluster).mockReturnValue(
+      new Promise((resolve) => {
+        releaseProbe = () =>
+          resolve({ reachable: false, version: null, node_count: null, error: "late" });
+      }),
+    );
+
+    const inFlight = clusters.switchCluster("staging");
+    // Let the switch reach the probe await before cancelling.
+    await Promise.resolve();
+    clusters.cancelSwitch();
+    expect(app.connecting).toBeNull();
+
+    releaseProbe();
+    await inFlight;
+
+    // The stale unreachable result was discarded.
+    expect(clusters.connectionState).toBe("unknown");
+    expect(app.connecting).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/stores/clusters.svelte.ts
+++ b/apps/desktop/src/lib/stores/clusters.svelte.ts
@@ -4,7 +4,7 @@
  * the backend has no health probe for inactive clusters).
  */
 
-import { listContexts, setContext, type ContextInfo } from "$lib/tauri";
+import { listContexts, probeCluster, setContext, type ContextInfo } from "$lib/tauri";
 import { assignIdentityColors, type IdentityColor } from "$lib/cluster-identity";
 import { errorMessage } from "$lib/errors";
 import { app } from "./app.svelte";
@@ -45,27 +45,51 @@ class ClustersStore {
   }
 
   /**
+   * Monotonic switch epoch: bumping it invalidates every in-flight switch,
+   * so a newer switch (or a cancel) preempts instead of waiting for the old
+   * one to time out (#308). Stale switches drop their results silently.
+   */
+  #switchEpoch = 0;
+
+  /**
    * Switch the active cluster (rail click / palette / ⌘1–5).
-   * Shows the connecting overlay, resets namespace + selections, probes the
-   * cluster with the initial list and lands connected or unreachable.
+   * Shows the connecting overlay (cancellable), resets namespace +
+   * selections, fail-fast probes the cluster (short-timeout client) and
+   * lands connected or unreachable. Calling it again while a switch is in
+   * flight preempts the previous one.
    */
   async switchCluster(name: string): Promise<void> {
-    if (app.connecting !== null) return;
+    if (app.connecting === name) return;
+    const epoch = ++this.#switchEpoch;
     app.connecting = name;
     try {
       await resources.stopWatching();
+      if (epoch !== this.#switchEpoch) return;
       resources.clear();
       try {
         await setContext(name);
       } catch (e) {
+        if (epoch !== this.#switchEpoch) return;
         toasts.push(`Failed to switch context: ${errorMessage(e)}`, "err");
         return;
       }
+      if (epoch !== this.#switchEpoch) return;
       app.activeCluster = name;
       app.resetForClusterSwitch();
       this.contexts = this.contexts.map((c) => ({ ...c, is_active: c.name === name }));
 
+      // Fail fast on dead clusters: the probe uses the short-timeout client
+      // (3s connect / 5s read) instead of blocking on a full resource load.
+      const health = await probeCluster(app.kubeconfigPath, name).catch(() => null);
+      if (epoch !== this.#switchEpoch) return;
+      if (health && !health.reachable) {
+        this.connectionState = "unreachable";
+        this.unreachableReason = health.error;
+        return;
+      }
+
       const ok = await resources.load();
+      if (epoch !== this.#switchEpoch) return;
       this.connectionState = ok ? "connected" : "unreachable";
       this.unreachableReason = ok ? null : resources.error;
       if (ok) {
@@ -73,8 +97,16 @@ class ClustersStore {
         resources.applyRefreshInterval();
       }
     } finally {
-      app.connecting = null;
+      if (epoch === this.#switchEpoch) {
+        app.connecting = null;
+      }
     }
+  }
+
+  /** Abort the in-flight switch (overlay Cancel / backdrop click). */
+  cancelSwitch(): void {
+    this.#switchEpoch++;
+    app.connecting = null;
   }
 
   /** Re-probe the active cluster (Retry on the unreachable screen). */


### PR DESCRIPTION
Unreachable cluster switch no longer locks the app behind the connecting overlay.

- **Switch epoch**: every `switchCluster` bumps a monotonic epoch; in-flight switches check it after each await and drop stale results — a newer switch preempts instead of being ignored (`if (app.connecting !== null) return` removed)
- **Fail fast**: reachability probe via the short-timeout client (`probe_cluster`, 3s/5s) before the full resource load → dead cluster lands on the unreachable view in ≤5s
- **Cancel** button on the connecting overlay (`cancelSwitch()`: epoch bump + overlay dismissed)

Tests: probe fail-fast (no resource load), preemption (second switch wins over a hung first), cancel discards the stale result; existing switch tests updated to the new semantics (same-target switch is the only no-op).

Fixes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)