### PR TITLE
fix(desktop): log flood freeze + label-selector filtering (#316)

### DIFF
--- a/apps/desktop/src/lib/components/views/LogsView.svelte
+++ b/apps/desktop/src/lib/components/views/LogsView.svelte
@@ -118,7 +118,7 @@
 					{logs.lines.length === 0 ? 'Waiting for log lines…' : 'No lines match the filter.'}
 				</p>
 			{:else}
-				{#each logs.filtered as line, i (i)}
+				{#each logs.filtered as line (line.id)}
 					<div class="flex items-baseline gap-2.5 px-2.5 py-px" style={rowStyle(line.level)}>
 						<span class="shrink-0 font-mono text-[10.5px] text-text-disabled">{clock(line.time)}</span>
 						<span

--- a/apps/desktop/src/lib/components/views/LogsView.svelte
+++ b/apps/desktop/src/lib/components/views/LogsView.svelte
@@ -2,14 +2,38 @@
 	import { logs, type LevelFilter } from '$lib/stores/logs.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
 	import { app } from '$lib/stores/app.svelte';
+	import { matchesSelector, parseLabelSelector } from '$lib/k8s-match';
 	import type { LogLevel } from '$lib/tauri';
 
-	let container = $state<HTMLDivElement | null>(null);
+	/** Backend streams at most this many pods (MAX_LOG_PODS in Rust). */
+	const MAX_STREAMED_PODS = 20;
 
-	// (Re)start the aggregated stream when cluster/namespace change.
+	let container = $state<HTMLDivElement | null>(null);
+	let labelSelector = $state('');
+	let debouncedSelector = $state('');
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+	// Debounce selector edits so each keystroke doesn't restart the stream.
+	$effect(() => {
+		const value = labelSelector;
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => (debouncedSelector = value), 300);
+		return () => clearTimeout(debounceTimer);
+	});
+
+	const streamedPods = $derived.by(() => {
+		const selector = parseLabelSelector(debouncedSelector);
+		const matched =
+			Object.keys(selector).length === 0
+				? resources.pods
+				: resources.pods.filter((p) => matchesSelector(p.labels, selector));
+		return matched.map((p) => ({ namespace: p.namespace, name: p.name }));
+	});
+
+	// (Re)start the aggregated stream when cluster/namespace/selector change.
 	$effect(() => {
 		void [app.activeCluster, app.namespace];
-		const pods = resources.pods.map((p) => ({ namespace: p.namespace, name: p.name }));
+		const pods = streamedPods;
 		void logs.start(pods);
 		return () => void logs.stop();
 	});
@@ -53,7 +77,20 @@
 
 <div class="flex min-h-0 flex-1 flex-col gap-3 p-4">
 	<div class="flex items-center gap-2">
-		<h1 class="type-title flex-1">Logs</h1>
+		<h1 class="type-title">Logs</h1>
+		<span class="type-caption flex-1 text-text-tertiary">
+			streaming {Math.min(streamedPods.length, MAX_STREAMED_PODS)}{streamedPods.length >
+			MAX_STREAMED_PODS
+				? ` of ${streamedPods.length}`
+				: ''} pods
+		</span>
+
+		<input
+			type="text"
+			placeholder="label=value,…"
+			bind:value={labelSelector}
+			class="focus-ring h-7 w-44 rounded-md border border-border-default bg-surface-window px-2.5 font-mono text-[11px] text-text-primary placeholder:text-text-disabled"
+		/>
 
 		<div class="flex overflow-hidden rounded-md border border-border-default">
 			{#each chips as chip (chip.value)}

--- a/apps/desktop/src/lib/k8s-match.test.ts
+++ b/apps/desktop/src/lib/k8s-match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matchesSelector } from "$lib/k8s-match";
+import { matchesSelector, parseLabelSelector } from "$lib/k8s-match";
 
 describe("matchesSelector", () => {
   it("matches when all selector entries are present", () => {
@@ -13,5 +13,24 @@ describe("matchesSelector", () => {
 
   it("never matches an empty selector (would select everything)", () => {
     expect(matchesSelector({ app: "api" }, {})).toBe(false);
+  });
+});
+
+describe("parseLabelSelector", () => {
+  it("parses an equality list with whitespace", () => {
+    expect(parseLabelSelector(" app=api, tier = web ")).toEqual({ app: "api", tier: "web" });
+  });
+
+  it("splits on the first equals sign only", () => {
+    expect(parseLabelSelector("cfg=a=b")).toEqual({ cfg: "a=b" });
+  });
+
+  it("ignores malformed tokens", () => {
+    expect(parseLabelSelector("app=api, nonsense, =v, k=")).toEqual({ app: "api" });
+  });
+
+  it("empty input parses to an empty selector", () => {
+    expect(parseLabelSelector("")).toEqual({});
+    expect(parseLabelSelector("   ")).toEqual({});
   });
 });

--- a/apps/desktop/src/lib/k8s-match.ts
+++ b/apps/desktop/src/lib/k8s-match.ts
@@ -7,3 +7,23 @@ export function matchesSelector(
   if (entries.length === 0) return false;
   return entries.every(([k, v]) => labels[k] === v);
 }
+
+/**
+ * Parses an equality-based label selector ("app=api, tier=web") into a
+ * selector map. Malformed tokens (no key, no value, no "=") are ignored;
+ * values may themselves contain "=". Empty input yields an empty selector,
+ * which callers must treat as "match all" (matchesSelector treats an empty
+ * selector as match-none by design).
+ */
+export function parseLabelSelector(text: string): Record<string, string> {
+  const selector: Record<string, string> = {};
+  for (const token of text.split(",")) {
+    const eq = token.indexOf("=");
+    if (eq < 0) continue;
+    const key = token.slice(0, eq).trim();
+    const value = token.slice(eq + 1).trim();
+    if (!key || !value) continue;
+    selector[key] = value;
+  }
+  return selector;
+}

--- a/apps/desktop/src/lib/stores/clusters.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/clusters.svelte.test.ts
@@ -46,6 +46,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   installLocalStorageMock();
   vi.mocked(probeCluster).mockResolvedValue({
+    context: "staging",
     reachable: true,
     version: "v1.30.0",
     node_count: 1,
@@ -132,6 +133,7 @@ describe("switchCluster", () => {
   it("fails fast to unreachable when the probe reports the cluster down", async () => {
     vi.mocked(setContext).mockResolvedValue(undefined);
     vi.mocked(probeCluster).mockResolvedValue({
+      context: "staging",
       reachable: false,
       version: null,
       node_count: null,
@@ -176,7 +178,7 @@ describe("switchCluster", () => {
     vi.mocked(probeCluster).mockReturnValue(
       new Promise((resolve) => {
         releaseProbe = () =>
-          resolve({ reachable: false, version: null, node_count: null, error: "late" });
+          resolve({ context: "staging", reachable: false, version: null, node_count: null, error: "late" });
       }),
     );
 

--- a/apps/desktop/src/lib/stores/logs.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/logs.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("$lib/tauri", () => ({
   streamLogs: vi.fn(async () => "1"),
@@ -9,7 +9,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 import { streamLogs, type LogLine } from "$lib/tauri";
-import { logs } from "./logs.svelte";
+import { logs, FLUSH_MS } from "./logs.svelte";
 import { app } from "./app.svelte";
 
 function line(overrides: Partial<LogLine> = {}): LogLine {
@@ -24,6 +24,7 @@ function line(overrides: Partial<LogLine> = {}): LogLine {
 }
 
 beforeEach(async () => {
+  vi.useFakeTimers();
   vi.clearAllMocks();
   await logs.stop();
   logs.clear();
@@ -34,28 +35,66 @@ beforeEach(async () => {
   app.activeCluster = "prod";
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("logs batching", () => {
+  it("does not touch lines until the flush interval elapses", () => {
+    for (let i = 0; i < 50; i++) logs.push(line({ message: `l${i}` }));
+    expect(logs.lines).toHaveLength(0);
+    vi.advanceTimersByTime(FLUSH_MS);
+    expect(logs.lines).toHaveLength(50);
+  });
+
+  it("coalesces many pushes into one batch per interval", () => {
+    logs.push(line({ message: "a" }));
+    vi.advanceTimersByTime(FLUSH_MS);
+    expect(logs.lines).toHaveLength(1);
+    for (let i = 0; i < 10; i++) logs.push(line({ message: `b${i}` }));
+    vi.advanceTimersByTime(FLUSH_MS);
+    expect(logs.lines).toHaveLength(11);
+  });
+
+  it("assigns monotonic unique ids across flushes", () => {
+    logs.push(line({ message: "a" }));
+    vi.advanceTimersByTime(FLUSH_MS);
+    logs.push(line({ message: "b" }));
+    vi.advanceTimersByTime(FLUSH_MS);
+    const ids = logs.lines.map((l) => l.id);
+    expect(ids[1]).toBeGreaterThan(ids[0]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
 describe("logs buffer", () => {
   it("caps the buffer at 180 lines", () => {
     for (let i = 0; i < 200; i++) logs.push(line({ message: `m${i}` }));
+    vi.advanceTimersByTime(FLUSH_MS);
     expect(logs.lines).toHaveLength(180);
     expect(logs.lines[0].message).toBe("m20");
+    expect(logs.lines.at(-1)?.message).toBe("m199");
   });
 
-  it("counts lines arriving while paused and resets on resume", () => {
+  it("while paused: no flush, counter grows; resume flushes immediately", () => {
     logs.toggleFollow();
     expect(logs.following).toBe(false);
     logs.push(line());
     logs.push(line());
+    vi.advanceTimersByTime(FLUSH_MS * 3);
+    expect(logs.lines).toHaveLength(0);
     expect(logs.bufferedWhilePaused).toBe(2);
     logs.toggleFollow();
     expect(logs.bufferedWhilePaused).toBe(0);
+    expect(logs.lines).toHaveLength(2);
   });
 
-  it("clear empties buffer and paused counter", () => {
+  it("clear empties buffer, pending queue, and paused counter", () => {
     logs.push(line());
     logs.toggleFollow();
     logs.push(line());
     logs.clear();
+    vi.advanceTimersByTime(FLUSH_MS);
     expect(logs.lines).toHaveLength(0);
     expect(logs.bufferedWhilePaused).toBe(0);
   });
@@ -65,6 +104,7 @@ describe("logs filters", () => {
   it("filters by level", () => {
     logs.push(line({ level: "info" }));
     logs.push(line({ level: "error", message: "boom" }));
+    vi.advanceTimersByTime(FLUSH_MS);
     logs.level = "error";
     expect(logs.filtered).toHaveLength(1);
     expect(logs.filtered[0].message).toBe("boom");
@@ -73,6 +113,7 @@ describe("logs filters", () => {
   it("filters by text across pod and message", () => {
     logs.push(line({ pod: "api-0", message: "hello" }));
     logs.push(line({ pod: "worker-1", message: "crunching" }));
+    vi.advanceTimersByTime(FLUSH_MS);
     logs.textFilter = "worker";
     expect(logs.filtered).toHaveLength(1);
     expect(logs.filtered[0].pod).toBe("worker-1");

--- a/apps/desktop/src/lib/stores/logs.svelte.ts
+++ b/apps/desktop/src/lib/stores/logs.svelte.ts
@@ -1,6 +1,11 @@
 /**
  * Aggregated multi-pod log stream state: rolling buffer (~180 lines),
  * severity/text filters, follow toggle with paused-buffer counter.
+ *
+ * Incoming lines land in a non-reactive pending queue and are flushed
+ * into the reactive buffer in batches every `FLUSH_MS` — one `$state`
+ * reassignment per interval instead of one per line, which is what froze
+ * the UI under log flood. While paused nothing flushes at all.
  */
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -12,21 +17,31 @@ import { toasts } from "./toasts.svelte";
 /** Spec: buffer cap ~180 lines. */
 const BUFFER_CAP = 180;
 
+/** Batch window for moving pending lines into the reactive buffer. */
+export const FLUSH_MS = 120;
+
 export type LevelFilter = "all" | "info" | "warn" | "error";
 
+/** A log line with a store-assigned stable key for `{#each}`. */
+export type KeyedLogLine = LogLine & { id: number };
+
 class LogsStore {
-  lines = $state<LogLine[]>([]);
+  lines = $state<KeyedLogLine[]>([]);
   following = $state(true);
   level = $state<LevelFilter>("all");
   textFilter = $state("");
-  /** Lines that arrived while paused (drives the "buffered" pill). */
+  /** Lines waiting in the queue while paused (drives the "buffered" pill). */
   bufferedWhilePaused = $state(0);
   streaming = $state(false);
 
   #streamId: string | null = null;
   #unlisten: UnlistenFn | null = null;
+  /** Non-reactive staging area; bounded at BUFFER_CAP. */
+  #pending: KeyedLogLine[] = [];
+  #flushTimer: ReturnType<typeof setInterval> | null = null;
+  #nextId = 0;
 
-  get filtered(): LogLine[] {
+  get filtered(): KeyedLogLine[] {
     const text = this.textFilter.toLowerCase();
     return this.lines.filter((line) => {
       if (this.level !== "all" && line.level !== this.level) return false;
@@ -36,17 +51,56 @@ class LogsStore {
   }
 
   push(line: LogLine): void {
-    this.lines = [...this.lines, line].slice(-BUFFER_CAP);
-    if (!this.following) this.bufferedWhilePaused += 1;
+    this.#pending.push({ ...line, id: this.#nextId++ });
+    if (this.#pending.length > BUFFER_CAP) {
+      this.#pending.splice(0, this.#pending.length - BUFFER_CAP);
+    }
+    if (!this.following) {
+      this.bufferedWhilePaused = this.#pending.length;
+      return;
+    }
+    this.#scheduleFlush();
+  }
+
+  #scheduleFlush(): void {
+    if (this.#flushTimer !== null) return;
+    this.#flushTimer = setInterval(() => {
+      if (this.#pending.length === 0) {
+        this.#stopFlushTimer();
+        return;
+      }
+      this.#flush();
+    }, FLUSH_MS);
+  }
+
+  #stopFlushTimer(): void {
+    if (this.#flushTimer !== null) {
+      clearInterval(this.#flushTimer);
+      this.#flushTimer = null;
+    }
+  }
+
+  #flush(): void {
+    if (this.#pending.length === 0) return;
+    this.lines = [...this.lines, ...this.#pending].slice(-BUFFER_CAP);
+    this.#pending = [];
   }
 
   toggleFollow(): void {
     this.following = !this.following;
-    if (this.following) this.bufferedWhilePaused = 0;
+    if (this.following) {
+      this.bufferedWhilePaused = 0;
+      this.#flush();
+    } else {
+      // Paused: stop the timer; the queue keeps accumulating (bounded).
+      this.#stopFlushTimer();
+      this.bufferedWhilePaused = this.#pending.length;
+    }
   }
 
   clear(): void {
     this.lines = [];
+    this.#pending = [];
     this.bufferedWhilePaused = 0;
   }
 
@@ -71,6 +125,8 @@ class LogsStore {
 
   async stop(): Promise<void> {
     this.streaming = false;
+    this.#stopFlushTimer();
+    this.#flush();
     if (this.#unlisten) {
       this.#unlisten();
       this.#unlisten = null;

--- a/docs/superpowers/plans/2026-07-18-logs-parity.md
+++ b/docs/superpowers/plans/2026-07-18-logs-parity.md
@@ -1,0 +1,111 @@
+# Logs Parity & Performance Implementation Plan (#316)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the desktop Logs UI freeze, add label filtering to desktop logs, and build the aggregated multi-pod Logs screen on macOS native.
+
+**Architecture:** Desktop: batch `log-line` events through a non-reactive queue flushed on an interval; filter the streamed pod set by a parsed equality label selector (client-side, labels already present). Native: new `AggregatedLogStore` fanning out `PodLogStreaming.streamPodLogs` per pod into one global-ID ring buffer, surfaced by a new `Logs` sidebar entry and `AggregatedLogsView`.
+
+**Tech Stack:** Svelte 5 runes + vitest; Swift 5 / SwiftUI + XCTest.
+
+## Global Constraints
+
+- Two branches off `main`: `feat/desktop-logs-filters-316` (Tasks D1–D2, includes docs), `feat/macos-aggregated-logs-316` (Tasks M1–M4). Two PRs, both referencing #316.
+- macOS working tree carries uncommitted #309 wiretap hunks in `Services/KubeAPIService.swift` + ATS `Info.plist` — never stage them (no task touches those files in batch C).
+- Desktop tests: `pnpm --dir apps/desktop test` (vitest), typecheck `pnpm --dir apps/desktop typecheck`, lint `pnpm --dir apps/desktop lint`.
+- macOS build/test: same xcodebuild commands as prior batches (`-derivedDataPath /tmp/cubelite-build`, `-skip-testing cubeliteUITests`).
+- Commits: Conventional Commits + `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task D1: Batched log store (freeze fix)
+
+**Files:**
+- Modify: `apps/desktop/src/lib/stores/logs.svelte.ts`
+- Test: `apps/desktop/src/lib/stores/logs.svelte.test.ts` (create)
+
+**Interfaces:**
+- `LogsStore.push(line)` becomes enqueue-only; new private `#flush()` on a ~120 ms interval performs the single `$state` reassignment. Timer only runs while the queue is non-empty and `following` is true.
+- Lines gain a store-assigned monotonic `id: number` (type `KeyedLogLine = LogLine & { id: number }`; `lines` becomes `KeyedLogLine[]`).
+- Paused: queue accumulates bounded at `BUFFER_CAP`, `bufferedWhilePaused` mirrors queue length, no flush; `toggleFollow()` back to following flushes immediately.
+- `filtered` unchanged in semantics.
+
+- [ ] Step 1: failing vitest specs — with `vi.useFakeTimers()`: (a) 50 pushes → `lines` updates only after advancing the flush interval, single batch; (b) paused: pushes don't change `lines`, `bufferedWhilePaused` grows; resume flushes; (c) cap respected; (d) ids monotonic.
+- [ ] Step 2: implement queue + interval flush.
+- [ ] Step 3: `pnpm --dir apps/desktop test` green; `LogsView.svelte` keyed each `(line.id)`.
+- [ ] Step 4: commit `fix(desktop): batch log-line events — no more UI freeze under flood (#316)`.
+
+### Task D2: Label filter for desktop logs
+
+**Files:**
+- Modify: `apps/desktop/src/lib/k8s-match.ts` (+ `parseLabelSelector`)
+- Modify: `apps/desktop/src/lib/components/views/LogsView.svelte` (selector input + pod-set filtering + debounce)
+- Test: `apps/desktop/src/lib/k8s-match.test.ts` (extend)
+
+**Interfaces:**
+- `parseLabelSelector(text: string): Record<string, string>` — splits on commas, trims, keeps only `k=v` tokens (first `=`), ignores malformed; empty text → `{}`.
+- LogsView: `let labelSelector = $state("")`; debounced (300 ms) `$effect` recomputes `pods = resources.pods.filter(p => sel none || matchesSelector(p.labels, sel))` and restarts `logs.start(pods)`. Header shows `streaming N/20 pods` when trimmed.
+
+- [ ] Step 1: failing tests for `parseLabelSelector` (equality list, whitespace, malformed tokens ignored, empty → `{}`).
+- [ ] Step 2: implement helper + UI input + debounce restart.
+- [ ] Step 3: tests + typecheck + lint green.
+- [ ] Step 4: commit `feat(desktop): label-selector filter for aggregated logs (#316)`; push; PR.
+
+---
+
+### Task M1: Pod labels + label selector matcher (native)
+
+**Files:**
+- Modify: `apps/macos/cubelite/cubelite/Models/ResourceModels.swift` (`PodInfo.labels`, copy in `toPodInfo`)
+- Create: `apps/macos/cubelite/cubelite/Models/LabelSelectorMatcher.swift`
+- Test: `apps/macos/cubelite/cubeliteTests/LabelSelectorMatcherTests.swift` (includes labels-mapping test)
+
+**Interfaces:**
+- `PodInfo.labels: [String: String]?` (post-construction `var`).
+- `struct LabelSelectorMatcher { init(_ text: String); let requirements: [String: String]; func matches(_ labels: [String: String]?) -> Bool }` — empty requirements match all; nil labels match only when requirements empty.
+
+- [ ] TDD cycle; commit `feat(macos): pod labels + equality label-selector matcher (#316)`.
+
+### Task M2: AggregatedLogStore
+
+**Files:**
+- Create: `apps/macos/cubelite/cubelite/Models/AggregatedLogStore.swift`
+- Test: `apps/macos/cubelite/cubeliteTests/AggregatedLogStoreTests.swift` (mock `PodLogStreaming` per `LogSessionStoreTests` pattern)
+
+**Interfaces:**
+- `struct AggregatedLogLine: Identifiable, Sendable { let id: Int; let pod: String; let namespace: String; let line: LogLine }`
+- `@Observable @MainActor final class AggregatedLogStore`:
+  - `init(streamer: any PodLogStreaming, backoffBase: Double = 2)`
+  - `func start(pods: [PodInfo], context: String?)` — stops first; caps at `maxPods = 20`; one task per pod: `streamPodLogs(tail 50)` loop with backoff (cap 30 s) on end/error, cancellation-aware.
+  - `private(set) var buffer: [AggregatedLogLine]` ring (cap 2000), `totalAppended: Int`
+  - `var levelFilter: LogLine.Level?`, `var textFilter: String`, `var isFollowing: Bool`, `private(set) var pausedAtCount: Int?`
+  - `var filtered: [AggregatedLogLine]` (level + case-insensitive text over pod+message)
+  - `var newSincePause: Int`, `func clear()`, `func stop()`, `private(set) var streamedPodCount: Int`
+
+- [ ] TDD cycle (merge with global IDs + pod attribution, cap 20 pods, filters, clear, stop cancels); commit `feat(macos): aggregated multi-pod log store (#316)`.
+
+### Task M3: Sidebar entry + AggregatedLogsView
+
+**Files:**
+- Modify: `apps/macos/cubelite/cubelite/Models/ClusterState.swift` (`ResourceType.logs = "Logs"`, `systemImage "text.alignleft"`)
+- Modify: `apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift` (Observe section)
+- Modify: `apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift` (`case .logs` in both switches)
+- Modify: `apps/macos/cubelite/cubelite/Views/MainView.swift` (`@State var aggregatedLogStore` init with `kubeAPIService`)
+- Create: `apps/macos/cubelite/cubelite/Views/AggregatedLogsView.swift`
+
+**Interfaces:**
+- `AggregatedLogsView(store: AggregatedLogStore, pods: [PodInfo], context: String?)` — internally filters `pods` by its `@State labelSelector` (300 ms debounce via `.task(id:)`), calls `store.start` on appear/pod-set change, `store.stop()` on disappear.
+- Toolbar: selector `TextField`, level chips (All/Info/Warn/Error), search field, follow toggle + "N new" pill, Clear, `streaming N/20 pods` caption.
+- Body: `ScrollViewReader` + `LazyVStack` of rows (time, level, pod, message) keyed by `AggregatedLogLine.id`; autoscroll on `totalAppended` while following.
+
+- [ ] Implement, build, run `MainViewStateTests`; commit `feat(macos): aggregated Logs screen under new Observe section (#316)`.
+
+### Task M4: Verification + PR
+
+- [ ] Full macOS unit suite green; no #309 hunks in commits; push; PR `feat(macos): aggregated log viewer with label filtering (#316)`.
+
+## Self-review notes
+
+- Desktop `LogLine` from backend has no `id`: the store assigns it at enqueue (`KeyedLogLine`), so the Rust payload is untouched.
+- Native `LogLine.parse(raw, id:)` requires an id: `AggregatedLogStore` passes its global counter, so per-session collision never arises.
+- `matchesSelector` (desktop) returns false for empty selector by design — the view must gate on `Object.keys(sel).length === 0` → match all, mirroring the native matcher's empty-matches-all.

--- a/docs/superpowers/specs/2026-07-18-logs-parity-design.md
+++ b/docs/superpowers/specs/2026-07-18-logs-parity-design.md
@@ -1,0 +1,73 @@
+# Logs Parity & Performance — Design
+
+**Date:** 2026-07-18
+**Issue:** [#316](https://github.com/massimilianolapuma/cubelite/issues/316)
+**Delivery:** two independent PRs — `feat/desktop-logs-filters-316` (desktop) and `feat/macos-aggregated-logs-316` (native), both off `main`.
+
+## Context
+
+Batch C of the parity effort. Desktop has an aggregated Logs view that freezes the UI under log flood and offers no namespace/label filtering; native has no aggregated view at all (only the per-pod docked panel).
+
+## Part D — Desktop
+
+### D1. Freeze fix (`src/lib/stores/logs.svelte.ts`)
+
+Root causes found: `push()` reallocates the whole `$state` array per incoming line; the auto-scroll `$effect` forces a filtered recompute + layout read per line; the buffer churns even while paused.
+
+Design:
+- Incoming `log-line` events append to a **non-reactive pending queue** (plain array, bounded at `BUFFER_CAP`).
+- A **flush interval (~120 ms)** moves the queue into `lines` with a single reassignment (`[...lines, ...queue].slice(-BUFFER_CAP)`). No timer runs while the queue is empty.
+- While paused (`following === false`) the queue still accumulates (bounded) but **no flush happens** — zero reactive churn; `bufferedWhilePaused` mirrors the queue length. Resuming flushes immediately.
+- Lines get a monotonic `id` at enqueue time; the `{#each}` keys by `line.id` instead of index.
+- Auto-scroll effect now fires at most once per flush (unchanged code, batched trigger).
+
+No virtualization: with a 180-line cap and batched updates the DOM cost is bounded; virtualization is YAGNI here (revisit only if cap grows).
+
+### D2. Filters (`LogsView.svelte` + store)
+
+- **Namespace:** already scoped by the global namespace dropdown (restarts the stream); documented, no new UI.
+- **Label selector:** new text input in the Logs toolbar accepting equality selectors (`app=api,tier=web`). The pod set passed to `logs.start()` becomes `resources.pods` filtered by the selector (pods already carry `labels` on the frontend). Changing the selector restarts the stream **debounced 300 ms**. Invalid/partial input = no match restriction until it parses.
+- Selector parsing/matching: pure helper `matchesLabelSelector(labels, selector)` in `$lib` (reuse `k8s-match.ts` if it already covers it), unit-tested.
+- Existing level chips and text filter unchanged. Streamed-pod count shown next to the input ("streaming 8/20 pods") so the 20-pod backend cap is visible.
+
+### D3. Rust: no changes (labels already serialized on `PodInfo`; `MAX_LOG_PODS=20` cap stays).
+
+### Tests (vitest)
+- Store batching: fake timers — N pushes → single `lines` update per flush; paused → no update, counter grows; resume → flush.
+- Selector matcher: equality lists, whitespace, empty selector = match-all, unparseable tokens ignored.
+
+## Part M — macOS native
+
+### M1. Pod labels
+
+`PodInfo` gains `var labels: [String: String]?` (post-construction, like nodeName); `K8sPod.toPodInfo()` copies `metadata?.labels`. Needed for label filtering.
+
+### M2. Label selector matcher
+
+`Models/LabelSelectorMatcher.swift`: parses `"k=v, k2=v2"` → requirements; `matches(_ labels:)` = subset test. Empty/whitespace selector matches all; malformed tokens (no `=`) are ignored. Unit-tested.
+
+### M3. Aggregated log store
+
+`Models/AggregatedLogStore.swift` — `@Observable @MainActor final class`, injected `streamer: any PodLogStreaming` (same seam as `LogSession`):
+- `start(pods: [PodInfo], context: String?)`: caps at **20 pods** (desktop parity), spawns one task per pod running `streamPodLogs` (tail 50, `timestamps` on) with a simple retry-on-end loop (exponential backoff, 30 s cap, cancellation-aware — same shape as `LogSession.followWithReconnect`).
+- Merged ring buffer (cap **2000**) of `AggregatedLogLine { id: Int (store-global), pod: String, namespace: String, line: LogLine }` — global IDs avoid the per-session collision.
+- UI state: `levelFilter` (all/info/warn/error), `textFilter`, `isFollowing` + `pausedAtCount` marker (buffer keeps appending; the view stops auto-scrolling), `filtered` computed, `clear()`, `stop()` cancels all tasks.
+- Restart semantics: `start` is idempotent per (pods set, context) — callers stop first.
+
+### M4. Aggregated Logs screen
+
+- `ResourceType.logs = "Logs"`, `systemImage: "text.alignleft"`; new sidebar section **Observe** (`DesignTokens.accentAltTeal` dot) with `[.logs]`.
+- `Views/AggregatedLogsView.swift`, wired as `case .logs` in the `resourceBrowserView` switch (keeps the context/namespace breadcrumb):
+  - Toolbar: label-selector field, level chips, text search, follow/pause with "N new" pill, clear.
+  - Pod set = `clusterState.pods` filtered by `LabelSelectorMatcher`; stream restarts on namespace change (via `sidebarSelection`) and on debounced selector edits (300 ms).
+  - Body: `ScrollViewReader` + `LazyVStack` rows (time, level chip, pod name, message) reusing `LogLine.parse` level inference; autoscroll while following; "waiting for log lines…" empty state.
+- Owned by `MainView` as `@State`, stopped in `.onDisappear` of the view and when leaving the `.logs` selection.
+
+### Tests (XCTest)
+- `LabelSelectorMatcherTests`: parse/match matrix.
+- `AggregatedLogStoreTests` with a mock `PodLogStreaming` (pattern from `LogSessionStoreTests`): lines from two pods merge with global IDs and pod attribution; 20-pod cap; level/text filtering; clear; stop cancels.
+- `PodInfo` labels mapping test.
+
+## Non-goals
+
+Reconnect banners/tabs/export in the aggregated native view (per-pod panel already has them); pod metrics; desktop per-pod viewer (#295); merged all-containers stream (#297); pop-out window (#298); set-based label selectors (`in`, `!=`).


### PR DESCRIPTION
Part D of #316 (desktop half; the macOS aggregated viewer lands separately).

## Changes
- **Freeze fix**: `log-line` events now land in a non-reactive queue flushed into the `$state` buffer every 120 ms — one array reassignment per batch instead of per line (the previous per-line `[...lines, line].slice(-180)` froze the UI under flood). Pausing stops flushing entirely; the queue keeps accumulating bounded at the cap. Rows keyed by store-assigned monotonic ids.
- **Label filter**: new `parseLabelSelector` helper + selector input in the Logs toolbar; the streamed pod set is filtered client-side (pod labels were already serialized), restart debounced 300 ms. Namespace filtering remains the global namespace dropdown, which already restarts the stream.
- **Visible cap**: header shows "streaming N pods" / "streaming 20 of N pods" against the Rust `MAX_LOG_PODS` cap.
- Drive-by: fixed 3 stale `probeCluster` test fixtures that broke `pnpm typecheck` on main (missing `context` field from #312).

## Tests
- New batching specs (fake timers) in `logs.svelte.test.ts`, `parseLabelSelector` specs in `k8s-match.test.ts`.
- vitest 163/163, `svelte-check` 0 errors, eslint clean.

Design spec: `docs/superpowers/specs/2026-07-18-logs-parity-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)