### PR TITLE
fix(macos): data race in MockLogStreamer crashed CI test runner

### DIFF
--- a/apps/macos/cubelite/cubeliteTests/LogSessionStoreTests.swift
+++ b/apps/macos/cubelite/cubeliteTests/LogSessionStoreTests.swift
@@ -4,23 +4,49 @@ import XCTest
 
 /// Scripted PodLogStreaming double: yields canned containers and lines,
 /// records the query parameters of every call.
+///
+/// The protocol's async methods are nonisolated, so AggregatedLogStore's
+/// 20-pod fan-out invokes them concurrently from the cooperative pool —
+/// all mutable state is guarded by a lock (the unguarded version crashed
+/// the CI test runner with a data race on `streamCalls`).
 final class MockLogStreamer: PodLogStreaming, @unchecked Sendable {
+    private let lock = NSLock()
+
     var containers: [ContainerInfo] = []
     var liveLines: [String] = []
     var previousLines: [String] = []
     /// The first N stream calls end right after yielding (dropped stream);
     /// later calls stay open like a healthy follow.
     var failFirstNStreams = 0
-    private(set) var streamCalls: [(container: String?, tailLines: Int, sinceTime: String?)] = []
-    private(set) var previousCalls: [(container: String?, tailLines: Int)] = []
+
+    private var recordedStreamCalls: [(container: String?, tailLines: Int, sinceTime: String?)] =
+        []
+    private var recordedPreviousCalls: [(container: String?, tailLines: Int)] = []
+
+    /// Synchronous critical section — callable from async contexts because
+    /// the lock never spans a suspension point.
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
+    var streamCalls: [(container: String?, tailLines: Int, sinceTime: String?)] {
+        withLock { recordedStreamCalls }
+    }
+
+    var previousCalls: [(container: String?, tailLines: Int)] {
+        withLock { recordedPreviousCalls }
+    }
 
     func streamPodLogs(
         namespace: String, pod: String, container: String?, tailLines: Int,
         sinceTime: String?, inContext contextName: String?
     ) async throws -> AsyncThrowingStream<String, Error> {
-        streamCalls.append((container, tailLines, sinceTime))
-        let lines = liveLines
-        let shouldDrop = streamCalls.count <= failFirstNStreams
+        let (lines, shouldDrop) = withLock {
+            recordedStreamCalls.append((container, tailLines, sinceTime))
+            return (liveLines, recordedStreamCalls.count <= failFirstNStreams)
+        }
         return AsyncThrowingStream { continuation in
             for line in lines { continuation.yield(line) }
             if shouldDrop { continuation.finish() }
@@ -32,8 +58,10 @@ final class MockLogStreamer: PodLogStreaming, @unchecked Sendable {
         namespace: String, pod: String, container: String?, tailLines: Int,
         inContext contextName: String?
     ) async throws -> [String] {
-        previousCalls.append((container, tailLines))
-        return previousLines
+        withLock {
+            recordedPreviousCalls.append((container, tailLines))
+            return previousLines
+        }
     }
 
     func fetchPodContainers(


### PR DESCRIPTION
Fixes the `Build & Test macOS` failure surfacing on #323 (and any PR CI run against current main).

## Root cause
`MockLogStreamer` (shared by `LogSessionStoreTests` and `AggregatedLogStoreTests`, merged in #322) is `@unchecked Sendable` with unguarded mutable arrays. The `PodLogStreaming` protocol methods are nonisolated `async`, so `AggregatedLogStore`'s 20-pod fan-out (`testStart_capsAtTwentyPods`) appends to `streamCalls` concurrently from the cooperative thread pool — a data race that crashed the CI test process (the log shows the suite's remaining tests finishing on a respawned runner PID). Locally it happened not to crash.

## Fix
All mock state behind an `NSLock` via a synchronous `withLock` helper (async-context safe: the lock never spans a suspension point). Test-only change.

## Verification
Affected suites run 5× consecutively: 22/22 green each time.

After merging, re-run the failed check on #323/#324 — their CI runs against the merge preview with main, which carries the racy mock until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)