### PR TITLE
fix(desktop): stale logs after namespace switch + confusing namespace-menu counts

### DIFF
--- a/apps/desktop/src/lib/components/ui/NamespaceDropdown.svelte
+++ b/apps/desktop/src/lib/components/ui/NamespaceDropdown.svelte
@@ -4,8 +4,6 @@
 	import { app } from '$lib/stores/app.svelte';
 	import { resources } from '$lib/stores/resources.svelte';
 
-	const counts = $derived(resources.podCountByNamespace);
-
 	async function select(ns: string | null) {
 		app.namespace = ns;
 		await resources.load();
@@ -28,21 +26,19 @@
 			class="animate-popin z-50 max-h-80 min-w-56 overflow-y-auto rounded-xl border border-border-strong bg-surface-overlay p-1 shadow-overlay"
 		>
 			<DropdownMenu.Item
-				class="flex cursor-default items-center justify-between rounded-md px-2.5 py-1.5 type-body text-text-secondary data-highlighted:text-text-primary"
+				class="flex cursor-default items-center rounded-md px-2.5 py-1.5 type-body text-text-secondary data-highlighted:text-text-primary"
 				style={app.namespace === null ? 'background: var(--alpha-active-nav-bg); color: var(--color-text-primary);' : ''}
 				onSelect={() => void select(null)}
 			>
 				<span>all namespaces</span>
-				<span class="font-mono text-[10.5px] text-text-tertiary">{resources.pods.length}</span>
 			</DropdownMenu.Item>
 			{#each resources.namespaces as ns (ns.name)}
 				<DropdownMenu.Item
-					class="flex cursor-default items-center justify-between gap-4 rounded-md px-2.5 py-1.5 type-body text-text-secondary data-highlighted:text-text-primary"
+					class="flex cursor-default items-center rounded-md px-2.5 py-1.5 type-body text-text-secondary data-highlighted:text-text-primary"
 					style={app.namespace === ns.name ? 'background: var(--alpha-active-nav-bg); color: var(--color-text-primary);' : ''}
 					onSelect={() => void select(ns.name)}
 				>
 					<span class="font-mono text-[11.5px]">{ns.name}</span>
-					<span class="font-mono text-[10.5px] text-text-tertiary">{counts.get(ns.name) ?? 0}</span>
 				</DropdownMenu.Item>
 			{/each}
 		</DropdownMenu.Content>

--- a/apps/desktop/src/lib/components/views/logs-view.test.ts
+++ b/apps/desktop/src/lib/components/views/logs-view.test.ts
@@ -69,11 +69,14 @@ describe("LogsView", () => {
     expect(screen.getByText("Clear")).toBeInTheDocument();
   });
 
-  it("renders lines with time, level, pod and message", () => {
+  it("renders lines with time, level, pod and message", async () => {
+    render(LogsView);
+    // Mounting restarts the stream, which clears the buffer — let the
+    // restart settle, then seed lines and wait for the flush to publish.
+    await new Promise((r) => setTimeout(r, 0));
     logs.push(line());
     logs.push(line({ pod: "worker-1", level: "error", message: "ERROR boom" }));
-    render(LogsView);
-    expect(screen.getByText("listening on :8080")).toBeInTheDocument();
+    expect(await screen.findByText("listening on :8080")).toBeInTheDocument();
     expect(screen.getByText("ERROR boom")).toBeInTheDocument();
     expect(screen.getByText("worker-1")).toBeInTheDocument();
     const errorRow = screen.getByText("ERROR boom").closest("div");
@@ -81,9 +84,11 @@ describe("LogsView", () => {
   });
 
   it("filters by severity chip", async () => {
+    render(LogsView);
+    await new Promise((r) => setTimeout(r, 0));
     logs.push(line({ message: "info line" }));
     logs.push(line({ level: "warn", message: "warn line" }));
-    render(LogsView);
+    await screen.findByText("warn line");
     await fireEvent.click(screen.getByText("WARN"));
     expect(screen.queryByText("info line")).toBeNull();
     expect(screen.getByText("warn line")).toBeInTheDocument();

--- a/apps/desktop/src/lib/stores/logs.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/logs.svelte.test.ts
@@ -121,6 +121,26 @@ describe("logs filters", () => {
 });
 
 describe("start/stop", () => {
+  it("start clears lines from the previous scope, even with no pods to stream", async () => {
+    logs.push(line({ pod: "ingress-nginx-1", message: "old scope" }));
+    vi.advanceTimersByTime(FLUSH_MS);
+    expect(logs.lines).toHaveLength(1);
+
+    await logs.start([]);
+
+    expect(logs.lines).toHaveLength(0);
+    expect(logs.bufferedWhilePaused).toBe(0);
+  });
+
+  it("start with pods also begins from an empty buffer", async () => {
+    logs.push(line({ message: "stale" }));
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    await logs.start([{ namespace: "default", name: "api-0" }]);
+
+    expect(logs.lines).toHaveLength(0);
+  });
+
   it("starts a stream with the given pods", async () => {
     await logs.start([{ namespace: "default", name: "api-0" }]);
     expect(streamLogs).toHaveBeenCalledWith(

--- a/apps/desktop/src/lib/stores/logs.svelte.ts
+++ b/apps/desktop/src/lib/stores/logs.svelte.ts
@@ -107,6 +107,11 @@ class LogsStore {
   /** Start streaming the given pods (restarts any previous stream). */
   async start(pods: PodRef[]): Promise<void> {
     await this.stop();
+    // A restart means the scope changed (cluster/namespace/selector) or
+    // the pod set did: begin from an empty buffer so stale lines from the
+    // previous scope never linger. The per-pod tail re-delivers recent
+    // history anyway.
+    this.clear();
     const kc = app.kubeconfigPath;
     const cluster = app.activeCluster;
     if (!kc || !cluster || pods.length === 0) return;


### PR DESCRIPTION
Two issues found while testing the Logs view.

## Stale logs on namespace switch
Changing namespace (or the label selector) restarts the aggregated stream, but the buffer kept the previous scope's lines — e.g. switching from `ingress-nginx` to an empty `default` still showed ingress logs indefinitely (with no pods to stream, nothing ever displaced them). `logs.start()` now clears the buffer (including the pending queue) before streaming; the 50-line per-pod tail re-delivers recent history, so nothing meaningful is lost.

## Namespace dropdown counts
The unlabeled number after each namespace was the pod count derived from **currently loaded** pods — with a specific namespace selected, every other row showed 0. Uninformative and misleading; removed.

## Tests
New store specs (start clears with and without pods to stream); LogsView component tests adapted to the clear-on-restart semantics. vitest 181/181, svelte-check 0 errors, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)