### PR TITLE
fix(desktop): window cannot be moved — explicit startDragging fallback (#317)

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,9 @@
   "identifier": "default",
   "description": "Default capability for the CubeLite desktop app",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-toggle-maximize"
+  ]
 }

--- a/apps/desktop/src/lib/components/shell/Titlebar.svelte
+++ b/apps/desktop/src/lib/components/shell/Titlebar.svelte
@@ -2,10 +2,25 @@
 	import Search from '@lucide/svelte/icons/search';
 	import Kbd from '$lib/components/ui/Kbd.svelte';
 	import NamespaceDropdown from '$lib/components/ui/NamespaceDropdown.svelte';
+	import { getCurrentWindow } from '@tauri-apps/api/window';
 	import { app } from '$lib/stores/app.svelte';
 	import { clusters } from '$lib/stores/clusters.svelte';
 	import { isMac, modLabel } from '$lib/platform';
 	import { providerOf } from '$lib/provider';
+	import { isDragSurface } from '$lib/window-drag';
+
+	// Explicit drag fallback: Tauri's injected data-tauri-drag-region
+	// handler is unreliable with the Overlay title bar on macOS (#317).
+	function beginDrag(event: MouseEvent) {
+		if (event.button !== 0) return;
+		if (!isDragSurface(event.target as Element | null)) return;
+		const window = getCurrentWindow();
+		if (event.detail === 2) {
+			void window.toggleMaximize();
+		} else {
+			void window.startDragging();
+		}
+	}
 
 	const activeContext = $derived(
 		clusters.contexts.find((c) => c.name === app.activeCluster) ?? null
@@ -18,8 +33,12 @@
 	);
 </script>
 
+<!-- The mousedown handler only begins a window drag — not an
+     interactive control, so no ARIA role applies. -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <header
 	data-tauri-drag-region
+	onmousedown={beginDrag}
 	class="flex h-[42px] shrink-0 items-center gap-3 border-b border-border-default bg-surface-surface pr-3"
 	style="padding-left: {isMac ? '78px' : '12px'};"
 >

--- a/apps/desktop/src/lib/window-drag.test.ts
+++ b/apps/desktop/src/lib/window-drag.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { isDragSurface } from "./window-drag";
+
+function build(html: string, selector: string): Element {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  const el = root.querySelector(selector);
+  if (!el) throw new Error(`selector ${selector} not found`);
+  return el;
+}
+
+describe("isDragSurface", () => {
+  it("accepts plain header surfaces", () => {
+    expect(isDragSurface(build("<header><div id='x'></div></header>", "#x"))).toBe(true);
+  });
+
+  it("rejects interactive elements and their descendants", () => {
+    expect(isDragSurface(build("<button id='x'>go</button>", "#x"))).toBe(false);
+    expect(isDragSurface(build("<button><span id='x'>go</span></button>", "#x"))).toBe(false);
+    expect(isDragSurface(build("<input id='x' />", "#x"))).toBe(false);
+    expect(isDragSurface(build("<a href='#' id='x'>l</a>", "#x"))).toBe(false);
+  });
+
+  it("rejects opted-out regions via data-no-drag", () => {
+    expect(
+      isDragSurface(build("<div data-no-drag><span id='x'></span></div>", "#x")),
+    ).toBe(false);
+  });
+
+  it("rejects null targets", () => {
+    expect(isDragSurface(null)).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/window-drag.ts
+++ b/apps/desktop/src/lib/window-drag.ts
@@ -1,0 +1,11 @@
+/**
+ * Guard for the Titlebar's explicit start-dragging fallback: a mousedown
+ * may begin a window drag only when it lands on inert chrome, never on an
+ * interactive control (or anything opted out via `data-no-drag`).
+ */
+const NON_DRAG_SELECTOR = "button, input, select, textarea, a, [role='menu'], [data-no-drag]";
+
+export function isDragSurface(target: Element | null): boolean {
+  if (!target) return false;
+  return target.closest(NON_DRAG_SELECTOR) === null;
+}

--- a/docs/superpowers/plans/2026-07-18-desktop-window-portforward.md
+++ b/docs/superpowers/plans/2026-07-18-desktop-window-portforward.md
@@ -1,0 +1,69 @@
+# Desktop Window Drag & Port-Forward Implementation Plan (#317, #318)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the desktop window draggable again and bring port-forwarding to desktop (macOS parity).
+
+**Architecture:** W: explicit `startDragging()` mousedown fallback in the Titlebar guarded by a pure `isDragSurface` helper, plus explicit window capabilities. P: kube-rs native portforward — per-connection forwarder behind a local `TcpListener` (0 = auto-assign) in `cubelite-core`, Tauri start/stop commands with a session registry, Svelte store + PodDrawer section with shared port validation.
+
+**Tech Stack:** Svelte 5 + vitest; Rust (kube 0.97 + `ws` feature, tokio); Tauri v2.
+
+## Global Constraints
+
+- Branch `fix/desktop-window-drag-317` (Task W, includes docs), then `feat/desktop-port-forward-318` (Tasks P1–P3) off `main`.
+- macOS wiretap files (#309) untouched — no macOS files in this batch.
+- Verify: `pnpm --dir apps/desktop test` / `typecheck` / `lint`; Rust: `cargo test -p cubelite-core` and `cargo check -p desktop` (src-tauri package name per its Cargo.toml).
+- Commits: Conventional Commits + `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task W: Window drag fallback (#317)
+
+**Files:**
+- Create: `apps/desktop/src/lib/window-drag.ts` (+ test `window-drag.test.ts`)
+- Modify: `apps/desktop/src/lib/components/shell/Titlebar.svelte` (mousedown handler)
+- Modify: `apps/desktop/src-tauri/capabilities/default.json` (explicit permissions)
+
+**Interfaces:**
+- `isDragSurface(target: Element | null): boolean` — false when the element or an ancestor matches `button, input, select, textarea, a, [role="menu"], [data-no-drag]`.
+- Titlebar `onmousedown`: primary button + `isDragSurface` → `event.detail === 2 ? toggleMaximize() : startDragging()` on `getCurrentWindow()`.
+- Capabilities gain `core:window:allow-start-dragging`, `core:window:allow-toggle-maximize`.
+
+- [ ] TDD on the helper; wire handler; tests+typecheck+lint green; commit `fix(desktop): explicit startDragging fallback — window draggable again (#317)`; push; PR.
+
+### Task P1: Rust port-forward core
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `kube` features += `"ws"`)
+- Create: `crates/cubelite-core/src/portforward.rs`; register in `lib.rs`
+
+**Interfaces:**
+- `pub fn bind_local(local_port: u16) -> impl Future<Output = std::io::Result<tokio::net::TcpListener>>` — binds `127.0.0.1:local_port` (0 = ephemeral).
+- `pub async fn forward_pod_port(client: kube::Client, namespace: String, pod: String, local_port: u16, remote_port: u16) -> Result<(u16, tokio::task::JoinHandle<()>), std::io::Error>` — binds first (errors propagate synchronously), returns actual port + the accept-loop handle; each accepted connection opens its own `Api::<Pod>::portforward` and `copy_bidirectional`s.
+
+- [ ] Unit tests: `bind_local(0)` → nonzero port; double bind of the same port → `Err(AddrInUse)`. `cargo test -p cubelite-core` green. Commit `feat(core): kube-rs port-forward with local listener and auto-assign (#318)`.
+
+### Task P2: Tauri commands + frontend store
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/commands/kubernetes.rs` (`PortForwardState`, `start_port_forward`, `stop_port_forward`), `apps/desktop/src-tauri/src/lib.rs` (manage + handler)
+- Create: `apps/desktop/src/lib/ports.ts` + `ports.test.ts`
+- Create: `apps/desktop/src/lib/stores/portforward.svelte.ts` + test
+- Modify: `apps/desktop/src/lib/tauri.ts` (wrappers + `ForwardStart` type)
+
+**Interfaces:**
+- Command `start_port_forward(kubeconfig_path, context: Option<String>, namespace, pod, local_port: u16, remote_port: u16) -> Result<ForwardStartResult { id: String, local_port: u16 }, String>`; `stop_port_forward(id: String)` aborts the handle.
+- `parsePort(text): number | null` (1–65535); `resolveLocalPort(text, remote): number | null` — `""` → remote, `"0"`/`"auto"` → 0, else parsePort.
+- Store: `sessions`, `start({namespace, pod, localPort, remotePort})` (toasts backend errors), `stop(id)`, `stopAll()`, `sessionsFor(namespace, pod)`.
+
+- [ ] TDD on ports helper + store (mock invoke); `cargo check`; commit `feat(desktop): port-forward commands and session store (#318)`.
+
+### Task P3: PodDrawer UI + wiring
+
+**Files:**
+- Modify: `apps/desktop/src/lib/components/pods/PodDrawer.svelte` (Port forward section)
+- Modify: cluster-switch reset site (`stores/clusters.svelte.ts` `switchCluster`) → `portforward.stopAll()`
+
+**Interfaces:** remote input (default "80"), local input (placeholder "auto"), Forward button (disabled invalid, inline error), session rows `localhost:N → M` (plain text) + Stop.
+
+- [ ] Implement; tests+typecheck+lint green; commit `feat(desktop): port-forward UI in the pod drawer (#318)`; push; PR.

--- a/docs/superpowers/specs/2026-07-18-desktop-window-portforward-design.md
+++ b/docs/superpowers/specs/2026-07-18-desktop-window-portforward-design.md
@@ -1,0 +1,38 @@
+# Desktop Window Drag & Port-Forward — Design
+
+**Date:** 2026-07-18
+**Issues:** [#317](https://github.com/massimilianolapuma/cubelite/issues/317) (window not movable), [#318](https://github.com/massimilianolapuma/cubelite/issues/318) (port-forward parity)
+**Delivery:** two PRs off `main` — `fix/desktop-window-drag-317`, `feat/desktop-port-forward-318`.
+
+## Part W — Window drag (#317)
+
+### Findings
+`Titlebar.svelte` already carries `data-tauri-drag-region` on the header, the cluster block, and a `flex-1` filler — layout is correct. The capability file grants only `core:default`. Tauri's injected drag-region handler is known-unreliable with `titleBarStyle: "Overlay"` on macOS, and the user reports the window cannot be dragged at all.
+
+### Design
+Belt-and-braces, independent of the injected handler:
+- **Explicit `onmousedown` fallback** on the header calling `getCurrentWindow().startDragging()`; double-click (`event.detail === 2`) calls `toggleMaximize()` to preserve native titlebar behavior.
+- Guard: primary button only, and never when the press lands on an interactive element — pure helper `isDragSurface(target: Element | null): boolean` in `src/lib/window-drag.ts` returning false for `closest('button, input, select, textarea, a, [role="menu"], [data-no-drag]')`. Unit-tested (jsdom).
+- **Capabilities**: add `core:window:allow-start-dragging` and `core:window:allow-toggle-maximize` explicitly so the fallback cannot be denied regardless of what `core:default` bundles.
+- Keep the `data-tauri-drag-region` attributes.
+
+## Part P — Port-forward (#318)
+
+Desktop has none. macOS has per-connection relays over the port-forward WebSocket. Desktop uses kube-rs, which ships a native portforward API — no hand-rolled WS protocol.
+
+### Rust (`crates/cubelite-core/src/portforward.rs` + commands)
+- Add the `ws` feature to the workspace `kube` dependency (required for `Api::portforward`).
+- `pub async fn forward_pod_port(client, namespace, pod, local_port, remote_port) -> Result<(u16, JoinHandle<()>), PortForwardError>`:
+  1. Bind `tokio::net::TcpListener` on `127.0.0.1:local_port` — **`local_port == 0` auto-assigns**; the actual bound port is returned. Bind errors (port in use) surface synchronously to the caller.
+  2. Spawn an accept loop: each TCP connection opens its own `Api::<Pod>::portforward(pod, &[remote_port])`, takes the stream for `remote_port`, and `tokio::io::copy_bidirectional`s until either side closes (per-connection forwarder, macOS parity).
+- Tauri commands (`commands/kubernetes.rs`, registered in `lib.rs`): `start_port_forward(kubeconfig_path, context, namespace, pod, local_port, remote_port) -> { id, local_port }` and `stop_port_forward(id)` (aborts the accept-loop task). Session registry `PortForwardState(Mutex<HashMap<String, JoinHandle>>)`, managed like `LogState`. Stale sessions die with the process; the frontend store is the source of truth for the UI.
+- Testable without a cluster: binding is separated into `bind_local(local_port)` — unit tests cover auto-assign (port 0 → nonzero) and port-in-use (double bind → error).
+
+### Frontend
+- `src/lib/ports.ts`: `parsePort(text): number | null` (trimmed integer 1–65535) and `resolveLocalPort(text, remote): number | null` — empty → mirror remote, `"0"` or `"auto"` → 0 (backend auto-assigns), else `parsePort`. Unit-tested. Semantics mirror the macOS `PortForwardInput` helper plus the auto option.
+- `src/lib/stores/portforward.svelte.ts`: `sessions = $state<ForwardSession[]>([])` (`{ id, namespace, pod, localPort, remotePort }`), `start(...)` (invokes backend, records returned port, toasts errors — e.g. "address already in use"), `stop(id)`, `stopAll()` on cluster switch, `sessionsFor(namespace, pod)`.
+- UI: new "Port forward" section in `PodDrawer.svelte` — remote input (default 80), local input (placeholder `auto`), Forward button disabled while invalid with inline error, session rows `localhost:N → M` + Stop. Ports rendered as plain text (no locale grouping — the macOS "6.789" lesson).
+- Cluster switch calls `portforward.stopAll()` (wired where the logs stream is reset).
+
+## Non-goals
+Service/deployment port-forward targets, persistence of sessions across restarts, UDP, per-session traffic stats, macOS-side changes.


### PR DESCRIPTION
Closes #317.

## Root cause
The titlebar's `data-tauri-drag-region` markup and layout were correct (header + flex filler regions), but Tauri's injected drag-region handler is unreliable with `titleBarStyle: "Overlay"` on macOS — the window could not be dragged at all.

## Fix
- Explicit `onmousedown` fallback in the Titlebar calling `getCurrentWindow().startDragging()`; double-click toggles maximize, preserving native behavior.
- Guarded by a pure `isDragSurface` helper so presses on the search button, namespace dropdown, links or `[data-no-drag]` regions never start a drag (unit-tested).
- Capabilities now grant `core:window:allow-start-dragging` and `core:window:allow-toggle-maximize` explicitly.
- Existing `data-tauri-drag-region` attributes kept (harmless, benefits from any upstream fix).

## Tests
vitest 167/167, svelte-check 0 errors, eslint clean. Needs a quick manual drag check on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)