### PR TITLE
feat(desktop): pod port-forward — kube-rs relay, auto-assign, drawer UI (#318)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2063,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
+ "rand",
  "rustls",
  "rustls-pemfile",
  "secrecy",
@@ -2065,6 +2072,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4258,6 +4266,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4485,6 +4505,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.82"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
-kube = { version = "0.97", features = ["runtime", "derive", "client"] }
+kube = { version = "0.97", features = ["runtime", "derive", "client", "ws"] }
 k8s-openapi = { version = "0.23", features = ["v1_31"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -86,10 +86,15 @@ pub async fn start_port_forward(
         .await
         .map_err(|e| e.to_string())?;
 
-    let (bound, handle) =
-        forward_pod_port(kube_client.client(), namespace, pod, local_port, remote_port)
-            .await
-            .map_err(|e| e.to_string())?;
+    let (bound, handle) = forward_pod_port(
+        kube_client.client(),
+        namespace,
+        pod,
+        local_port,
+        remote_port,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
 
     let id = FORWARD_COUNTER.fetch_add(1, Ordering::SeqCst).to_string();
     app.state::<PortForwardState>()

--- a/apps/desktop/src-tauri/src/commands/kubernetes.rs
+++ b/apps/desktop/src-tauri/src/commands/kubernetes.rs
@@ -3,6 +3,7 @@ use cubelite_core::{
     helm::HelmReleaseInfo,
     logs::{stream_pod_logs, stream_pod_logs_opts, LogStreamOptions},
     metrics::{NodeCapacityInfo, PodMetricsInfo},
+    portforward::forward_pod_port,
     resources::{
         ConfigMapInfo, ContainerDetail, CronJobInfo, DeploymentInfo, EventInfo, IngressInfo,
         JobInfo, NamespaceInfo, NodeInfo, PodInfo, PvcInfo, SecretInfo, ServiceInfo,
@@ -44,6 +45,80 @@ pub struct PodRef {
     pub namespace: String,
     /// Pod name.
     pub name: String,
+}
+
+/// Monotonically increasing counter for generating unique forward IDs.
+static FORWARD_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Tauri managed state holding all active port-forward accept loops.
+///
+/// Keyed by the session ID returned from [`start_port_forward`].
+#[derive(Default)]
+pub struct PortForwardState {
+    handles: Mutex<HashMap<String, JoinHandle<()>>>,
+}
+
+/// Result of starting a port-forward session.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForwardStartResult {
+    /// Session ID for [`stop_port_forward`].
+    pub id: String,
+    /// The actually-bound local port (relevant when 0 = auto was requested).
+    pub local_port: u16,
+}
+
+/// Starts forwarding `127.0.0.1:<local_port>` → `<pod>:<remote_port>`.
+///
+/// `local_port == 0` auto-assigns a free port; the bound port is returned.
+/// Errors (kubeconfig, port in use) are returned as strings for the UI.
+#[tauri::command]
+pub async fn start_port_forward(
+    app: AppHandle,
+    kubeconfig_path: String,
+    context: Option<String>,
+    namespace: String,
+    pod: String,
+    local_port: u16,
+    remote_port: u16,
+) -> Result<ForwardStartResult, String> {
+    let kube_client = KubeClient::new(Path::new(&kubeconfig_path), context.as_deref())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let (bound, handle) =
+        forward_pod_port(kube_client.client(), namespace, pod, local_port, remote_port)
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let id = FORWARD_COUNTER.fetch_add(1, Ordering::SeqCst).to_string();
+    app.state::<PortForwardState>()
+        .handles
+        .lock()
+        .await
+        .insert(id.clone(), handle);
+
+    Ok(ForwardStartResult {
+        id,
+        local_port: bound,
+    })
+}
+
+/// Stops a port-forward session: aborts the accept loop and drops the
+/// local listener. Connections already established keep relaying until
+/// either side closes.
+#[tauri::command]
+pub async fn stop_port_forward(app: AppHandle, id: String) -> Result<(), String> {
+    if let Some(handle) = app
+        .state::<PortForwardState>()
+        .handles
+        .lock()
+        .await
+        .remove(&id)
+    {
+        handle.abort();
+    }
+    Ok(())
 }
 
 /// Tauri managed state holding all active watch task handles.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,8 +6,9 @@ use commands::kubernetes::{
     list_configmaps, list_contexts, list_cronjobs, list_deployments, list_events,
     list_helm_releases, list_ingresses, list_jobs, list_namespaces, list_nodes, list_pod_metrics,
     list_pods, list_pvcs, list_secrets, list_services, list_statefulsets, probe_cluster,
-    restart_deployment, scale_deployment, set_context, stop_logs, stream_logs, stream_pod_log,
-    unwatch_resources, watch_resources, LogState, WatchState,
+    restart_deployment, scale_deployment, set_context, start_port_forward, stop_logs,
+    stop_port_forward, stream_logs, stream_pod_log, unwatch_resources, watch_resources, LogState,
+    PortForwardState, WatchState,
 };
 
 /// Entry point for the Tauri application.
@@ -18,6 +19,7 @@ pub fn run() {
     if let Err(e) = tauri::Builder::default()
         .manage(WatchState::default())
         .manage(LogState::default())
+        .manage(PortForwardState::default())
         .invoke_handler(tauri::generate_handler![
             list_pods,
             list_namespaces,
@@ -49,6 +51,8 @@ pub fn run() {
             list_contexts,
             get_current_context,
             set_context,
+            start_port_forward,
+            stop_port_forward,
         ])
         .run(tauri::generate_context!())
     {

--- a/apps/desktop/src/lib/components/pods/PodDrawer.svelte
+++ b/apps/desktop/src/lib/components/pods/PodDrawer.svelte
@@ -13,7 +13,9 @@
 	import { app } from '$lib/stores/app.svelte';
 	import { logs } from '$lib/stores/logs.svelte';
 	import { mutations } from '$lib/stores/mutations.svelte';
+	import { portforward } from '$lib/stores/portforward.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
+	import { parsePort, resolveLocalPort } from '$lib/ports';
 	import { formatBytes, formatCpu, percentOf } from '$lib/units';
 	import type { PodInfo } from '$lib/tauri';
 
@@ -25,6 +27,27 @@
 
 	const restarting = $derived(mutations.isDeleting(pod.namespace, pod.name));
 	let yamlOpen = $state(false);
+
+	// Port-forward inputs. Empty local mirrors remote; "auto"/"0" lets the
+	// OS assign a free port.
+	let remotePortText = $state('80');
+	let localPortText = $state('');
+	let forwarding = $state(false);
+	const remotePort = $derived(parsePort(remotePortText));
+	const localPort = $derived(
+		remotePort === null ? null : resolveLocalPort(localPortText, remotePort)
+	);
+	const forwardSessions = $derived(portforward.sessionsFor(pod.namespace, pod.name));
+
+	async function forward() {
+		if (remotePort === null || localPort === null || forwarding) return;
+		forwarding = true;
+		try {
+			await portforward.start(pod.namespace, pod.name, localPort, remotePort);
+		} finally {
+			forwarding = false;
+		}
+	}
 
 	async function restart() {
 		// A pod "restart" is a delete; the owning controller recreates it.
@@ -111,6 +134,55 @@
 					metrics unavailable — metrics-server not detected in this cluster
 				</p>
 			{/if}
+		</div>
+
+		<div>
+			<div class="type-section mb-1.5 text-text-tertiary">Port forward</div>
+			<div class="flex items-center gap-1.5">
+				<input
+					type="text"
+					aria-label="Remote port"
+					bind:value={remotePortText}
+					class="focus-ring h-7 w-16 rounded-md border border-border-default bg-surface-window px-2 text-center font-mono text-[11px] text-text-primary"
+				/>
+				<span class="type-caption text-text-tertiary">→</span>
+				<input
+					type="text"
+					aria-label="Local port"
+					placeholder="auto"
+					bind:value={localPortText}
+					class="focus-ring h-7 w-16 rounded-md border border-border-default bg-surface-window px-2 text-center font-mono text-[11px] text-text-primary placeholder:text-text-disabled"
+				/>
+				<button
+					type="button"
+					disabled={remotePort === null || localPort === null || forwarding}
+					class="focus-ring type-caption flex h-7 items-center rounded-md border border-border-default bg-surface-raised px-2.5 text-text-secondary hover:brightness-110 disabled:opacity-45"
+					onclick={() => void forward()}
+				>
+					{forwarding ? 'Forwarding…' : 'Forward'}
+				</button>
+			</div>
+			{#if remotePort === null || localPort === null}
+				<p class="type-caption mt-1 text-status-err">
+					Ports must be numbers between 1 and 65535 (local: empty = remote, "auto" = free port)
+				</p>
+			{/if}
+			{#each forwardSessions as session (session.id)}
+				<div class="mt-1.5 flex items-center gap-2">
+					<span class="h-1.5 w-1.5 shrink-0 rounded-full" style="background: var(--color-status-ok);"
+					></span>
+					<span class="flex-1 font-mono text-[11px] text-text-secondary">
+						localhost:{session.localPort} → {session.remotePort}
+					</span>
+					<button
+						type="button"
+						class="focus-ring type-caption flex h-6 items-center rounded-md border border-border-default bg-surface-raised px-2 text-text-secondary hover:brightness-110"
+						onclick={() => void portforward.stop(session.id)}
+					>
+						Stop
+					</button>
+				</div>
+			{/each}
 		</div>
 	</div>
 

--- a/apps/desktop/src/lib/ports.test.ts
+++ b/apps/desktop/src/lib/ports.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { parsePort, resolveLocalPort } from "./ports";
+
+describe("parsePort", () => {
+  it("parses valid ports and trims whitespace", () => {
+    expect(parsePort("6789")).toBe(6789);
+    expect(parsePort(" 80 ")).toBe(80);
+  });
+
+  it("enforces the 1-65535 range", () => {
+    expect(parsePort("1")).toBe(1);
+    expect(parsePort("65535")).toBe(65535);
+    expect(parsePort("0")).toBeNull();
+    expect(parsePort("65536")).toBeNull();
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(parsePort("")).toBeNull();
+    expect(parsePort("http")).toBeNull();
+    expect(parsePort("6.789")).toBeNull();
+    expect(parsePort("-80")).toBeNull();
+  });
+});
+
+describe("resolveLocalPort", () => {
+  it("empty mirrors the remote port", () => {
+    expect(resolveLocalPort("", 6789)).toBe(6789);
+    expect(resolveLocalPort("  ", 80)).toBe(80);
+  });
+
+  it("'auto' and '0' request OS assignment", () => {
+    expect(resolveLocalPort("auto", 80)).toBe(0);
+    expect(resolveLocalPort("0", 80)).toBe(0);
+  });
+
+  it("explicit valid port wins; invalid is null", () => {
+    expect(resolveLocalPort("9000", 80)).toBe(9000);
+    expect(resolveLocalPort("abc", 80)).toBeNull();
+    expect(resolveLocalPort("70000", 80)).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/ports.ts
+++ b/apps/desktop/src/lib/ports.ts
@@ -1,0 +1,23 @@
+/**
+ * Port-forward input parsing, mirroring the macOS PortForwardInput rules
+ * plus an auto-assign option.
+ */
+
+/** Trimmed integer in 1-65535, else null. */
+export function parsePort(text: string): number | null {
+  const trimmed = text.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return value >= 1 && value <= 65535 ? value : null;
+}
+
+/**
+ * Resolves the local-port field: empty mirrors `remote`, "auto"/"0"
+ * request OS assignment (0), anything else must be a valid port.
+ */
+export function resolveLocalPort(text: string, remote: number): number | null {
+  const trimmed = text.trim();
+  if (trimmed === "") return remote;
+  if (trimmed === "0" || trimmed.toLowerCase() === "auto") return 0;
+  return parsePort(trimmed);
+}

--- a/apps/desktop/src/lib/stores/clusters.svelte.ts
+++ b/apps/desktop/src/lib/stores/clusters.svelte.ts
@@ -8,6 +8,7 @@ import { listContexts, probeCluster, setContext, type ContextInfo } from "$lib/t
 import { assignIdentityColors, type IdentityColor } from "$lib/cluster-identity";
 import { errorMessage } from "$lib/errors";
 import { app } from "./app.svelte";
+import { portforward } from "./portforward.svelte";
 import { resources } from "./resources.svelte";
 import { settings } from "./settings.svelte";
 import { toasts } from "./toasts.svelte";
@@ -66,6 +67,8 @@ class ClustersStore {
       await resources.stopWatching();
       if (epoch !== this.#switchEpoch) return;
       resources.clear();
+      // Forward sessions target pods of the old cluster — tear them down.
+      void portforward.stopAll();
       try {
         await setContext(name);
       } catch (e) {

--- a/apps/desktop/src/lib/stores/portforward.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/portforward.svelte.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("$lib/tauri", () => ({
+  startPortForward: vi.fn(async () => ({ id: "1", localPort: 8080 })),
+  stopPortForward: vi.fn(async () => undefined),
+}));
+
+import { startPortForward, stopPortForward } from "$lib/tauri";
+import { portforward } from "./portforward.svelte";
+import { app } from "./app.svelte";
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.mocked(startPortForward).mockResolvedValue({ id: "1", localPort: 8080 });
+  vi.mocked(stopPortForward).mockResolvedValue(undefined);
+  portforward.sessions = [];
+  app.kubeconfigPath = "/home/u/.kube/config";
+  app.activeCluster = "prod";
+});
+
+describe("portforward store", () => {
+  it("start records the session with the backend-assigned port", async () => {
+    vi.mocked(startPortForward).mockResolvedValue({ id: "7", localPort: 51234 });
+
+    const ok = await portforward.start("default", "api-0", 0, 8080);
+
+    expect(ok).toBe(true);
+    expect(startPortForward).toHaveBeenCalledWith(
+      "/home/u/.kube/config",
+      "default",
+      "api-0",
+      0,
+      8080,
+      "prod",
+    );
+    expect(portforward.sessions).toEqual([
+      { id: "7", namespace: "default", pod: "api-0", localPort: 51234, remotePort: 8080 },
+    ]);
+  });
+
+  it("start failure records nothing and returns false", async () => {
+    vi.mocked(startPortForward).mockRejectedValue(new Error("address already in use"));
+
+    const ok = await portforward.start("default", "api-0", 80, 80);
+
+    expect(ok).toBe(false);
+    expect(portforward.sessions).toHaveLength(0);
+  });
+
+  it("sessionsFor filters by pod identity", async () => {
+    await portforward.start("default", "api-0", 80, 80);
+    vi.mocked(startPortForward).mockResolvedValue({ id: "2", localPort: 9090 });
+    await portforward.start("default", "worker-1", 9090, 9090);
+
+    expect(portforward.sessionsFor("default", "api-0")).toHaveLength(1);
+    expect(portforward.sessionsFor("default", "worker-1")[0].localPort).toBe(9090);
+  });
+
+  it("stop removes the session and notifies the backend", async () => {
+    await portforward.start("default", "api-0", 80, 80);
+
+    await portforward.stop("1");
+
+    expect(portforward.sessions).toHaveLength(0);
+    expect(stopPortForward).toHaveBeenCalledWith("1");
+  });
+
+  it("stopAll clears every session", async () => {
+    await portforward.start("default", "api-0", 80, 80);
+    vi.mocked(startPortForward).mockResolvedValue({ id: "2", localPort: 81 });
+    await portforward.start("default", "api-1", 81, 81);
+
+    await portforward.stopAll();
+
+    expect(portforward.sessions).toHaveLength(0);
+    expect(stopPortForward).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/lib/stores/portforward.svelte.ts
+++ b/apps/desktop/src/lib/stores/portforward.svelte.ts
@@ -1,0 +1,66 @@
+/**
+ * Active port-forward sessions. The backend owns the listeners; this
+ * store is the UI's source of truth for what is forwarding where.
+ */
+
+import { startPortForward, stopPortForward } from "$lib/tauri";
+import { errorMessage } from "$lib/errors";
+import { app } from "./app.svelte";
+import { toasts } from "./toasts.svelte";
+
+export interface ForwardSession {
+  id: string;
+  namespace: string;
+  pod: string;
+  localPort: number;
+  remotePort: number;
+}
+
+class PortForwardStore {
+  sessions = $state<ForwardSession[]>([]);
+
+  sessionsFor(namespace: string, pod: string): ForwardSession[] {
+    return this.sessions.filter((s) => s.namespace === namespace && s.pod === pod);
+  }
+
+  /** Starts a forward; `localPort === 0` auto-assigns. Toasts on failure. */
+  async start(
+    namespace: string,
+    pod: string,
+    localPort: number,
+    remotePort: number,
+  ): Promise<boolean> {
+    const kc = app.kubeconfigPath;
+    const cluster = app.activeCluster;
+    if (!kc || !cluster) return false;
+    try {
+      const result = await startPortForward(kc, namespace, pod, localPort, remotePort, cluster);
+      this.sessions = [
+        ...this.sessions,
+        { id: result.id, namespace, pod, localPort: result.localPort, remotePort },
+      ];
+      return true;
+    } catch (e) {
+      toasts.push(`Port forward failed: ${errorMessage(e)}`, "err");
+      return false;
+    }
+  }
+
+  async stop(id: string): Promise<void> {
+    this.sessions = this.sessions.filter((s) => s.id !== id);
+    try {
+      await stopPortForward(id);
+    } catch {
+      // Backend may already have dropped the session.
+    }
+  }
+
+  /** Stops every session (cluster switch). */
+  async stopAll(): Promise<void> {
+    const ids = this.sessions.map((s) => s.id);
+    this.sessions = [];
+    await Promise.allSettled(ids.map((id) => stopPortForward(id)));
+  }
+}
+
+export const portforward = new PortForwardStore();

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -564,3 +564,32 @@ export function watchResources(
 export function unwatchResources(watchId: string): Promise<void> {
   return invoke("unwatch_resources", { watchId });
 }
+
+/** Result of starting a port-forward session. */
+export interface ForwardStartResult {
+  id: string;
+  /** The actually-bound local port (relevant when 0 = auto was requested). */
+  localPort: number;
+}
+
+export function startPortForward(
+  kubeconfigPath: string,
+  namespace: string,
+  pod: string,
+  localPort: number,
+  remotePort: number,
+  context?: string,
+): Promise<ForwardStartResult> {
+  return invoke<ForwardStartResult>("start_port_forward", {
+    kubeconfigPath,
+    context: context ?? null,
+    namespace,
+    pod,
+    localPort,
+    remotePort,
+  });
+}
+
+export function stopPortForward(id: string): Promise<void> {
+  return invoke("stop_port_forward", { id });
+}

--- a/crates/cubelite-core/Cargo.toml
+++ b/crates/cubelite-core/Cargo.toml
@@ -11,7 +11,7 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 dirs = "5"
-kube = { version = "0.97", features = ["runtime", "derive", "client", "oidc"] }
+kube = { version = "0.97", features = ["runtime", "derive", "client", "oidc", "ws"] }
 serde_json = { workspace = true }
 k8s-openapi = { version = "0.23", features = ["v1_30"] }
 base64 = "0.22"

--- a/crates/cubelite-core/src/lib.rs
+++ b/crates/cubelite-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod helm;
 pub mod kubeconfig;
 pub mod logs;
 pub mod metrics;
+pub mod portforward;
 pub mod resources;
 pub mod types;
 pub mod watcher;

--- a/crates/cubelite-core/src/portforward.rs
+++ b/crates/cubelite-core/src/portforward.rs
@@ -1,0 +1,81 @@
+//! Local TCP port-forwarding to a pod via the Kubernetes port-forward API.
+//!
+//! [`forward_pod_port`] binds a local listener (`0` = OS-assigned port) and
+//! relays every accepted connection through its own port-forward stream, so
+//! one broken connection never takes down the session.
+
+use k8s_openapi::api::core::v1::Pod;
+use kube::{Api, Client};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+/// Binds the local listener for a forward session on 127.0.0.1.
+///
+/// `local_port == 0` lets the OS pick a free ephemeral port. A port
+/// already in use surfaces as `AddrInUse` here, before any cluster I/O.
+pub async fn bind_local(local_port: u16) -> std::io::Result<TcpListener> {
+    TcpListener::bind(("127.0.0.1", local_port)).await
+}
+
+/// Starts forwarding `127.0.0.1:<local>` → `<pod>:<remote_port>`.
+///
+/// Returns the actually-bound local port and the accept-loop task handle.
+/// Aborting the handle stops accepting new connections and drops the
+/// listener; connections already established keep relaying until either
+/// side closes.
+pub async fn forward_pod_port(
+    client: Client,
+    namespace: String,
+    pod: String,
+    local_port: u16,
+    remote_port: u16,
+) -> std::io::Result<(u16, JoinHandle<()>)> {
+    let listener = bind_local(local_port).await?;
+    let bound = listener.local_addr()?.port();
+
+    let handle = tokio::spawn(async move {
+        let api: Api<Pod> = Api::namespaced(client, &namespace);
+        loop {
+            let Ok((mut conn, _)) = listener.accept().await else {
+                break;
+            };
+            let api = api.clone();
+            let pod = pod.clone();
+            tokio::spawn(async move {
+                let Ok(mut forwarder) = api.portforward(&pod, &[remote_port]).await else {
+                    return;
+                };
+                let Some(mut upstream) = forwarder.take_stream(remote_port) else {
+                    return;
+                };
+                let _ = tokio::io::copy_bidirectional(&mut conn, &mut upstream).await;
+            });
+        }
+    });
+
+    Ok((bound, handle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bind_local_zero_assigns_ephemeral_port() {
+        let listener = bind_local(0).await.expect("bind should succeed");
+        assert_ne!(listener.local_addr().unwrap().port(), 0);
+    }
+
+    #[tokio::test]
+    async fn bind_local_taken_port_fails_with_addr_in_use() {
+        let first = bind_local(0).await.expect("first bind should succeed");
+        let port = first.local_addr().unwrap().port();
+
+        let second = bind_local(port).await;
+
+        assert_eq!(
+            second.expect_err("second bind must fail").kind(),
+            std::io::ErrorKind::AddrInUse
+        );
+    }
+}


### PR DESCRIPTION
Closes #318. macOS parity: desktop had no port-forward at all.

## Changes
- **Core (`cubelite-core/portforward.rs`)**: `forward_pod_port` binds `127.0.0.1:<local>` (**0 = OS auto-assign**, actual port returned; port-in-use surfaces synchronously as `AddrInUse`) and relays each accepted TCP connection through its own `Api::<Pod>::portforward` stream via `copy_bidirectional` — per-connection forwarders, matching the macOS design. Requires the kube `ws` feature (added).
- **Commands**: `start_port_forward` → `{ id, localPort }`, `stop_port_forward(id)` aborts the accept loop; `PortForwardState` registry managed like `LogState`.
- **Frontend**: `ports.ts` validation shared-semantics with macOS `PortForwardInput` (1–65535; empty local mirrors remote) plus `auto`/`0` = free port; `portforward` store (sessions, toasts backend errors like "address already in use", `stopAll()` on cluster switch); Port-forward section in the pod drawer with session rows `localhost:N → M` + Stop. Ports rendered as plain text — no locale digit grouping.

## Tests
- Rust: bind auto-assign + AddrInUse unit tests (`cargo test -p cubelite-core`, 99 green).
- vitest 174/174 (new: `ports.test.ts`, `portforward.svelte.test.ts`), svelte-check 0 errors, eslint clean, `cargo check` on the Tauri backend green.

Needs a manual end-to-end check against a real cluster (curl through the forwarded port).

Design spec: `docs/superpowers/specs/2026-07-18-desktop-window-portforward-design.md` (lands with #323)

🤖 Generated with [Claude Code](https://claude.com/claude-code)