### PR TITLE
feat(macos): aggregated log viewer with label filtering (#316)

### DIFF
--- a/apps/macos/cubelite/cubelite/Models/AggregatedLogStore.swift
+++ b/apps/macos/cubelite/cubelite/Models/AggregatedLogStore.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Observation
+
+/// One line in the aggregated multi-pod stream, with pod attribution and
+/// a store-global ID (per-pod line IDs would collide across streams).
+struct AggregatedLogLine: Identifiable, Sendable {
+    let id: Int
+    let pod: String
+    let namespace: String
+    let line: LogLine
+}
+
+/// Aggregated multi-pod log stream for the Logs screen (desktop parity):
+/// fans out one follow-stream per pod into a single ring buffer with
+/// level/text filtering and a follow/pause marker.
+@Observable
+@MainActor
+final class AggregatedLogStore {
+
+    /// Streamed-pod cap, matching the desktop backend's MAX_LOG_PODS.
+    static let maxPods = 20
+    /// Merged ring-buffer capacity.
+    static let bufferCap = 2000
+    /// History requested per pod when a stream (re)opens.
+    static let tailLines = 50
+
+    private let streamer: any PodLogStreaming
+    private let backoffBase: Double
+    private var tasks: [Task<Void, Never>] = []
+    private var nextID = 0
+
+    /// Merged lines, oldest first, bounded at ``bufferCap``.
+    private(set) var buffer: [AggregatedLogLine] = []
+    /// Total lines ever appended (drives autoscroll + the "new" pill).
+    private(set) var totalAppended = 0
+    /// How many pods are actually being streamed (after the cap).
+    private(set) var streamedPodCount = 0
+    private(set) var isStreaming = false
+
+    /// nil shows every level.
+    var levelFilter: LogLine.Level?
+    var textFilter = ""
+    var isFollowing = true {
+        didSet { pausedAtCount = isFollowing ? nil : totalAppended }
+    }
+    /// `totalAppended` at the moment of pausing; nil while following.
+    private(set) var pausedAtCount: Int?
+
+    /// Lines arrived since the user paused.
+    var newSincePause: Int {
+        guard let pausedAtCount else { return 0 }
+        return totalAppended - pausedAtCount
+    }
+
+    var filtered: [AggregatedLogLine] {
+        let text = textFilter.lowercased()
+        return buffer.filter { entry in
+            if let levelFilter, entry.line.level != levelFilter { return false }
+            if !text.isEmpty,
+                !"\(entry.pod) \(entry.line.message)".lowercased().contains(text)
+            {
+                return false
+            }
+            return true
+        }
+    }
+
+    init(streamer: any PodLogStreaming, backoffBase: Double = 2) {
+        self.streamer = streamer
+        self.backoffBase = backoffBase
+    }
+
+    /// Restarts streaming for the given pod set (first ``maxPods`` pods).
+    func start(pods: [PodInfo], context: String?) {
+        stop()
+        let selected = pods.prefix(Self.maxPods)
+        streamedPodCount = selected.count
+        isStreaming = !selected.isEmpty
+        for pod in selected {
+            tasks.append(
+                Task { [weak self] in
+                    await self?.streamLoop(pod: pod, context: context)
+                })
+        }
+    }
+
+    func stop() {
+        for task in tasks {
+            task.cancel()
+        }
+        tasks = []
+        isStreaming = false
+    }
+
+    func clear() {
+        buffer = []
+        totalAppended = 0
+        pausedAtCount = isFollowing ? nil : 0
+    }
+
+    /// Follows one pod's log stream, reconnecting with capped exponential
+    /// backoff when the server drops it (same shape as LogSession).
+    private func streamLoop(pod: PodInfo, context: String?) async {
+        var attempt = 0
+        while !Task.isCancelled {
+            do {
+                let stream = try await streamer.streamPodLogs(
+                    namespace: pod.namespace, pod: pod.name, container: nil,
+                    tailLines: Self.tailLines, sinceTime: nil, inContext: context)
+                for try await raw in stream {
+                    attempt = 0
+                    append(raw, pod: pod)
+                }
+                // Stream ended without error: server closed it — reconnect.
+            } catch is CancellationError {
+                return
+            } catch {
+                // Transient failure — fall through to backoff.
+            }
+            if Task.isCancelled { return }
+            attempt += 1
+            let delay = min(30, backoffBase * pow(2, Double(attempt - 1)))
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+    }
+
+    private func append(_ raw: String, pod: PodInfo) {
+        let line = LogLine.parse(raw, id: nextID)
+        buffer.append(
+            AggregatedLogLine(id: nextID, pod: pod.name, namespace: pod.namespace, line: line))
+        nextID += 1
+        totalAppended += 1
+        if buffer.count > Self.bufferCap {
+            buffer.removeFirst(buffer.count - Self.bufferCap)
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Models/ClusterState.swift
+++ b/apps/macos/cubelite/cubelite/Models/ClusterState.swift
@@ -111,6 +111,8 @@ enum ResourceType: String, CaseIterable, Identifiable {
     case pvcs = "PVCs"
     /// Cluster nodes (read-only).
     case nodes = "Nodes"
+    /// Aggregated multi-pod log stream.
+    case logs = "Logs"
 
     var id: String { rawValue }
 
@@ -129,6 +131,7 @@ enum ResourceType: String, CaseIterable, Identifiable {
         case .cronJobs: "clock.arrow.circlepath"
         case .pvcs: "externaldrive"
         case .nodes: "server.rack"
+        case .logs: "text.alignleft"
         }
     }
 }

--- a/apps/macos/cubelite/cubelite/Models/LabelSelectorMatcher.swift
+++ b/apps/macos/cubelite/cubelite/Models/LabelSelectorMatcher.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Equality-based label selector ("app=api, tier=web") with subset
+/// matching semantics.
+///
+/// Malformed tokens (no key, no value, no "=") are ignored; values may
+/// themselves contain "=". An empty selector matches everything.
+struct LabelSelectorMatcher: Equatable {
+
+    /// Parsed key → required value.
+    let requirements: [String: String]
+
+    init(_ text: String) {
+        var parsed: [String: String] = [:]
+        for token in text.split(separator: ",") {
+            guard let eq = token.firstIndex(of: "=") else { continue }
+            let key = token[token.startIndex..<eq].trimmingCharacters(in: .whitespaces)
+            let value = token[token.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty, !value.isEmpty else { continue }
+            parsed[key] = value
+        }
+        requirements = parsed
+    }
+
+    /// True when every requirement is present in `labels`. An empty
+    /// selector matches all pods, including ones without labels.
+    func matches(_ labels: [String: String]?) -> Bool {
+        guard !requirements.isEmpty else { return true }
+        guard let labels else { return false }
+        return requirements.allSatisfy { labels[$0.key] == $0.value }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
+++ b/apps/macos/cubelite/cubelite/Models/ResourceModels.swift
@@ -21,6 +21,8 @@ struct PodInfo: Codable, Sendable, Identifiable {
     var cpuRequest: String?
     /// Memory resource request from the first container (e.g. `"128Mi"`).
     var memoryRequest: String?
+    /// Pod labels, used for label-selector filtering.
+    var labels: [String: String]?
 
     /// Creates a ``PodInfo`` with core scheduling fields.
     ///
@@ -729,6 +731,7 @@ extension K8sPod {
         info.podIP = status?.podIP
         info.cpuRequest = firstContainer?.resources?.requests?["cpu"]
         info.memoryRequest = firstContainer?.resources?.requests?["memory"]
+        info.labels = metadata?.labels
         return info
     }
 }

--- a/apps/macos/cubelite/cubelite/Views/AggregatedLogsView.swift
+++ b/apps/macos/cubelite/cubelite/Views/AggregatedLogsView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+
+/// Aggregated multi-pod Logs screen (desktop parity): streams every pod
+/// in the current namespace scope — optionally narrowed by an equality
+/// label selector — into one merged, filterable stream.
+struct AggregatedLogsView: View {
+
+    let pods: [PodInfo]
+    let context: String?
+
+    @State private var store: AggregatedLogStore
+    @State private var labelSelector = ""
+    /// Selector actually applied to the stream (debounced copy).
+    @State private var appliedSelector = ""
+
+    init(streamer: any PodLogStreaming, pods: [PodInfo], context: String?) {
+        self.pods = pods
+        self.context = context
+        _store = State(initialValue: AggregatedLogStore(streamer: streamer))
+    }
+
+    private var matchedPods: [PodInfo] {
+        let matcher = LabelSelectorMatcher(appliedSelector)
+        return pods.filter { matcher.matches($0.labels) }
+    }
+
+    /// Identity of the streamed set — changing it restarts the stream.
+    private var streamKey: String {
+        let ids = matchedPods.map(\.id).sorted().joined(separator: ",")
+        return "\(context ?? "")|\(appliedSelector)|\(ids)"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            logList
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+        // Debounce selector edits so each keystroke doesn't restart streams.
+        .task(id: labelSelector) {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            if !Task.isCancelled { appliedSelector = labelSelector }
+        }
+        .task(id: streamKey) {
+            store.start(pods: matchedPods, context: context)
+        }
+        .onDisappear { store.stop() }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            Text(verbatim: streamingCaption)
+                .font(.system(size: 10.5))
+                .foregroundStyle(DesignTokens.textTertiary)
+            Spacer(minLength: 8)
+            TextField("label=value,…", text: $labelSelector)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 11, design: .monospaced))
+                .frame(width: 160)
+            levelChips
+            TextField("Filter…", text: Bindable(store).textFilter)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 11))
+                .frame(width: 140)
+            followButton
+            Button("Clear") { store.clear() }
+                .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+    }
+
+    private var streamingCaption: String {
+        let total = matchedPods.count
+        let streamed = min(total, AggregatedLogStore.maxPods)
+        return streamed < total
+            ? "streaming \(streamed) of \(total) pods"
+            : "streaming \(streamed) pods"
+    }
+
+    private var levelChips: some View {
+        let options: [(label: String, level: LogLine.Level?)] = [
+            ("ALL", nil), ("INFO", .info), ("WARN", .warn), ("ERR", .error),
+        ]
+        return HStack(spacing: 0) {
+            ForEach(options, id: \.label) { option in
+                let active = store.levelFilter == option.level
+                Button(option.label) { store.levelFilter = option.level }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(active ? DesignTokens.surfaceRaised : .clear)
+                    .foregroundStyle(
+                        active ? DesignTokens.textPrimary : DesignTokens.textTertiary)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: DesignTokens.radiusMd)
+                .strokeBorder(DesignTokens.borderDefault, lineWidth: 1))
+    }
+
+    private var followButton: some View {
+        Button {
+            store.isFollowing.toggle()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: store.isFollowing ? "play.fill" : "pause.fill")
+                    .font(.system(size: 8))
+                Text(store.isFollowing ? "Following" : "Paused")
+                if !store.isFollowing, store.newSincePause > 0 {
+                    Text(verbatim: "+\(store.newSincePause)")
+                        .font(.system(size: 9, design: .monospaced))
+                }
+            }
+            .font(.system(size: 10.5))
+        }
+        .controlSize(.small)
+        .tint(store.isFollowing ? DesignTokens.statusOk : DesignTokens.statusWarn)
+    }
+
+    // MARK: - Log List
+
+    private var logList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if store.filtered.isEmpty {
+                        Text(
+                            store.buffer.isEmpty
+                                ? "Waiting for log lines…" : "No lines match the filter."
+                        )
+                        .font(.system(size: 11))
+                        .foregroundStyle(DesignTokens.textTertiary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 32)
+                    } else {
+                        ForEach(store.filtered) { entry in
+                            logRow(entry)
+                                .id(entry.id)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .onChange(of: store.totalAppended) { _, _ in
+                if store.isFollowing, let last = store.filtered.last {
+                    proxy.scrollTo(last.id, anchor: .bottom)
+                }
+            }
+        }
+    }
+
+    private func logRow(_ entry: AggregatedLogLine) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(verbatim: entry.line.time ?? "—")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(DesignTokens.textTertiary)
+                .frame(width: 88, alignment: .leading)
+            Text(verbatim: levelLabel(entry.line.level))
+                .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+                .foregroundStyle(levelColor(entry.line.level))
+                .frame(width: 36, alignment: .leading)
+            Text(entry.pod)
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundStyle(DesignTokens.textSecondary)
+                .lineLimit(1)
+            Text(entry.line.message)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(DesignTokens.textLog)
+                .textSelection(.enabled)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 1)
+    }
+
+    private func levelLabel(_ level: LogLine.Level) -> String {
+        switch level {
+        case .debug: "DBG"
+        case .info: "INFO"
+        case .warn: "WARN"
+        case .error: "ERR"
+        }
+    }
+
+    private func levelColor(_ level: LogLine.Level) -> Color {
+        switch level {
+        case .debug: DesignTokens.textTertiary
+        case .info: DesignTokens.statusInfo
+        case .warn: DesignTokens.statusWarn
+        case .error: DesignTokens.statusErr
+        }
+    }
+}

--- a/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
+++ b/apps/macos/cubelite/cubelite/Views/MainView+DetailArea.swift
@@ -30,7 +30,7 @@ extension MainView {
             case .dashboard:
                 OverviewView()
             case .pods, .deployments, .services, .secrets, .configMaps, .ingresses,
-                .helmReleases, .nodes, .jobs, .statefulSets, .cronJobs, .pvcs:
+                .helmReleases, .nodes, .jobs, .statefulSets, .cronJobs, .pvcs, .logs:
                 resourceBrowserView(context: sel.context, namespace: sel.namespace)
             }
         } else {
@@ -129,6 +129,12 @@ extension MainView {
                     PvcListView()
                 case .nodes:
                     NodeListView()
+                case .logs:
+                    AggregatedLogsView(
+                        streamer: kubeAPIService,
+                        pods: clusterState.pods,
+                        context: context
+                    )
                 case .dashboard:
                     EmptyView()
                 }

--- a/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
+++ b/apps/macos/cubelite/cubelite/Views/Shell/UnifiedSidebarView.swift
@@ -29,6 +29,9 @@ struct UnifiedSidebarView: View {
             Section(
                 label: "Config", dot: DesignTokens.statusWarn,
                 items: [.configMaps, .secrets, .pvcs]),
+            Section(
+                label: "Observe", dot: DesignTokens.accentAltTeal,
+                items: [.logs]),
         ]
     }
 

--- a/apps/macos/cubelite/cubeliteTests/AggregatedLogStoreTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/AggregatedLogStoreTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+
+@testable import cubelite
+
+// MARK: - AggregatedLogStoreTests
+
+/// Tests the aggregated multi-pod log store against the scripted
+/// `MockLogStreamer` double (shared with LogSessionStoreTests).
+@MainActor
+final class AggregatedLogStoreTests: XCTestCase {
+
+    private var streamer: MockLogStreamer!
+    private var store: AggregatedLogStore!
+
+    override func setUp() async throws {
+        streamer = MockLogStreamer()
+        store = AggregatedLogStore(streamer: streamer, backoffBase: 0.01)
+    }
+
+    override func tearDown() async throws {
+        store.stop()
+    }
+
+    private func makePod(_ name: String, namespace: String = "default") -> PodInfo {
+        PodInfo(
+            name: name, namespace: namespace, phase: "Running", ready: true, restarts: 0,
+            creationTimestamp: nil)
+    }
+
+    /// Polls the main actor until `condition` holds or the timeout elapses.
+    private func waitUntil(
+        _ condition: @escaping () -> Bool, timeout: TimeInterval = 2
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() > deadline {
+                XCTFail("Timed out waiting for condition")
+                return
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+
+    func testStart_mergesLinesFromAllPods_withGlobalUniqueIDs() async throws {
+        streamer.liveLines = ["2026-07-18T10:00:00Z hello", "2026-07-18T10:00:01Z world"]
+
+        store.start(pods: [makePod("api-1"), makePod("worker-1")], context: nil)
+        try await waitUntil { self.store.buffer.count == 4 }
+
+        let pods = Set(store.buffer.map(\.pod))
+        XCTAssertEqual(pods, ["api-1", "worker-1"])
+        let ids = store.buffer.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+        XCTAssertEqual(store.totalAppended, 4)
+        XCTAssertTrue(store.isStreaming)
+    }
+
+    func testStart_capsAtTwentyPods() async throws {
+        streamer.liveLines = []
+        let pods = (0..<25).map { makePod("pod-\($0)") }
+
+        store.start(pods: pods, context: nil)
+
+        XCTAssertEqual(store.streamedPodCount, 20)
+        try await waitUntil { self.streamer.streamCalls.count == 20 }
+    }
+
+    func testFiltered_byLevelAndText() async throws {
+        streamer.liveLines = [
+            "2026-07-18T10:00:00Z ERROR boom",
+            "2026-07-18T10:00:01Z all good",
+        ]
+
+        store.start(pods: [makePod("api-1")], context: nil)
+        try await waitUntil { self.store.buffer.count == 2 }
+
+        store.levelFilter = .error
+        XCTAssertEqual(store.filtered.count, 1)
+        XCTAssertEqual(store.filtered.first?.line.message, "ERROR boom")
+
+        store.levelFilter = nil
+        store.textFilter = "good"
+        XCTAssertEqual(store.filtered.count, 1)
+
+        store.textFilter = "api-1"
+        XCTAssertEqual(store.filtered.count, 2, "text filter matches pod names too")
+    }
+
+    func testPause_marksCount_andNewSincePauseGrows() async throws {
+        streamer.liveLines = ["2026-07-18T10:00:00Z one"]
+
+        store.start(pods: [makePod("api-1")], context: nil)
+        try await waitUntil { self.store.buffer.count == 1 }
+
+        store.isFollowing = false
+        XCTAssertEqual(store.pausedAtCount, 1)
+        XCTAssertEqual(store.newSincePause, 0)
+
+        store.isFollowing = true
+        XCTAssertNil(store.pausedAtCount)
+    }
+
+    func testClear_emptiesBuffer() async throws {
+        streamer.liveLines = ["2026-07-18T10:00:00Z one"]
+
+        store.start(pods: [makePod("api-1")], context: nil)
+        try await waitUntil { self.store.buffer.count == 1 }
+        store.clear()
+
+        XCTAssertTrue(store.buffer.isEmpty)
+        XCTAssertEqual(store.totalAppended, 0)
+    }
+
+    func testStop_endsStreaming() async throws {
+        streamer.liveLines = ["2026-07-18T10:00:00Z one"]
+
+        store.start(pods: [makePod("api-1")], context: nil)
+        try await waitUntil { self.store.buffer.count == 1 }
+        store.stop()
+
+        XCTAssertFalse(store.isStreaming)
+    }
+}

--- a/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/ClusterStateTests.swift
@@ -147,7 +147,7 @@ final class ResourceTypeTests: XCTestCase {
 
     func testCaseIterable_containsAllCases() {
         let all = ResourceType.allCases
-        XCTAssertEqual(all.count, 13)
+        XCTAssertEqual(all.count, 14)
         XCTAssertTrue(all.contains(.dashboard))
         XCTAssertTrue(all.contains(.pods))
         XCTAssertTrue(all.contains(.deployments))

--- a/apps/macos/cubelite/cubeliteTests/LabelSelectorMatcherTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/LabelSelectorMatcherTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+@testable import cubelite
+
+// MARK: - LabelSelectorMatcherTests
+
+/// Tests the equality label-selector parser/matcher and the PodInfo
+/// labels mapping it depends on.
+final class LabelSelectorMatcherTests: XCTestCase {
+
+    // MARK: - Parsing
+
+    func testInit_parsesEqualityListWithWhitespace() {
+        let matcher = LabelSelectorMatcher(" app=api, tier = web ")
+
+        XCTAssertEqual(matcher.requirements, ["app": "api", "tier": "web"])
+    }
+
+    func testInit_splitsOnFirstEqualsOnly() {
+        XCTAssertEqual(LabelSelectorMatcher("cfg=a=b").requirements, ["cfg": "a=b"])
+    }
+
+    func testInit_ignoresMalformedTokens() {
+        let matcher = LabelSelectorMatcher("app=api, nonsense, =v, k=")
+
+        XCTAssertEqual(matcher.requirements, ["app": "api"])
+    }
+
+    func testInit_emptyInput_hasNoRequirements() {
+        XCTAssertTrue(LabelSelectorMatcher("").requirements.isEmpty)
+        XCTAssertTrue(LabelSelectorMatcher("   ").requirements.isEmpty)
+    }
+
+    // MARK: - Matching
+
+    func testMatches_subsetSemantics() {
+        let matcher = LabelSelectorMatcher("app=api")
+
+        XCTAssertTrue(matcher.matches(["app": "api", "tier": "web"]))
+        XCTAssertFalse(matcher.matches(["app": "worker"]))
+        XCTAssertFalse(matcher.matches(["tier": "web"]))
+    }
+
+    func testMatches_emptySelector_matchesEverything() {
+        let matcher = LabelSelectorMatcher("")
+
+        XCTAssertTrue(matcher.matches(["app": "api"]))
+        XCTAssertTrue(matcher.matches([:]))
+        XCTAssertTrue(matcher.matches(nil))
+    }
+
+    func testMatches_nilLabels_onlyWhenNoRequirements() {
+        XCTAssertFalse(LabelSelectorMatcher("app=api").matches(nil))
+    }
+
+    // MARK: - PodInfo labels mapping
+
+    func testToPodInfo_copiesLabels() {
+        let pod = K8sPod(
+            metadata: K8sObjectMeta(
+                name: "api-1", namespace: "default", labels: ["app": "api"]))
+
+        XCTAssertEqual(pod.toPodInfo().labels, ["app": "api"])
+    }
+}

--- a/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/MainViewStateTests.swift
@@ -235,7 +235,7 @@ final class MainViewStateTests: XCTestCase {
     }
 
     func testResourceType_allCases_matchesEnum() {
-        XCTAssertEqual(ResourceType.allCases.count, 13)
+        XCTAssertEqual(ResourceType.allCases.count, 14)
     }
 
     func testResourceType_pods_hasSystemImage() {


### PR DESCRIPTION
Part M of #316 (macOS half; desktop freeze fix + label filter is #321). Closes #316 together with #321.

## Changes
- **New "Logs" screen** under a new **Observe** sidebar section: streams every pod in the current cluster/namespace scope into one merged view (20-pod cap, matching desktop's `MAX_LOG_PODS`).
- **`AggregatedLogStore`**: fans out one follow-stream per pod via the existing `PodLogStreaming` seam, reconnects with capped exponential backoff, merges into a 2000-line ring buffer with store-global line IDs; level/text filters, follow/pause with paused-at marker, clear.
- **Label filtering**: `PodInfo` now carries pod labels; new `LabelSelectorMatcher` (equality selectors, `app=api,tier=web`) narrows the streamed pod set, debounced 300 ms. Namespace scoping comes from the global namespace picker, as on desktop.
- Toolbar shows `streaming N pods` / `streaming 20 of N pods`.

## Tests
- New: `LabelSelectorMatcherTests` (8, incl. labels mapping), `AggregatedLogStoreTests` (6, on the shared `MockLogStreamer`).
- Updated `ResourceType` case-count tests (13 → 14).
- Full macOS unit suite green (only known-flaky keychain test recovered on retry).

Design spec: `docs/superpowers/specs/2026-07-18-logs-parity-design.md` (lands with #321)

🤖 Generated with [Claude Code](https://claude.com/claude-code)